### PR TITLE
Lambda fixes

### DIFF
--- a/packages/deployer/src/config-data/config.json.example
+++ b/packages/deployer/src/config-data/config.json.example
@@ -45,7 +45,7 @@
     ]
   },
   "triggers": {
-    "requests": [
+    "request": [
       {
         "endpointId": "0xc3eb02c57654b57e06a745a970317987f7886c000e95a4a51d4a4447c515cc05",
         "oisTitle": "coinlayer",

--- a/packages/deployer/src/handlers/aws/index.ts
+++ b/packages/deployer/src/handlers/aws/index.ts
@@ -33,7 +33,7 @@ export async function callApi(event: any) {
   const [logs, apiCallResponse] = await node.handlers.callApi(config, aggregatedApiCall);
   node.logger.logPending(logs, logOptions);
   const response = encodeBody({ ok: true, data: apiCallResponse });
-  return { statusCode: 200, body: JSON.stringify(response) };
+  return { statusCode: 200, body: response };
 }
 
 export async function processProviderRequests(event: any) {

--- a/packages/node/__dev__/config.json.example
+++ b/packages/node/__dev__/config.json.example
@@ -24,7 +24,7 @@
     ]
   },
   "triggers": {
-    "requests": [
+    "request": [
       {
         "endpointId": "0x2f3a3adf6daf5a3bb00ab83aa82262a6a84b59b0a89222386135330a1819ab48",
         "oisTitle": "coinlayer",

--- a/packages/node/src/adapters/http/worker.test.ts
+++ b/packages/node/src/adapters/http/worker.test.ts
@@ -17,7 +17,9 @@ describe('spawnNewApiCall', () => {
   };
 
   it('handles remote AWS calls', async () => {
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: true, data: { value: '0x123' } }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: true, data: { value: '0x123' } }) }) })
+    );
     const aggregatedApiCall = fixtures.createAggregatedApiCall();
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnNewApiCall(aggregatedApiCall, logOptions, workerOpts);
@@ -54,7 +56,9 @@ describe('spawnNewApiCall', () => {
 
   it('returns an error if the response has an error log', async () => {
     const errorLog = logger.pend('ERROR', 'Something went wrong');
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: false, errorLog }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false, errorLog }) }) })
+    );
     const aggregatedApiCall = fixtures.createAggregatedApiCall();
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnNewApiCall(aggregatedApiCall, logOptions, workerOpts);
@@ -71,7 +75,9 @@ describe('spawnNewApiCall', () => {
   });
 
   it('returns an error if the response is not ok', async () => {
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: false }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false }) }) })
+    );
     const aggregatedApiCall = fixtures.createAggregatedApiCall();
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnNewApiCall(aggregatedApiCall, logOptions, workerOpts);

--- a/packages/node/src/coordinator/calls/aggregation.ts
+++ b/packages/node/src/coordinator/calls/aggregation.ts
@@ -1,7 +1,7 @@
 import { AggregatedApiCall, AggregatedApiCallsById, ApiCall, ClientRequest, Config, RequestStatus } from '../../types';
 
 function createAggregatedCall(config: Config, request: ClientRequest<ApiCall>): AggregatedApiCall {
-  const trigger = config.triggers.requests.find((t) => t.endpointId === request.endpointId);
+  const trigger = config.triggers.request.find((t) => t.endpointId === request.endpointId);
 
   return {
     id: request.id,

--- a/packages/node/src/evm/workers.test.ts
+++ b/packages/node/src/evm/workers.test.ts
@@ -12,7 +12,9 @@ import * as worker from './workers';
 describe('spawnNewProvider', () => {
   it('handles remote AWS calls', async () => {
     const state = fixtures.buildEVMProviderState();
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: true, data: state }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: true, data: state }) }) })
+    );
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnNewProvider(state, workerOpts);
     expect(logs).toEqual([]);
@@ -53,7 +55,9 @@ describe('spawnNewProvider', () => {
   it('returns an error if the response has an error log', async () => {
     const state = fixtures.buildEVMProviderState();
     const errorLog = logger.pend('ERROR', 'Something went wrong');
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: false, errorLog }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false, errorLog }) }) })
+    );
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnNewProvider(state, workerOpts);
     expect(logs).toEqual([errorLog]);
