### PR TITLE
Require response parameters to be whitelisted in the OIS

### DIFF
--- a/packages/node/src/core/adapters/http/parameters.test.ts
+++ b/packages/node/src/core/adapters/http/parameters.test.ts
@@ -24,18 +24,17 @@ describe('getResponseParameterValue', () => {
   });
 
   it('returns the reserved parameter from the Endpoint first', () => {
-    const endpoint = { ...baseEndpoint };
     // This should be ignored
     const requestParameters = { _type: 'bytes32' };
-    const res = parameters.getResponseParameterValue('_type', endpoint, requestParameters);
+    const res = parameters.getResponseParameterValue('_type', baseEndpoint, requestParameters);
     expect(res).toEqual('int256');
   });
 
-  it('returns the request parameter from the Endpoint if no reserved parameter exists', () => {
+  it('returns undefined if no reserved parameter exists', () => {
     const endpoint = { ...baseEndpoint, reservedParameters: [] };
     const requestParameters = { _type: 'bytes32' };
     const res = parameters.getResponseParameterValue('_type', endpoint, requestParameters);
-    expect(res).toEqual('bytes32');
+    expect(res).toEqual(undefined);
   });
 
   it('returns the default if the request parameter does not exist', () => {
@@ -71,14 +70,5 @@ describe('getResponseParameters', () => {
   it('fetches the response parameters', () => {
     const res = parameters.getResponseParameters(baseEndpoint, { _type: 'bytes32', _path: 'updated.path' });
     expect(res).toEqual({ _type: 'int256', _path: 'updated.path' });
-  });
-
-  it('converts _times to a number', () => {
-    const res = parameters.getResponseParameters(baseEndpoint, {
-      _type: 'bytes32',
-      _path: 'updated.path',
-      _times: '1000000',
-    });
-    expect(res).toEqual({ _type: 'int256', _path: 'updated.path', _times: 1000000 });
   });
 });

--- a/packages/node/src/core/adapters/http/parameters.ts
+++ b/packages/node/src/core/adapters/http/parameters.ts
@@ -9,8 +9,10 @@ export function getResponseParameterValue(
   requestParameters: ApiCallParameters
 ): string | undefined {
   const reservedParameter = endpoint.reservedParameters.find((rp) => rp.name === name);
+  // Reserved parameters must be whitelisted in order to be use, even if they have no
+  // fixed or default value
   if (!reservedParameter) {
-    return requestParameters[name];
+    return undefined;
   }
 
   if (reservedParameter.fixed) {
@@ -30,9 +32,5 @@ export function getResponseParameters(endpoint: Endpoint, requestParameters: Api
   const _times = getResponseParameterValue('_times', endpoint, requestParameters);
   const _type = getResponseParameterValue('_type', endpoint, requestParameters);
 
-  return {
-    _type,
-    _path,
-    _times: _times ? Number(_times) : undefined,
-  };
+  return { _type, _path, _times };
 }

--- a/packages/node/test/fixtures/config/ois.ts
+++ b/packages/node/test/fixtures/config/ois.ts
@@ -65,6 +65,8 @@ export function buildOIS(ois?: Partial<OIS>): OIS {
           },
         ],
         reservedParameters: [
+          { name: '_type' },
+          { name: '_path' },
           {
             name: '_times',
             default: '100000',


### PR DESCRIPTION
### Changes

1. See title. Response parameters must now be specified in the `endpoints.x.reservedParameters` - even if no default or fixed value is set.

### Addresses

https://github.com/api3dao/airnode/issues/156
