### PR TITLE
Fix provider admin config name

### DIFF
--- a/packages/node/src/core/evm/handlers/initialize-provider.ts
+++ b/packages/node/src/core/evm/handlers/initialize-provider.ts
@@ -52,7 +52,7 @@ export async function initializeProvider(
   // STEP 2: Get current block number and find or create the provider
   // =================================================================
   const providerFetchOptions = {
-    adminAddressForCreatingProviderRecord: state1.settings.adminAddressForCreatingProviderRecord,
+    providerAdminForRecordCreation: state1.settings.providerAdminForRecordCreation,
     airnodeAddress: state1.contracts.Airnode,
     convenienceAddress: state1.contracts.Convenience,
     masterHDNode: state1.masterHDNode,

--- a/packages/node/src/core/evm/providers.test.ts
+++ b/packages/node/src/core/evm/providers.test.ts
@@ -20,7 +20,7 @@ import * as providers from './providers';
 
 describe('findWithBlock', () => {
   const options = {
-    adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+    providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
     airnodeAddress: '0xe60b966B798f9a0C41724f111225A5586ff30656',
     convenienceAddress: '0xD5659F26A72A8D718d1955C42B3AE418edB001e0',
     masterHDNode: wallet.getMasterHDNode(),
@@ -47,7 +47,7 @@ describe('findWithBlock', () => {
       },
     ]);
     expect(res).toEqual({
-      adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+      providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
       blockNumber: 12,
       providerExists: true,
       xpub:
@@ -70,7 +70,7 @@ describe('findWithBlock', () => {
       { level: 'INFO', message: 'Provider not found' },
     ]);
     expect(res).toEqual({
-      adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+      providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
       blockNumber: 12,
       providerExists: false,
       xpub: '',
@@ -99,7 +99,7 @@ describe('findWithBlock', () => {
       },
     ]);
     expect(res).toEqual({
-      adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+      providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
       blockNumber: 12,
       providerExists: true,
       xpub:
@@ -129,7 +129,7 @@ describe('findWithBlock', () => {
 
 describe('create', () => {
   const options = {
-    adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+    providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
     airnodeAddress: '0xe60b966B798f9a0C41724f111225A5586ff30656',
     convenienceAddress: '0xD5659F26A72A8D718d1955C42B3AE418edB001e0',
     masterHDNode: wallet.getMasterHDNode(),
@@ -265,7 +265,7 @@ describe('create', () => {
 
 describe('findOrCreateProviderWithBlock', () => {
   const options = {
-    adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+    providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
     airnodeAddress: '0xe60b966B798f9a0C41724f111225A5586ff30656',
     convenienceAddress: '0xD5659F26A72A8D718d1955C42B3AE418edB001e0',
     masterHDNode: wallet.getMasterHDNode(),
@@ -297,7 +297,7 @@ describe('findOrCreateProviderWithBlock', () => {
     ]);
   });
 
-  it('returns null if attemping creating the provider without adminAddressForCreatingProviderRecord', async () => {
+  it('returns null if attemping creating the provider without providerAdminForRecordCreation', async () => {
     getProviderAndBlockNumberMock.mockResolvedValueOnce({
       admin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
       blockNumber: ethers.BigNumber.from('12'),
@@ -305,7 +305,7 @@ describe('findOrCreateProviderWithBlock', () => {
     });
     const [logs, res] = await providers.findOrCreateProviderWithBlock({
       ...options,
-      adminAddressForCreatingProviderRecord: undefined,
+      providerAdminForRecordCreation: undefined,
     });
     expect(logs).toEqual([
       {
@@ -316,7 +316,7 @@ describe('findOrCreateProviderWithBlock', () => {
       { level: 'INFO', message: 'Fetching current block and provider admin details...' },
       { level: 'INFO', message: 'Current block:12' },
       { level: 'INFO', message: 'Provider not found' },
-      { level: 'ERROR', message: 'Unable to find adminAddressForCreatingProviderRecord address' },
+      { level: 'ERROR', message: 'Unable to find providerAdminForRecordCreation address' },
     ]);
     expect(res).toEqual(null);
     expect(getProviderAndBlockNumberMock).toHaveBeenCalledTimes(1);
@@ -362,7 +362,7 @@ describe('findOrCreateProviderWithBlock', () => {
       },
     ]);
     expect(res).toEqual({
-      adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+      providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
       blockNumber: 12,
       providerExists: false,
       xpub: '',
@@ -410,7 +410,7 @@ describe('findOrCreateProviderWithBlock', () => {
       { level: 'DEBUG', message: 'Skipping provider creation as the provider exists' },
     ]);
     expect(res).toEqual({
-      adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+      providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
       blockNumber: 12,
       providerExists: true,
       xpub:

--- a/packages/node/src/core/evm/providers.ts
+++ b/packages/node/src/core/evm/providers.ts
@@ -7,7 +7,7 @@ import * as wallet from './wallet';
 import { LogsData } from '../../types';
 
 interface BaseFetchOptions {
-  adminAddressForCreatingProviderRecord?: string;
+  providerAdminForRecordCreation?: string;
   airnodeAddress: string;
   convenienceAddress: string;
   masterHDNode: ethers.utils.HDNode;
@@ -19,7 +19,7 @@ interface FindOptions extends BaseFetchOptions {
 }
 
 interface CreateOptions extends BaseFetchOptions {
-  adminAddressForCreatingProviderRecord: string;
+  providerAdminForRecordCreation: string;
   airnodeAddress: string;
   masterHDNode: ethers.utils.HDNode;
   provider: ethers.providers.JsonRpcProvider;
@@ -27,7 +27,7 @@ interface CreateOptions extends BaseFetchOptions {
 }
 
 interface ProviderWithBlockNumber {
-  adminAddressForCreatingProviderRecord: string;
+  providerAdminForRecordCreation: string;
   blockNumber: number;
   providerExists: boolean;
   xpub: string;
@@ -47,7 +47,7 @@ export async function findWithBlock(fetchOptions: FindOptions): Promise<LogsData
   }
 
   const data: ProviderWithBlockNumber = {
-    adminAddressForCreatingProviderRecord: res.admin,
+    providerAdminForRecordCreation: res.admin,
     // Converting this BigNumber to a JS number should not throw as the current block number
     // should always be a valid number
     blockNumber: res.blockNumber.toNumber(),
@@ -70,10 +70,7 @@ export async function findWithBlock(fetchOptions: FindOptions): Promise<LogsData
 }
 
 export async function create(options: CreateOptions): Promise<LogsData<ethers.Transaction | null>> {
-  const log1 = logger.pend(
-    'INFO',
-    `Creating provider with address:${options.adminAddressForCreatingProviderRecord}...`
-  );
+  const log1 = logger.pend('INFO', `Creating provider with address:${options.providerAdminForRecordCreation}...`);
 
   const masterWallet = wallet.getWallet(options.masterHDNode.privateKey);
   const connectedWallet = masterWallet.connect(options.provider);
@@ -118,7 +115,7 @@ export async function create(options: CreateOptions): Promise<LogsData<ethers.Tr
 
   const log6 = logger.pend('INFO', 'Submitting create provider transaction...');
 
-  const createProviderTx = airnode.createProvider(options.adminAddressForCreatingProviderRecord, options.xpub, {
+  const createProviderTx = airnode.createProvider(options.providerAdminForRecordCreation, options.xpub, {
     value: fundsToSend,
     gasLimit,
     gasPrice,
@@ -152,14 +149,14 @@ export async function findOrCreateProviderWithBlock(
   // If the extended public key was returned as an empty string, it means that the provider does
   // not exist onchain yet
   if (!providerBlockData.providerExists) {
-    if (!options.adminAddressForCreatingProviderRecord) {
-      const errLog = logger.pend('ERROR', 'Unable to find adminAddressForCreatingProviderRecord address');
+    if (!options.providerAdminForRecordCreation) {
+      const errLog = logger.pend('ERROR', 'Unable to find providerAdminForRecordCreation address');
       return [[idLog, ...providerBlockLogs, errLog], null];
     }
 
     const createOptions = {
       ...options,
-      adminAddressForCreatingProviderRecord: options.adminAddressForCreatingProviderRecord,
+      providerAdminForRecordCreation: options.providerAdminForRecordCreation,
       xpub: wallet.getExtendedPublicKey(options.masterHDNode),
     };
     const [createLogs, _createTx] = await create(createOptions);

--- a/packages/node/src/core/evm/providers.ts
+++ b/packages/node/src/core/evm/providers.ts
@@ -83,7 +83,10 @@ export async function create(options: CreateOptions): Promise<LogsData<ethers.Tr
 
   // Gas cost is 160,076
   const [estimateErr, estimatedGasCost] = await go(
-    airnode.estimateGas.createProvider(options.adminAddressForCreatingProviderRecord, options.xpub, { value: 1 })
+    airnode.estimateGas.createProvider(options.providerAdminForRecordCreation, options.xpub, {
+      value: 1,
+      gasLimit: 300_000,
+    })
   );
   if (estimateErr || !estimatedGasCost) {
     const errLog = logger.pend('ERROR', 'Unable to estimate transaction cost', estimateErr);

--- a/packages/node/src/core/providers/initialize.test.ts
+++ b/packages/node/src/core/providers/initialize.test.ts
@@ -20,7 +20,7 @@ jest.mock('fs');
 
 const chains: ChainConfig[] = [
   {
-    adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+    providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
     contracts: {
       Airnode: '0x197F3826040dF832481f835652c290aC7c41f073',
       Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',
@@ -30,7 +30,7 @@ const chains: ChainConfig[] = [
     providers: [{ name: 'infura-mainnet', url: 'https://mainnet.infura.io/v3/<key>' }],
   },
   {
-    adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+    providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
     contracts: {
       Airnode: '0x32D228B5d44Fd18FefBfd68BfE5A5F3f75C873AE',
       Convenience: '0xd029Ec5D9184Ecd8E853dC9642bdC1E0766266A1',
@@ -76,7 +76,7 @@ describe('initializeProviders', () => {
           Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',
         },
         settings: {
-          adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+          providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
           blockHistoryLimit: 600,
           chainId: 1,
           chainType: 'evm',
@@ -108,7 +108,7 @@ describe('initializeProviders', () => {
           Convenience: '0xd029Ec5D9184Ecd8E853dC9642bdC1E0766266A1',
         },
         settings: {
-          adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+          providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
           blockHistoryLimit: 600,
           chainId: 3,
           chainType: 'evm',

--- a/packages/node/src/core/providers/state.test.ts
+++ b/packages/node/src/core/providers/state.test.ts
@@ -8,7 +8,7 @@ describe('create', () => {
     const coordinatorId = '837daEf231';
     const chainProvider: ChainProvider = { name: 'ganache-test', url: 'http://localhost:4111' };
     const chainConfig: ChainConfig = {
-      adminAddressForCreatingProviderRecord: '0xadminAddressForCreatingProviderRecord',
+      providerAdminForRecordCreation: '0xproviderAdminForRecordCreation',
       contracts: {
         Airnode: '0x197F3826040dF832481f835652c290aC7c41f073',
         Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',
@@ -25,7 +25,7 @@ describe('create', () => {
         Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',
       },
       settings: {
-        adminAddressForCreatingProviderRecord: '0xadminAddressForCreatingProviderRecord',
+        providerAdminForRecordCreation: '0xproviderAdminForRecordCreation',
         blockHistoryLimit: 600,
         chainId: 1337,
         chainType: 'evm',
@@ -63,7 +63,7 @@ describe('create', () => {
       url: 'http://localhost:4111',
     };
     const chainConfig: ChainConfig = {
-      adminAddressForCreatingProviderRecord: '0xadminAddressForCreatingProviderRecord',
+      providerAdminForRecordCreation: '0xproviderAdminForRecordCreation',
       contracts: {
         Airnode: '0x197F3826040dF832481f835652c290aC7c41f073',
         Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',
@@ -80,7 +80,7 @@ describe('create', () => {
         Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',
       },
       settings: {
-        adminAddressForCreatingProviderRecord: '0xadminAddressForCreatingProviderRecord',
+        providerAdminForRecordCreation: '0xproviderAdminForRecordCreation',
         blockHistoryLimit: 150,
         chainId: 1337,
         chainType: 'evm',

--- a/packages/node/src/core/providers/state.ts
+++ b/packages/node/src/core/providers/state.ts
@@ -20,7 +20,7 @@ export function buildEVMState(
   const provider = evm.newProvider(chainProvider.url, chain.id);
 
   const providerSettings: ProviderSettings = {
-    adminAddressForCreatingProviderRecord: chain.adminAddressForCreatingProviderRecord,
+    providerAdminForRecordCreation: chain.providerAdminForRecordCreation,
     blockHistoryLimit: chainProvider.blockHistoryLimit || 600,
     chainId: chain.id,
     chainType: 'evm' as ChainType,

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -98,7 +98,7 @@ export interface GroupedRequests {
 }
 
 export interface ProviderSettings extends CoordinatorSettings {
-  readonly adminAddressForCreatingProviderRecord?: string;
+  readonly providerAdminForRecordCreation?: string;
   readonly blockHistoryLimit: number;
   readonly chainId: number;
   readonly chainType: ChainType;
@@ -295,7 +295,7 @@ export interface ChainProvider {
 }
 
 export interface ChainConfig {
-  readonly adminAddressForCreatingProviderRecord?: string;
+  readonly providerAdminForRecordCreation?: string;
   readonly contracts: ChainContracts;
   readonly id: number;
   readonly providers: ChainProvider[];

--- a/packages/node/test/fixtures/config/node-settings.ts
+++ b/packages/node/test/fixtures/config/node-settings.ts
@@ -9,7 +9,7 @@ export function buildNodeSettings(settings?: Partial<NodeSettings>): NodeSetting
     stage: 'test',
     chains: [
       {
-        adminAddressForCreatingProviderRecord: '0xadminAddressForCreatingProviderRecord',
+        providerAdminForRecordCreation: '0xproviderAdminForRecordCreation',
         contracts: {
           Airnode: '0x197F3826040dF832481f835652c290aC7c41f073',
           Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',

--- a/packages/node/test/fixtures/provider-states/evm.ts
+++ b/packages/node/test/fixtures/provider-states/evm.ts
@@ -8,7 +8,7 @@ export function buildEVMProviderState(
   const coordinatorId = '837daEf231';
   const chainProvider: ChainProvider = { name: 'ganache-test', url: 'http://localhost:4111' };
   const chainConfig: ChainConfig = {
-    adminAddressForCreatingProviderRecord: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+    providerAdminForRecordCreation: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
     contracts: {
       Airnode: '0x197F3826040dF832481f835652c290aC7c41f073',
       Convenience: '0x2393737d287c555d148012270Ce4567ABb1ee95C',


### PR DESCRIPTION
- Renames `adminAddressForCreatingProviderRecord` as `providerAdminForRecordCreation` to conform to the [`config.json` docs](https://github.com/api3dao/api3-docs/blob/master/airnode/2-7-config-json.md)

- Sets a `gasLimit` of `300,000` while estimating gas for provider record creation. `estimateGas` fails if `gasLimit * getGasPrice()` is larger than the master wallet balance. Sometimes `ethers` (or whatever is doing this in the background) picks absurdly large `gasLimit`s, which may result in the gas estimation failing even if the master wallet balance is decent like 0.1 ETH. I didn't encounter this here specifically, but still, setting a large `gasLimit` as such doesn't really have any downsides in this context.