@@ -70,7 +74,9 @@ describe('spawnNewProvider', () => {
 
   it('returns an error if the response is not ok', async () => {
     const state = fixtures.buildEVMProviderState();
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: false }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false }) }) })
+    );
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnNewProvider(state, workerOpts);
     expect(logs).toEqual([{ level: 'ERROR', message: 'Unable to initialize provider:ganache-test' }]);
@@ -89,7 +95,9 @@ describe('spawnNewProvider', () => {
 describe('spawnProviderRequestProcessor', () => {
   it('handles remote AWS calls', async () => {
     const state = fixtures.buildEVMProviderState();
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: true, data: state }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: true, data: state }) }) })
+    );
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnProviderRequestProcessor(state, workerOpts);
     expect(logs).toEqual([]);
@@ -130,7 +138,9 @@ describe('spawnProviderRequestProcessor', () => {
   it('returns an error if the response has an error log', async () => {
     const state = fixtures.buildEVMProviderState();
     const errorLog = logger.pend('ERROR', 'Something went wrong');
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: false, errorLog }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false, errorLog }) }) })
+    );
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnProviderRequestProcessor(state, workerOpts);
     expect(logs).toEqual([errorLog]);
@@ -147,7 +157,9 @@ describe('spawnProviderRequestProcessor', () => {
 
   it('returns an error if the response is not ok', async () => {
     const state = fixtures.buildEVMProviderState();
-    invokeMock.mockImplementationOnce((params, callback) => callback(null, { ok: false }));
+    invokeMock.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false }) }) })
+    );
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const [logs, res] = await worker.spawnProviderRequestProcessor(state, workerOpts);
     expect(logs).toEqual([{ level: 'ERROR', message: 'Unable to process provider requests:ganache-test' }]);

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -236,7 +236,7 @@ export interface RequestTrigger {
 }
 
 export interface Triggers {
-  readonly requests: RequestTrigger[];
+  readonly request: RequestTrigger[];
 }
 
 // ===========================================

--- a/packages/node/src/workers/cloud-platforms/aws.test.ts
+++ b/packages/node/src/workers/cloud-platforms/aws.test.ts
@@ -14,7 +14,9 @@ describe('spawn', () => {
   it('derives the function name, invokes and returns the response', async () => {
     const lambda = new AWS.Lambda();
     const invoke = lambda.invoke as jest.Mock;
-    invoke.mockImplementationOnce((params, callback) => callback(null, { value: 7777 }));
+    invoke.mockImplementationOnce((params, callback) =>
+      callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ value: 7777 }) }) })
+    );
     const workerOpts = fixtures.buildWorkerOptions({ cloudProvider: 'aws' });
     const parameters = {
       ...workerOpts,

--- a/packages/node/src/workers/cloud-platforms/aws.ts
+++ b/packages/node/src/workers/cloud-platforms/aws.ts
@@ -18,7 +18,7 @@ export function spawn(params: WorkerParameters): Promise<WorkerResponse> {
       if (err) {
         reject(err);
       }
-      resolve(data as WorkerResponse);
+      resolve(JSON.parse(JSON.parse(data.Payload as string).body) as WorkerResponse);
     });
   });
 }

--- a/packages/node/test/fixtures/config/config.ts
+++ b/packages/node/test/fixtures/config/config.ts
@@ -6,7 +6,7 @@ export function buildConfig(config?: Partial<Config>): Config {
   return {
     id: 'my-config',
     triggers: {
-      requests: [{ endpointId: 'endpointId', endpointName: 'endpointName', oisTitle: 'oisTitle' }],
+      request: [{ endpointId: 'endpointId', endpointName: 'endpointName', oisTitle: 'oisTitle' }],
     },
     ois: [ois.buildOIS()],
     nodeSettings: settings.buildNodeSettings(),


### PR DESCRIPTION
- Changed the `triggers` field from `requests` to [`request`](https://github.com/api3dao/api3-docs/blob/master/airnode/config-json.md#triggers)
- AWS Lambda InvocationResponse is
```ts
export interface InvocationResponse {
    StatusCode?: Integer;
    FunctionError?: String;
    LogResult?: String;
    Payload?: _Blob;
    ExecutedVersion?: Version;
  }
```
where `data` is in `Payload` under `body` in stringified form. So updated the worker to return the parsed `data` and updated the related tests.
- `ApiCall` was stringifying the response unlike the provider functions causing inconsistency, so removed that.