### PR TITLE
Hardcode artifact dependencies

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -2,7 +2,7 @@
 
 1. Build the Docker image
 ```sh
-docker build . -t api3/airnode
+docker build . -t api3/airnode:latest
 ```
 
 2. Ensure that your `.env` file looks like [`.env.example`](/packages/deployer/.env.example) and is the current working directory.

--- a/packages/deployer/src/evm/evm.ts
+++ b/packages/deployer/src/evm/evm.ts
@@ -1,6 +1,6 @@
 import * as ethers from 'ethers';
 import ora from 'ora';
-import { AirnodeABI } from '@airnode/protocol';
+import { AirnodeArtifact } from '@airnode/protocol';
 
 const chainIdsToNames = {
   1: 'mainnet',
@@ -20,7 +20,7 @@ export async function checkProviderRecords(providerId, chains, masterWalletAddre
       // Use the first provider of the chain in config.json
       const provider = new ethers.providers.JsonRpcProvider(chain.providers[0].url);
       // chain.contracts.Airnode is a required field
-      const airnode = new ethers.Contract(chain.contracts.Airnode, AirnodeABI, provider);
+      const airnode = new ethers.Contract(chain.contracts.Airnode, AirnodeArtifact.abi, provider);
       const providerRecord = await airnode.getProvider(providerId);
       if (providerRecord.xpub === '') {
         spinner.warn(`Provider record not found on chain: ${chainName}`);

--- a/packages/node/src/evm/contracts/airnode.ts
+++ b/packages/node/src/evm/contracts/airnode.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { AirnodeABI, AirnodeAddresses } from '@airnode/protocol';
+import { AirnodeArtifact, AirnodeAddresses } from '@airnode/protocol';
 import { Contract } from './types';
 
 const ClientRequestCreated = ethers.utils.id(
@@ -28,7 +28,7 @@ export const Airnode: Contract = {
     4: AirnodeAddresses[4],
     1337: '0x197F3826040dF832481f835652c290aC7c41f073',
   },
-  ABI: AirnodeABI,
+  ABI: AirnodeArtifact.abi,
   topics: {
     // API calls
     ClientRequestCreated,

--- a/packages/node/src/evm/contracts/convenience.ts
+++ b/packages/node/src/evm/contracts/convenience.ts
@@ -1,5 +1,5 @@
 import { Contract } from './types';
-import { ConvenienceABI, ConvenienceAddresses } from '@airnode/protocol';
+import { ConvenienceArtifact, ConvenienceAddresses } from '@airnode/protocol';
 
 export const Convenience: Contract = {
   addresses: {
@@ -8,6 +8,6 @@ export const Convenience: Contract = {
     4: ConvenienceAddresses[4],
     1337: '0x2393737d287c555d148012270Ce4567ABb1ee95C',
   },
-  ABI: ConvenienceABI,
+  ABI: ConvenienceArtifact.abi,
   topics: {},
 };

--- a/packages/protocol/index.js
+++ b/packages/protocol/index.js
@@ -1,16 +1,19 @@
 const AirnodeArtifact = require('./artifacts/contracts/Airnode.sol/Airnode.json');
 const ConvenienceArtifact = require('./artifacts/contracts/Convenience.sol/Convenience.json');
 
-const networkChainIds = { ropsten: 3, rinkeby: 4 };
-
 const AirnodeAddresses = {};
 const ConvenienceAddresses = {};
-for (const network in networkChainIds) {
-  const AirnodeDeployment = require(`./deployments/${network}/Airnode.json`);
-  AirnodeAddresses[networkChainIds[network]] = AirnodeDeployment.receipt.contractAddress;
-  const ConvenienceDeployment = require(`./deployments/${network}/Convenience.json`);
-  ConvenienceAddresses[networkChainIds[network]] = ConvenienceDeployment.receipt.contractAddress;
-}
+let AirnodeDeployment, ConvenienceDeployment;
+// Ropsten - 3
+AirnodeDeployment = require(`./deployments/ropsten/Airnode.json`);
+AirnodeAddresses[3] = AirnodeDeployment.receipt.contractAddress;
+ConvenienceDeployment = require(`./deployments/ropsten/Convenience.json`);
+ConvenienceAddresses[3] = ConvenienceDeployment.receipt.contractAddress;
+// Rinkeby - 4
+AirnodeDeployment = require(`./deployments/rinkeby/Airnode.json`);
+AirnodeAddresses[4] = AirnodeDeployment.receipt.contractAddress;
+ConvenienceDeployment = require(`./deployments/rinkeby/Convenience.json`);
+ConvenienceAddresses[4] = ConvenienceDeployment.receipt.contractAddress
 
 module.exports = {
   AirnodeArtifact,

--- a/packages/protocol/index.js
+++ b/packages/protocol/index.js
@@ -2,19 +2,20 @@ const AirnodeArtifact = require('./artifacts/contracts/Airnode.sol/Airnode.json'
 const ConvenienceArtifact = require('./artifacts/contracts/Convenience.sol/Convenience.json');
 const MockAirnodeClientArtifact = require('./artifacts/contracts/mock/MockAirnodeClient.sol/MockAirnodeClient.json');
 
-const AirnodeAddresses = {};
-const ConvenienceAddresses = {};
-let AirnodeDeployment, ConvenienceDeployment;
-// Ropsten - 3
-AirnodeDeployment = require(`./deployments/ropsten/Airnode.json`);
-AirnodeAddresses[3] = AirnodeDeployment.receipt.contractAddress;
-ConvenienceDeployment = require(`./deployments/ropsten/Convenience.json`);
-ConvenienceAddresses[3] = ConvenienceDeployment.receipt.contractAddress;
-// Rinkeby - 4
-AirnodeDeployment = require(`./deployments/rinkeby/Airnode.json`);
-AirnodeAddresses[4] = AirnodeDeployment.receipt.contractAddress;
-ConvenienceDeployment = require(`./deployments/rinkeby/Convenience.json`);
-ConvenienceAddresses[4] = ConvenienceDeployment.receipt.contractAddress;
+const AirnodeRopsten = require('./deployments/ropsten/Airnode.json');
+const ConvenienceRopsten = require('./deployments/ropsten/Convenience.json');
+
+const AirnodeRinkeby = require('./deployments/rinkeby/Airnode.json');
+const ConvenienceRinkeby = require('./deployments/rinkeby/Convenience.json');
+
+const AirnodeAddresses = {
+  3: AirnodeRopsten.receipt.contractAddress,
+  4: AirnodeRinkeby.receipt.contractAddress,
+};
+const ConvenienceAddresses = {
+  3: ConvenienceRopsten.receipt.contractAddress,
+  4: ConvenienceRinkeby.receipt.contractAddress,
+};
 
 module.exports = {
   AirnodeArtifact,

--- a/packages/protocol/index.js
+++ b/packages/protocol/index.js
@@ -14,7 +14,7 @@ ConvenienceAddresses[3] = ConvenienceDeployment.receipt.contractAddress;
 AirnodeDeployment = require(`./deployments/rinkeby/Airnode.json`);
 AirnodeAddresses[4] = AirnodeDeployment.receipt.contractAddress;
 ConvenienceDeployment = require(`./deployments/rinkeby/Convenience.json`);
-ConvenienceAddresses[4] = ConvenienceDeployment.receipt.contractAddress
+ConvenienceAddresses[4] = ConvenienceDeployment.receipt.contractAddress;
 
 module.exports = {
   AirnodeArtifact,

--- a/packages/protocol/index.js
+++ b/packages/protocol/index.js
@@ -13,8 +13,8 @@ for (const network in networkChainIds) {
 }
 
 module.exports = {
-  AirnodeABI: AirnodeArtifact.abi,
-  ConvenienceABI: ConvenienceArtifact.abi,
+  AirnodeArtifact,
+  ConvenienceArtifact,
   AirnodeAddresses,
   ConvenienceAddresses,
 };

--- a/packages/protocol/index.js
+++ b/packages/protocol/index.js
@@ -1,5 +1,6 @@
 const AirnodeArtifact = require('./artifacts/contracts/Airnode.sol/Airnode.json');
 const ConvenienceArtifact = require('./artifacts/contracts/Convenience.sol/Convenience.json');
+const MockAirnodeClientArtifact = require('./artifacts/contracts/mock/MockAirnodeClient.sol/MockAirnodeClient.json');
 
 const AirnodeAddresses = {};
 const ConvenienceAddresses = {};
@@ -20,4 +21,9 @@ module.exports = {
   ConvenienceArtifact,
   AirnodeAddresses,
   ConvenienceAddresses,
+  mocks: {
+    MockAirnodeClient: MockAirnodeClientArtifact,
+  },
+  // TODO
+  authorizers: {},
 };


### PR DESCRIPTION
- Unrolled protocol contract artifact dependencies and hardcoded them so that they are added to the package by `serverless-plugin-optimize`
- I copied the additions from https://github.com/api3dao/airnode/blob/operation-package/packages/protocol/index.js in advance. However I exported the artifacts more explicitly as `AirnodeArtifact` instead of `Airnode` instead of importing them with aliases later because the names `Airnode`/`Convenience` are already used (as in https://github.com/api3dao/airnode/blob/operation-package/packages/node/src/evm/contracts/airnode.ts#L2).