### PR TITLE
Ignore requests that are not actionable

### DIFF
--- a/packages/node/src/core/coordinator/calls/aggregation.test.ts
+++ b/packages/node/src/core/coordinator/calls/aggregation.test.ts
@@ -1,7 +1,19 @@
 import * as fixtures from 'test/fixtures';
 import * as aggregation from './aggregation';
+import { RequestStatus } from 'src/types';
 
 describe('aggregate (API calls)', () => {
+  it('ignores requests that are not pending', () => {
+    const apiCalls = [
+      fixtures.requests.createApiCall({ status: RequestStatus.Errored }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Ignored }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Blocked }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Fulfilled }),
+    ];
+    const res = aggregation.aggregate(fixtures.buildConfig(), apiCalls);
+    expect(res).toEqual({});
+  });
+
   it('groups calls if they have the exact same attributes', () => {
     const apiCalls = [
       fixtures.requests.createApiCall(),

--- a/packages/node/src/core/coordinator/calls/aggregation.ts
+++ b/packages/node/src/core/coordinator/calls/aggregation.ts
@@ -1,4 +1,11 @@
-import { AggregatedApiCall, AggregatedApiCallsById, ApiCall, ClientRequest, Config } from '../../../types';
+import {
+  AggregatedApiCall,
+  AggregatedApiCallsById,
+  ApiCall,
+  ClientRequest,
+  Config,
+  RequestStatus,
+} from '../../../types';
 
 function createAggregatedCall(config: Config, request: ClientRequest<ApiCall>): AggregatedApiCall {
   const trigger = config.triggers.requests.find((t) => t.endpointId === request.endpointId);
@@ -16,14 +23,16 @@ function createAggregatedCall(config: Config, request: ClientRequest<ApiCall>): 
 
 export function aggregate(config: Config, flatApiCalls: ClientRequest<ApiCall>[]): AggregatedApiCallsById {
   const aggregatedApiCallsById = flatApiCalls.reduce((acc: AggregatedApiCallsById, request) => {
+    if (request.status !== RequestStatus.Pending) {
+      return acc;
+    }
+
     const existingAggregatedCall = acc[request.id];
 
     // If this is the first time we're seeing this API call, then create a new aggregated API call
     if (!existingAggregatedCall) {
-      return {
-        ...acc,
-        [request.id]: createAggregatedCall(config, request),
-      };
+      const aggregatedCall = createAggregatedCall(config, request);
+      return { ...acc, [request.id]: aggregatedCall };
     }
 
     // If this is the first time we're seeing this request, add it to the list of unique requests

--- a/packages/node/src/core/evm/handlers/initialize-provider.ts
+++ b/packages/node/src/core/evm/handlers/initialize-provider.ts
@@ -3,6 +3,7 @@ import * as authorizations from '../authorization';
 import * as logger from '../../logger';
 import * as providers from '../providers';
 import { fetchPendingRequests } from './fetch-pending-requests';
+import * as requests from '../../requests';
 import * as state from '../../providers/state';
 import * as templates from '../templates';
 import * as transactionCounts from '../transaction-counts';
@@ -75,7 +76,8 @@ export async function initializeProvider(
     logger.error('Unable to get pending requests', { ...baseLogOptions, error: dataErr });
     return null;
   }
-  const { apiCalls, withdrawals } = groupedRequests;
+  const apiCalls = requests.filterActionableApiCalls(groupedRequests.apiCalls);
+  const withdrawals = requests.filterActionableWithdrawals(groupedRequests.withdrawals);
   logger.info(`Pending requests: ${apiCalls.length} API call(s), ${withdrawals.length} withdrawal(s)`, baseLogOptions);
   const state3 = state.update(state2, { requests: groupedRequests });
 

--- a/packages/node/src/core/handlers/start-coordinator.ts
+++ b/packages/node/src/core/handlers/start-coordinator.ts
@@ -38,9 +38,9 @@ export async function startCoordinator(config: Config) {
   });
   logger.info('Forking to initialize providers complete', baseLogOptions);
 
-  const hasNoRequests = state2.EVMProviders.every((provider) => request.hasNoRequests(provider!.requests));
+  const hasNoRequests = state2.EVMProviders.every((provider) => request.hasNoActionableRequests(provider!.requests));
   if (hasNoRequests) {
-    logger.info('No actionable requests detected. Exiting...', baseLogOptions);
+    logger.info('No actionable requests detected. Returning...', baseLogOptions);
     return state2;
   }
 

--- a/packages/node/src/core/requests/request.test.ts
+++ b/packages/node/src/core/requests/request.test.ts
@@ -1,22 +1,124 @@
 import * as fixtures from 'test/fixtures';
 import * as request from './request';
-import { GroupedRequests, RequestErrorCode } from 'src/types';
+import { GroupedRequests, RequestErrorCode, RequestStatus } from 'src/types';
 
-describe('hasNoRequests', () => {
-  it('returns false if API calls are present', () => {
-    const requests: GroupedRequests = {
-      apiCalls: [fixtures.requests.createApiCall()],
-      withdrawals: [],
-    };
-    expect(request.hasNoRequests(requests)).toEqual(false);
+describe('filterActionableApiCalls', () => {
+  it('returns actionable API calls', () => {
+    const apiCalls = [
+      fixtures.requests.createApiCall({ status: RequestStatus.Pending }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Errored }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Ignored }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Blocked }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Fulfilled }),
+    ];
+    expect(request.filterActionableApiCalls(apiCalls)).toEqual([
+      fixtures.requests.createApiCall({ status: RequestStatus.Pending }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Errored }),
+    ]);
+  });
+});
+
+describe('filterActionableWithdrawals', () => {
+  it('returns actionable withdrawals', () => {
+    const withdrawals = [
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Pending }),
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Errored }),
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Ignored }),
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Blocked }),
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Fulfilled }),
+    ];
+    expect(request.filterActionableWithdrawals(withdrawals)).toEqual([
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Pending }),
+    ]);
+  });
+});
+
+describe('hasActionableApiCalls', () => {
+  it('returns true if pending API calls are present', () => {
+    const apiCalls = [fixtures.requests.createApiCall({ status: RequestStatus.Pending })];
+    expect(request.hasActionableApiCalls(apiCalls)).toEqual(true);
   });
 
-  it('returns false if withdrawals are present', () => {
+  it('returns true if errored API calls are present', () => {
+    const apiCalls = [fixtures.requests.createApiCall({ status: RequestStatus.Errored })];
+    expect(request.hasActionableApiCalls(apiCalls)).toEqual(true);
+  });
+
+  it('returns false if there are no pending or errored API calls', () => {
+    const apiCalls = [
+      fixtures.requests.createApiCall({ status: RequestStatus.Ignored }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Blocked }),
+      fixtures.requests.createApiCall({ status: RequestStatus.Fulfilled }),
+    ];
+    expect(request.hasActionableApiCalls(apiCalls)).toEqual(false);
+  });
+
+  it('returns false if there are no API calls', () => {
+    expect(request.hasActionableApiCalls([])).toEqual(false);
+  });
+});
+
+describe('hasActionableWithdrawals', () => {
+  it('returns true if pending withdrawals are present', () => {
+    const withdrawals = [fixtures.requests.createWithdrawal({ status: RequestStatus.Pending })];
+    expect(request.hasActionableWithdrawals(withdrawals)).toEqual(true);
+  });
+
+  it('returns false if there are no pending withdrawals', () => {
+    const withdrawals = [
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Errored }),
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Ignored }),
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Blocked }),
+      fixtures.requests.createWithdrawal({ status: RequestStatus.Fulfilled }),
+    ];
+    expect(request.hasActionableWithdrawals(withdrawals)).toEqual(false);
+  });
+
+  it('returns false if there are no withdrawals', () => {
+    expect(request.hasActionableWithdrawals([])).toEqual(false);
+  });
+});
+
+describe('hasNoActionableRequests', () => {
+  it('returns false if actionable API calls are present', () => {
+    const requests: GroupedRequests = {
+      apiCalls: [fixtures.requests.createApiCall({ status: RequestStatus.Pending })],
+      withdrawals: [],
+    };
+    expect(request.hasNoActionableRequests(requests)).toEqual(false);
+  });
+
+  it('returns false if actionable withdrawals are present', () => {
+    const requests: GroupedRequests = {
+      apiCalls: [fixtures.requests.createApiCall({ status: RequestStatus.Errored })],
+      withdrawals: [],
+    };
+    expect(request.hasNoActionableRequests(requests)).toEqual(false);
+  });
+
+  it('returns true if there are no actionable API calls or withdrawals', () => {
+    const requests: GroupedRequests = {
+      apiCalls: [
+        fixtures.requests.createApiCall({ status: RequestStatus.Ignored }),
+        fixtures.requests.createApiCall({ status: RequestStatus.Blocked }),
+        fixtures.requests.createApiCall({ status: RequestStatus.Fulfilled }),
+      ],
+      withdrawals: [
+        fixtures.requests.createWithdrawal({ status: RequestStatus.Errored }),
+        fixtures.requests.createWithdrawal({ status: RequestStatus.Ignored }),
+        fixtures.requests.createWithdrawal({ status: RequestStatus.Blocked }),
+        fixtures.requests.createWithdrawal({ status: RequestStatus.Fulfilled }),
+      ],
+    };
+    expect(request.hasNoActionableRequests(requests)).toEqual(true);
+  });
+
+  it('returns true if no requests are present', () => {
     const requests: GroupedRequests = {
       apiCalls: [],
-      withdrawals: [fixtures.requests.createWithdrawal()],
+      withdrawals: [],
     };
-    expect(request.hasNoRequests(requests)).toEqual(false);
+    expect(request.hasNoActionableRequests(requests)).toEqual(true);
   });
 
   it('returns true if there are no requests present', () => {
@@ -24,7 +126,7 @@ describe('hasNoRequests', () => {
       apiCalls: [],
       withdrawals: [],
     };
-    expect(request.hasNoRequests(requests)).toEqual(true);
+    expect(request.hasNoActionableRequests(requests)).toEqual(true);
   });
 });
 

--- a/packages/node/src/core/requests/request.ts
+++ b/packages/node/src/core/requests/request.ts
@@ -1,10 +1,28 @@
 import isEmpty from 'lodash/isEmpty';
-import { ClientRequest, GroupedRequests, RequestStatus } from '../../types';
+import { ApiCall, ClientRequest, GroupedRequests, RequestStatus, Withdrawal } from '../../types';
 
-export function hasNoRequests(requests: GroupedRequests): boolean {
-  return Object.keys(requests).every((requestType) => {
-    return isEmpty(requests[requestType]);
-  });
+export function filterActionableApiCalls(apiCalls: ClientRequest<ApiCall>[]): ClientRequest<ApiCall>[] {
+  return apiCalls.filter((a) => a.status === RequestStatus.Pending || a.status === RequestStatus.Errored);
+}
+
+export function filterActionableWithdrawals(withdrawals: ClientRequest<Withdrawal>[]): ClientRequest<Withdrawal>[] {
+  return withdrawals.filter((w) => w.status === RequestStatus.Pending);
+}
+
+export function hasActionableApiCalls(apiCalls: ClientRequest<ApiCall>[]): boolean {
+  const actionableApiCalls = filterActionableApiCalls(apiCalls);
+  return !isEmpty(actionableApiCalls);
+}
+
+export function hasActionableWithdrawals(withdrawals: ClientRequest<Withdrawal>[]): boolean {
+  const actionableWithdrawals = filterActionableWithdrawals(withdrawals);
+  return !isEmpty(actionableWithdrawals);
+}
+
+export function hasNoActionableRequests(groupedRequests: GroupedRequests): boolean {
+  const noApiCalls = !hasActionableApiCalls(groupedRequests.apiCalls);
+  const noWithdrawals = !hasActionableWithdrawals(groupedRequests.withdrawals);
+  return noApiCalls && noWithdrawals;
 }
 
 export function getStatusNames() {


### PR DESCRIPTION
### Changes

1. API calls that are not pending will no longer be considered when aggregating before HTTP calls are made

2. Fix some incorrect logging messages when API calls or withdrawals are not actionable.
  a. API calls must be either "pending" or "errored" to be considered actionable.
  b. Withdrawals must be "pending" to be considered actionable.
