### PR TITLE
Fix designated wallet derivation convention

### DIFF
--- a/packages/node/src/evm/transaction-counts.test.ts
+++ b/packages/node/src/evm/transaction-counts.test.ts
@@ -30,7 +30,7 @@ describe('fetchByRequesterIndex', () => {
     expect(logs).toEqual([]);
     expect(res).toEqual({ 1: 5 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(1);
-    expect(getTransactionCountMock).toHaveBeenCalledWith('0xBff368EaD703f07fC6C9585e25d9755A47361562', 10716084);
+    expect(getTransactionCountMock).toHaveBeenCalledWith('0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E', 10716084);
   });
 
   it('returns transaction counts for multiple wallets', async () => {
@@ -47,8 +47,8 @@ describe('fetchByRequesterIndex', () => {
     expect(res).toEqual({ 1: 45, 2: 123 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(2);
     expect(getTransactionCountMock.mock.calls).toEqual([
-      ['0xBff368EaD703f07fC6C9585e25d9755A47361562', 10716084],
-      ['0x6722FC66C05d7092833CC772fD2C00Fdc0f939a6', 10716084],
+      ['0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E', 10716084],
+      ['0xa46c4b41d72Ada9D14157b28A8a2Db97560fFF12', 10716084],
     ]);
   });
 
@@ -66,8 +66,8 @@ describe('fetchByRequesterIndex', () => {
     expect(res).toEqual({ 1: 123 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(2);
     expect(getTransactionCountMock.mock.calls).toEqual([
-      ['0xBff368EaD703f07fC6C9585e25d9755A47361562', 10716084],
-      ['0xBff368EaD703f07fC6C9585e25d9755A47361562', 10716084],
+      ['0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E', 10716084],
+      ['0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E', 10716084],
     ]);
   });
 
@@ -84,7 +84,7 @@ describe('fetchByRequesterIndex', () => {
     expect(logs).toEqual([
       {
         level: 'ERROR',
-        message: 'Unable to fetch transaction count for wallet:0xBff368EaD703f07fC6C9585e25d9755A47361562',
+        message: 'Unable to fetch transaction count for wallet:0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E',
         error: new Error('Server says no'),
       },
     ]);

--- a/packages/node/src/evm/verification/request-verification.test.ts
+++ b/packages/node/src/evm/verification/request-verification.test.ts
@@ -59,7 +59,7 @@ describe('verifyDesignatedWallets', () => {
     expect(logs).toEqual([
       {
         level: 'ERROR',
-        message: `Invalid designated wallet:${apiCall.designatedWallet} for Request:${apiCall.id}. Expected:0xdEc1ef92C1c1C5C84Ae0aF715745E691071Cb4fa`,
+        message: `Invalid designated wallet:${apiCall.designatedWallet} for Request:${apiCall.id}. Expected:0x2EfDDdd9337999A00f36f28e58F036381B8b1125`,
       },
     ]);
     expect(res[0]).toEqual({
@@ -71,14 +71,14 @@ describe('verifyDesignatedWallets', () => {
 
   it('does nothing if the designated wallet matches the expected wallet', () => {
     const apiCall = fixtures.requests.createApiCall({
-      designatedWallet: '0xdEc1ef92C1c1C5C84Ae0aF715745E691071Cb4fa',
+      designatedWallet: '0x2EfDDdd9337999A00f36f28e58F036381B8b1125',
       requesterIndex: '3',
     });
     const [logs, res] = verification.verifyDesignatedWallets([apiCall], masterHDNode);
     expect(logs).toEqual([
       {
         level: 'DEBUG',
-        message: `Request ID:${apiCall.id} is linked to a valid designated wallet:0xdEc1ef92C1c1C5C84Ae0aF715745E691071Cb4fa`,
+        message: `Request ID:${apiCall.id} is linked to a valid designated wallet:0x2EfDDdd9337999A00f36f28e58F036381B8b1125`,
       },
     ]);
     expect(res[0]).toEqual(apiCall);

--- a/packages/node/src/evm/wallet.test.ts
+++ b/packages/node/src/evm/wallet.test.ts
@@ -32,9 +32,9 @@ describe('deriveWalletAddressFromIndex', () => {
     const adminWallet = wallet.deriveWalletAddressFromIndex(masterHDNode, '0');
     const wallet1 = wallet.deriveWalletAddressFromIndex(masterHDNode, '1');
     const wallet2 = wallet.deriveWalletAddressFromIndex(masterHDNode, '777');
-    expect(adminWallet).toEqual('0x566954B6E04BDb789e7d1118e3dC1AC9A34A8B44');
-    expect(wallet1).toEqual('0xBff368EaD703f07fC6C9585e25d9755A47361562');
-    expect(wallet2).toEqual('0x36c6c96d0ce55c37613a8acA1D895B923C557FA4');
+    expect(adminWallet).toEqual('0xF47dD64127f46ca44679647BC1B3c6B248bf79A0');
+    expect(wallet1).toEqual('0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E');
+    expect(wallet2).toEqual('0x5547c2B0420D120f1DE7767c9BE451705df5a4E5');
   });
 });
 
@@ -43,7 +43,7 @@ describe('deriveSigningWalletFromIndex', () => {
     const masterHDNode = wallet.getMasterHDNode();
     const signingWallet = wallet.deriveSigningWalletFromIndex(masterHDNode, '0');
     expect(signingWallet._isSigner).toEqual(true);
-    expect(signingWallet.address).toEqual('0x566954B6E04BDb789e7d1118e3dC1AC9A34A8B44');
+    expect(signingWallet.address).toEqual('0xF47dD64127f46ca44679647BC1B3c6B248bf79A0');
   });
 });
 

--- a/packages/node/src/evm/wallet.ts
+++ b/packages/node/src/evm/wallet.ts
@@ -1,18 +1,15 @@
 import { ethers } from 'ethers';
 import * as config from '../config';
 
-// We can reserve 2^256-1 different wallets as below
-// m/0/0/0: designatorAddress
-// m/0/0/1: First reserved wallet path
-// m/0/0/2: Second reserved wallet path
+// 2^31-1 different wallets can be designated as below
+// m/0/0: masterWalletAddress
+// m/0/1: First reserved wallet path
+// m/0/2: Second reserved wallet path
 // ...
-// m/0/0/2^31-1 (each index is represented in 31-bits)
-// m/0/1/0
-// m/0/1/1
-// ...
-// but there is no need for more than 2^31-1 per provider
+// m/0/2^31-1 (each index is represented in 31-bits)
+// Although this can be extended as m/0/*/... it will not be needed.
 function getPathFromIndex(index: number | string) {
-  return `m/0/0/${index}`;
+  return `m/0/${index}`;
 }
 
 export function getMasterHDNode(): ethers.utils.HDNode {


### PR DESCRIPTION
I think we miscommunicated about this. It's better to use `m/0/#` as the path because it cuts down on running time, we definitely won't need more than 2^31 requesters and we can still extend this by using `m/0/*/...`.
The designated wallet addresses updated in the tests are calculated with a separate script.