### PR TITLE
Authorization fetching fallback

### DIFF
--- a/packages/node/src/evm/authorization/authorization-fetching.ts
+++ b/packages/node/src/evm/authorization/authorization-fetching.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import chunk from 'lodash/chunk';
 import flatMap from 'lodash/flatMap';
 import isEmpty from 'lodash/isEmpty';
+import isNil from 'lodash/isNil';
 import { Convenience } from '../contracts';
 import * as logger from '../../logger';
 import { go, retryOperation } from '../../utils/promise-utils';
@@ -12,6 +13,30 @@ interface FetchOptions {
   convenienceAddress: string;
   providerId: string;
   provider: ethers.providers.JsonRpcProvider;
+}
+
+export async function fetchAuthorizationStatus(
+  convenience: ethers.Contract,
+  providerId: string,
+  apiCall: ClientRequest<ApiCall>
+): Promise<LogsData<boolean | null>> {
+  const contractCall = () =>
+    convenience.checkAuthorizationStatus(
+      providerId,
+      apiCall.id,
+      apiCall.endpointId,
+      apiCall.requesterIndex,
+      apiCall.designatedWallet,
+      apiCall.clientAddress
+    ) as Promise<boolean>;
+  const retryableContractCall = retryOperation(OPERATION_RETRIES, contractCall);
+
+  const [err, authorized] = await go(retryableContractCall);
+  if (err || !authorized) {
+    const log = logger.pend('ERROR', 'Failed to fetch authorization details', err);
+    return [[log], null];
+  }
+  return [[], authorized];
 }
 
 async function fetchAuthorizationStatuses(
@@ -39,16 +64,31 @@ async function fetchAuthorizationStatuses(
 
   const [err, data] = await go(retryableContractCall);
   if (err || !data) {
-    const log = logger.pend('ERROR', 'Failed to fetch authorization details', err);
-    return [[log], null];
+    const groupLog = logger.pend('ERROR', 'Failed to fetch group authorization details', err);
+
+    // If the authorization batch cannot be fetched, fallback to fetching authorizations individually
+    const promises: Promise<LogsData<{ id: string; authorized: boolean | null }>>[] = apiCalls.map(async (apiCall) => {
+      const [logs, authorized] = await fetchAuthorizationStatus(convenience, providerId, apiCall);
+      const data = { id: apiCall.id, authorized };
+      const result: LogsData<{ id: string; authorized: boolean | null }> = [logs, data];
+      return result;
+    });
+    const results = await Promise.all(promises);
+    const individualLogs = flatMap(results, (v) => v[0]);
+    const authorizationsWithId = results.filter((v) => !isNil(v[1])).map((v) => v[1]);
+    const authorizationsById: { [id: string]: boolean } = authorizationsWithId.reduce((acc, status) => {
+      return { ...acc, [status.id]: status.authorized };
+    }, {});
+
+    return [[groupLog, ...individualLogs], authorizationsById];
   }
 
   // Authorization statuses are returned in the same order that they are requested.
-  const authorizations = apiCalls.reduce((acc, apiCall, index) => {
+  const authorizationsById = apiCalls.reduce((acc, apiCall, index) => {
     return { ...acc, [apiCall.id]: data[index] };
   }, {});
 
-  return [[], authorizations];
+  return [[], authorizationsById];
 }
 
 export async function fetch(

--- a/packages/node/src/evm/authorization/authorization-fetching.ts
+++ b/packages/node/src/evm/authorization/authorization-fetching.ts
@@ -75,13 +75,13 @@ async function fetchAuthorizationStatuses(
       return result;
     });
     const results = await Promise.all(promises);
-    const individualLogs = flatMap(results, (v) => v[0]);
-    const authorizationsWithId = results.filter((v) => !isNil(v[1].authorized)).map((v) => v[1]);
+    const allLogs = flatMap(results, (r) => r[0]);
+    const authorizationsWithId = results.filter((r) => !isNil(r[1].authorized)).map((r) => r[1]);
     const authorizationsById: { [id: string]: boolean } = authorizationsWithId.reduce((acc, status) => {
       return { ...acc, [status.id]: status.authorized };
     }, {});
 
-    return [[groupLog, ...individualLogs], authorizationsById];
+    return [[groupLog, ...allLogs], authorizationsById];
   }
 
   // Authorization statuses are returned in the same order that they are requested.

--- a/packages/node/src/evm/templates/template-fetching.test.ts
+++ b/packages/node/src/evm/templates/template-fetching.test.ts
@@ -306,7 +306,7 @@ describe('fetchTemplate', () => {
     expect(getTemplateMock).toHaveBeenCalledTimes(1);
   });
 
-  it('retries individual template fetches once', async () => {
+  it('retries individual template calls once', async () => {
     const rawTemplate = {
       designatedWallet: 'designatedWallet-0',
       endpointId: 'endpointId-0',


### PR DESCRIPTION
I'm targeting the template-fallback branch for now. There are still a few outstanding comments so I haven't merged it yet

### Changes

1. Falls back to individual authorization calls when the authorization batch call fails twice.

### Addresses

https://github.com/api3dao/airnode/issues/64