### PR TITLE
Fix lambda function names

### DIFF
--- a/packages/node/src/core/adapters/http/worker.test.ts
+++ b/packages/node/src/core/adapters/http/worker.test.ts
@@ -26,7 +26,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-callApi',
+        FunctionName: 'airnode-19255a4-test-callApi',
         Payload: JSON.stringify({ aggregatedApiCall, logOptions }),
       },
       expect.anything()
@@ -45,7 +45,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-callApi',
+        FunctionName: 'airnode-19255a4-test-callApi',
         Payload: JSON.stringify({ aggregatedApiCall, logOptions }),
       },
       expect.anything()
@@ -63,7 +63,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-callApi',
+        FunctionName: 'airnode-19255a4-test-callApi',
         Payload: JSON.stringify({ aggregatedApiCall, logOptions }),
       },
       expect.anything()
@@ -80,7 +80,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-callApi',
+        FunctionName: 'airnode-19255a4-test-callApi',
         Payload: JSON.stringify({ aggregatedApiCall, logOptions }),
       },
       expect.anything()

--- a/packages/node/src/core/evm/retry-provider.ts
+++ b/packages/node/src/core/evm/retry-provider.ts
@@ -17,7 +17,7 @@ export function newProvider(url: string, chainId: number) {
   // a list of "known" networks to stop these extra calls if possible.
   const network = NETWORKS[chainId] || null;
 
-  // Ethers only let's us configure the timeout when creating a provider, so
+  // Ethers only lets us configure the timeout when creating a provider, so
   // set a high value here and we'll control it ourselves by overriding
   // the 'perform' method.
   return new RetryProvider({ url, timeout: 30_000 }, network);

--- a/packages/node/src/core/evm/workers.test.ts
+++ b/packages/node/src/core/evm/workers.test.ts
@@ -20,7 +20,7 @@ describe('spawnNewProvider', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-initializeProvider',
+        FunctionName: 'airnode-19255a4-test-initializeProvider',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()
@@ -43,7 +43,7 @@ describe('spawnNewProvider', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-initializeProvider',
+        FunctionName: 'airnode-19255a4-test-initializeProvider',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()
@@ -61,7 +61,7 @@ describe('spawnNewProvider', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-initializeProvider',
+        FunctionName: 'airnode-19255a4-test-initializeProvider',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()
@@ -78,7 +78,7 @@ describe('spawnNewProvider', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-initializeProvider',
+        FunctionName: 'airnode-19255a4-test-initializeProvider',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()
@@ -97,7 +97,7 @@ describe('spawnProviderRequestProcessor', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-processProviderRequests',
+        FunctionName: 'airnode-19255a4-test-processProviderRequests',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()
@@ -120,7 +120,7 @@ describe('spawnProviderRequestProcessor', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-processProviderRequests',
+        FunctionName: 'airnode-19255a4-test-processProviderRequests',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()
@@ -138,7 +138,7 @@ describe('spawnProviderRequestProcessor', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-processProviderRequests',
+        FunctionName: 'airnode-19255a4-test-processProviderRequests',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()
@@ -155,7 +155,7 @@ describe('spawnProviderRequestProcessor', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-processProviderRequests',
+        FunctionName: 'airnode-19255a4-test-processProviderRequests',
         Payload: JSON.stringify({ state }),
       },
       expect.anything()

--- a/packages/node/src/core/workers/cloud-platforms/aws.test.ts
+++ b/packages/node/src/core/workers/cloud-platforms/aws.test.ts
@@ -31,7 +31,7 @@ describe('spawn', () => {
     expect(invoke).toHaveBeenCalledTimes(1);
     expect(invoke).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-some-function',
+        FunctionName: 'airnode-19255a4-test-some-function',
         Payload: JSON.stringify({ from: 'ETH', to: 'USD' }),
       },
       expect.any(Function)
@@ -57,7 +57,7 @@ describe('spawn', () => {
     expect(invoke).toHaveBeenCalledTimes(1);
     expect(invoke).toHaveBeenCalledWith(
       {
-        FunctionName: 'airnode-test-19255a4-some-function',
+        FunctionName: 'airnode-19255a4-test-some-function',
         Payload: JSON.stringify({ from: 'ETH', to: 'USD' }),
       },
       expect.any(Function)

--- a/packages/node/src/core/workers/cloud-platforms/aws.ts
+++ b/packages/node/src/core/workers/cloud-platforms/aws.ts
@@ -4,10 +4,10 @@ import { WorkerParameters, WorkerResponse } from '../../../types';
 export function spawn(params: WorkerParameters): Promise<WorkerResponse> {
   // lambda.invoke is synchronous so we need to wrap this in a promise
   return new Promise((resolve, reject) => {
-    // TODO: configure lambda environment
+    // Uses the current region by default
     const lambda = new AWS.Lambda();
 
-    const resolvedName = `airnode-${params.stage}-${params.providerIdShort}-${params.functionName}`;
+    const resolvedName = `airnode-${params.providerIdShort}-${params.stage}-${params.functionName}`;
 
     const options = {
       FunctionName: resolvedName,


### PR DESCRIPTION
Fixes Lambda function name build order as `airnode-${providerIdShort}-${stage}-${functionName}`