### PR TITLE
Extract EVM specific provider code and decouple gas price fetching

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -57,6 +57,7 @@ core/
 ├── evm/                # EVM specific code
 │   ├── authorization/  # Authorizing clients and requests
 │   ├── contracts/      # Contract addresses and ABIs
+│   ├── provider/       # EVM specific implementations of provider functions
 │   ├── requests/       # Request/response specific code
 │   ├── templates       # Fetching and applying request templates
 │   ├── transactions/   # Executing transactions

--- a/packages/node/src/core/evm/authorization/authorization-application.test.ts
+++ b/packages/node/src/core/evm/authorization/authorization-application.test.ts
@@ -24,9 +24,8 @@ describe('mergeAuthorizations', () => {
       },
     };
     const authorizationsByEndpoint = { '0xendpointId': { '0xrequesterAddress': true } };
-    const [logs, err, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
+    const [logs, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
     expect(logs).toEqual([]);
-    expect(err).toEqual(null);
     expect(Object.keys(res).length).toEqual(1);
     expect(res[1].requests.apiCalls[0].status).toEqual(RequestStatus.Errored);
     expect(res[1].requests.apiCalls[0].errorCode).toEqual(RequestErrorCode.InvalidRequestParameters);
@@ -53,9 +52,8 @@ describe('mergeAuthorizations', () => {
       },
     };
     const authorizationsByEndpoint = { '0xendpointId': { '0xrequesterAddress': true } };
-    const [logs, err, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
+    const [logs, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
     expect(logs).toEqual([]);
-    expect(err).toEqual(null);
     expect(Object.keys(res).length).toEqual(1);
     expect(res[1].requests.apiCalls[0].status).toEqual(RequestStatus.Blocked);
   });
@@ -74,9 +72,8 @@ describe('mergeAuthorizations', () => {
       },
     };
     const authorizationsByEndpoint = { '0xendpointId': { '0xrequesterAddress': true } };
-    const [logs, err, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
+    const [logs, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
     expect(logs).toEqual([{ level: 'ERROR', message: 'No endpoint ID found for Request ID:apiCallId' }]);
-    expect(err).toEqual(null);
     expect(Object.keys(res).length).toEqual(1);
     expect(res[1].requests.apiCalls[0].status).toEqual(RequestStatus.Blocked);
     expect(res[1].requests.apiCalls[0].errorCode).toEqual(RequestErrorCode.TemplateNotFound);
@@ -94,9 +91,8 @@ describe('mergeAuthorizations', () => {
         transactionCount: 3,
       },
     };
-    const [logs, err, res] = authorization.mergeAuthorizations(walletDataByIndex, {});
+    const [logs, res] = authorization.mergeAuthorizations(walletDataByIndex, {});
     expect(logs).toEqual([{ level: 'WARN', message: 'Authorization not found for Request ID:apiCallId' }]);
-    expect(err).toEqual(null);
     expect(Object.keys(res).length).toEqual(1);
     expect(res[1].requests.apiCalls[0].status).toEqual(RequestStatus.Blocked);
     expect(res[1].requests.apiCalls[0].errorCode).toEqual(RequestErrorCode.AuthorizationNotFound);
@@ -118,9 +114,8 @@ describe('mergeAuthorizations', () => {
       },
     };
     const authorizationsByEndpoint = { '0xendpointId': { '0xrequesterAddress': true } };
-    const [logs, err, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
+    const [logs, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
     expect(logs).toEqual([]);
-    expect(err).toEqual(null);
     expect(Object.keys(res).length).toEqual(1);
     expect(res[1].requests.apiCalls[0].status).toEqual(RequestStatus.Pending);
     expect(res[1].requests.apiCalls[0].errorCode).toEqual(undefined);
@@ -142,7 +137,7 @@ describe('mergeAuthorizations', () => {
       },
     };
     const authorizationsByEndpoint = { '0xendpointId': { '0xrequesterAddress': false } };
-    const [logs, err, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
+    const [logs, res] = authorization.mergeAuthorizations(walletDataByIndex, authorizationsByEndpoint);
     expect(logs).toEqual([
       {
         level: 'WARN',
@@ -150,7 +145,6 @@ describe('mergeAuthorizations', () => {
           'Client:0xrequesterAddress is not authorized to access Endpoint ID:0xendpointId for Request ID:apiCallId',
       },
     ]);
-    expect(err).toEqual(null);
     expect(Object.keys(res).length).toEqual(1);
     expect(res[1].requests.apiCalls[0].status).toEqual(RequestStatus.Errored);
     expect(res[1].requests.apiCalls[0].errorCode).toEqual(RequestErrorCode.UnauthorizedClient);

--- a/packages/node/src/core/evm/gas-prices.test.ts
+++ b/packages/node/src/core/evm/gas-prices.test.ts
@@ -18,60 +18,62 @@ jest.mock('ethers', () => {
 });
 
 import { ethers } from 'ethers';
-import { ProviderState } from '../../types';
-import * as providerState from '../providers/state';
 import * as utils from './utils';
 import * as gasPrices from './gas-prices';
 
 describe('getGasPrice', () => {
-  let state: ProviderState;
-
-  beforeEach(() => {
-    const config = { chainId: 1234, url: 'https://some.provider', name: 'test-provider' };
-    state = providerState.create(config, 0);
-  });
-
+  const baseFetchOptions = {
+    address: '0x3071f278C740B3E3F76301Cf7CAFcdAEB0682565',
+  };
   it('takes the gas price feed price if it is highest', async () => {
+    const provider = new ethers.providers.JsonRpcProvider();
     const contract = new ethers.Contract('address', ['ABI']);
     contract.latestAnswer.mockResolvedValueOnce(utils.weiToBigNumber('53000000000'));
-
-    const getGasPrice = state.provider.getGasPrice as jest.Mock;
+    const getGasPrice = provider.getGasPrice as jest.Mock;
     getGasPrice.mockResolvedValueOnce(utils.weiToBigNumber('48000000000'));
-
-    const gasPrice = await gasPrices.getGasPrice(state);
+    const [logs, gasPrice] = await gasPrices.getGasPrice({ ...baseFetchOptions, provider });
+    expect(logs).toEqual([]);
     expect(utils.weiToGwei(gasPrice)).toEqual('53.0');
   });
 
   it('takes the node price if it is highest', async () => {
+    const provider = new ethers.providers.JsonRpcProvider();
     const contract = new ethers.Contract('address', ['ABI']);
     contract.latestAnswer.mockResolvedValueOnce(utils.weiToBigNumber('53000000000'));
-
-    const getGasPrice = state.provider.getGasPrice as jest.Mock;
+    const getGasPrice = provider.getGasPrice as jest.Mock;
     getGasPrice.mockResolvedValueOnce(utils.weiToBigNumber('55000000000'));
-
-    const gasPrice = await gasPrices.getGasPrice(state);
+    const [logs, gasPrice] = await gasPrices.getGasPrice({ ...baseFetchOptions, provider });
+    expect(logs).toEqual([]);
     expect(utils.weiToGwei(gasPrice)).toEqual('55.0');
   });
 
   it('returns the fallback price if no usable responses are received from any sources', async () => {
+    const provider = new ethers.providers.JsonRpcProvider();
     const contract = new ethers.Contract('address', ['ABI']);
     contract.latestAnswer.mockRejectedValueOnce(new Error('Contract says no'));
-
-    const getGasPrice = state.provider.getGasPrice as jest.Mock;
+    const getGasPrice = provider.getGasPrice as jest.Mock;
     getGasPrice.mockRejectedValueOnce(new Error('Node says no'));
-
-    const gasPrice = await gasPrices.getGasPrice(state);
+    const [logs, gasPrice] = await gasPrices.getGasPrice({ ...baseFetchOptions, provider });
+    expect(logs).toEqual([
+      { level: 'ERROR', message: 'Failed to get gas price from Ethereum node', error: new Error('Node says no') },
+      {
+        level: 'ERROR',
+        message: 'Failed to get gas price from gas price feed contract',
+        error: new Error('Contract says no'),
+      },
+      { level: 'ERROR', message: 'Failed to get gas prices from any sources. Falling back to default price 40.0 Gwei' },
+    ]);
     expect(utils.weiToGwei(gasPrice)).toEqual('40.0');
   });
 
   it('limits the maximum gas price that can be returned', async () => {
+    const provider = new ethers.providers.JsonRpcProvider();
     const contract = new ethers.Contract('address', ['ABI']);
     contract.latestAnswer.mockResolvedValueOnce(utils.weiToBigNumber('43000000000000'));
-
-    const getGasPrice = state.provider.getGasPrice as jest.Mock;
+    const getGasPrice = provider.getGasPrice as jest.Mock;
     getGasPrice.mockResolvedValueOnce(utils.weiToBigNumber('48000000000'));
-
-    const gasPrice = await gasPrices.getGasPrice(state);
+    const [logs, gasPrice] = await gasPrices.getGasPrice({ ...baseFetchOptions, provider });
+    expect(logs).toEqual([]);
     expect(utils.weiToGwei(gasPrice)).toEqual('1000.0');
   });
 });

--- a/packages/node/src/core/evm/providers/index.ts
+++ b/packages/node/src/core/evm/providers/index.ts
@@ -1,0 +1,2 @@
+export * from './initialize';
+export * from './process-transactions';

--- a/packages/node/src/core/evm/providers/initialize.ts
+++ b/packages/node/src/core/evm/providers/initialize.ts
@@ -1,11 +1,11 @@
-import { go } from '../utils/promise-utils';
-import { ProviderConfig, ProviderState } from '../../types';
-import * as authorization from '../evm/authorization';
-import * as logger from '../logger';
-import * as triggers from '../evm/triggers';
-import * as templates from '../evm/templates';
-import * as transactionCounts from '../evm/transaction-counts';
-import * as state from './state';
+import { go } from '../../utils/promise-utils';
+import * as authorization from '../authorization';
+import * as logger from '../../logger';
+import * as triggers from '../triggers';
+import * as templates from '../templates';
+import * as transactionCounts from '../transaction-counts';
+import * as state from '../../providers/state';
+import { ProviderConfig, ProviderState } from '../../../types';
 
 type ParallelPromise = Promise<{ id: string; data: any }>;
 
@@ -74,7 +74,7 @@ export async function initializeState(config: ProviderConfig, index: number): Pr
   // // =================================================================
   // // STEP 5: Merge authorizations and transaction counts
   // // =================================================================
-  const [authLogs, _authErr, walletDataWithAuthorizations] = authorization.mergeAuthorizations(
+  const [authLogs, walletDataWithAuthorizations] = authorization.mergeAuthorizations(
     walletDataWithTransactionCounts,
     authorizationsByEndpoint
   );

--- a/packages/node/src/core/providers/index.ts
+++ b/packages/node/src/core/providers/index.ts
@@ -1,2 +1,10 @@
-export * from './initialize';
-export * from './process-transactions';
+import * as evmProvider from '../evm/providers';
+import { ProviderConfig, ProviderState } from '../../types';
+
+export async function initializeState(config: ProviderConfig, index: number): Promise<ProviderState | null> {
+  return evmProvider.initializeState(config, index);
+}
+
+export async function processTransactions(initialState: ProviderState) {
+  return evmProvider.processTransactions(initialState);
+}


### PR DESCRIPTION
Hopefully the last part of my decoupling work. There are probably more things that could be done but I think I want to stop here for now

Highlights:
1. Extract EVM specific provider functions (initialize and submit-transactions) to the `evm/` directory.
2. Remove useless `null` elements from the tuples that get returned from transaction-related functions
3. The `getGasPrice` function now only needs the contract address for the gas price feed and the ethers `provider` instead of the entire state.