### PR TITLE
Add master and self authorizers

### DIFF
--- a/packages/protocol/contracts/authorizers/MasterAuthorizer.sol
+++ b/packages/protocol/contracts/authorizers/MasterAuthorizer.sol
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "./interfaces/IMasterAuthorizer.sol";
+
+/// @title Authorizer contract with a master admin
+/// @notice This contract assumes that there is a master admin who can be
+/// trusted with whitelisting clients and requesters for specific providers.
+/// In the API3 context, this would be the API3 DAO. However, requiring a DAO
+/// to vote on every whitelisting and blacklisting action is not scalable. As
+/// a solution, the master admin (i.e., the API3 DAO) appoints addresses as
+/// admins (e.g., a multisig controlled by the integrations team). These admins
+/// are limited in authority; for example, they can only extend whitelistings
+/// up to a limited length (specified by the master admin). Most importantly,
+/// the admins cannot revoke whitelistings, as this can be used to perform a
+/// denial of service attack. Note that the master admin is authorized to
+/// revoke whitelistings.
+/// Contracts can also be set as admins. For example, a contract can
+/// automatically extend the whitelistings of clients or requesters when it
+/// receives payment.
+contract MasterAuthorizer is IMasterAuthorizer {
+    struct Admin {
+        bool status;
+        uint256 maxWhitelistExtension;
+        }
+
+    uint256 public immutable authorizerType = 1;
+    address public masterAdmin;
+    mapping(address => Admin) public admins;
+    mapping(bytes32 => mapping(address => uint256)) public
+        providerIdToClientAddressToWhitelistExpiration;
+    mapping(bytes32 => mapping(uint256 => uint256)) public
+        providerIdToRequesterIndexToWhitelistExpiration;
+
+    /// @dev Reverts if the caller is not the master admin
+    modifier onlyMasterAdmin()
+    {
+        require(
+            msg.sender == masterAdmin,
+            "Caller is not master admin"
+            );
+        _;
+    }
+
+    /// @dev Reverts if the caller is not an admin
+    modifier onlyAdmin()
+    {
+        require(
+            admins[msg.sender].status,
+            "Caller is not an admin"
+            );
+        _;
+    }
+
+    /// @dev Reverts if `whitelistExpiration` is not in the future or is too
+    /// far in the future
+    /// @param whitelistExpiration Timestamp at which the whitelisting will
+    /// expire
+    modifier onlyValidExpiration(uint256 whitelistExpiration)
+    {
+        require(
+            // solhint-disable-next-line not-rely-on-time
+            whitelistExpiration >= now,
+            "Expiration is in past"
+            );
+        require(
+            // solhint-disable-next-line not-rely-on-time
+            whitelistExpiration <= now + admins[msg.sender].maxWhitelistExtension,
+            "Expiration exceeds admin limit"
+            );
+        _;
+    }
+
+    /// @param _masterAdmin Address that will be set as the master admin
+    constructor (address _masterAdmin)
+        public
+    {
+        masterAdmin = _masterAdmin;
+    }
+
+    /// @notice Called by the master admin to transfer the master adminship to
+    /// another address
+    /// @param _masterAdmin Address the master adminship will be transferred to
+    function transferMasterAdminship(address _masterAdmin)
+        external
+        override
+        onlyMasterAdmin
+    {
+        require(
+            _masterAdmin != address(0),
+            "Used zero address"
+            );
+        require(
+            _masterAdmin != masterAdmin,
+            "Input will not update state"
+            );
+        emit MasterAdminshipTransferred(
+            masterAdmin,
+            _masterAdmin
+            );
+        masterAdmin = _masterAdmin;
+    }
+
+    /// @notice Called by the master admin to set the adminship parameters of
+    /// an address
+    /// @param adminAddress Address whose adminship parameters will be set
+    /// @param status Adminship status
+    /// @param maxWhitelistExtension Amount that the respective admin can
+    /// extend the whitelistings for
+    function setAdminParameters(
+        address adminAddress,
+        bool status,
+        uint256 maxWhitelistExtension
+        )
+        external
+        override
+        onlyMasterAdmin
+    {
+        admins[adminAddress] = Admin(
+            status,
+            maxWhitelistExtension
+            );
+        emit AdminParametersSet(
+            adminAddress,
+            status,
+            maxWhitelistExtension
+            );
+    }
+
+    /// @notice Called by the admin to renounce their adminship
+    /// @dev To minimize the number of transactions the master admin will have
+    /// to make, the contract is implemented optimistically, i.e., the admins
+    /// are expected to renounce their adminship when they are supposed to. If
+    /// this is not the case, the master admin can always revoke their
+    /// adminship by force.
+    function renounceAdminship()
+        external
+        override
+        onlyAdmin()
+    {
+        admins[msg.sender].status = false;
+        emit AdminshipRenounced(msg.sender);
+    }
+
+    /// @notice Called by the admin to extend the whitelisting of a client
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param clientAddress Client address
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// client will expire
+    function extendClientWhitelisting(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyAdmin()
+        onlyValidExpiration(whitelistExpiration)
+    {
+        require(
+            whitelistExpiration > providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress],
+            "Expiration does not extend"
+            );
+        providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress] = whitelistExpiration;
+        emit ClientWhitelistingExtended(
+            providerId,
+            clientAddress,
+            whitelistExpiration,
+            msg.sender
+            );
+    }
+
+    /// @notice Called by the admin to extend the whitelisting of a requester
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param requesterIndex Requester index from `RequesterStore.sol`
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// requester will expire
+    function extendRequesterWhitelisting(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyAdmin()
+        onlyValidExpiration(whitelistExpiration)
+    {
+        require(
+            whitelistExpiration > providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex],
+            "Expiration does not extend"
+            );
+        providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex] = whitelistExpiration;
+        emit RequesterWhitelistingExtended(
+            providerId,
+            requesterIndex,
+            whitelistExpiration,
+            msg.sender
+            );
+    }
+
+    /// @notice Called by the master admin to set the whitelisting expiration
+    /// time of the client
+    /// @dev Note that the master admin can use this method to set the client's
+    /// `whitelistExpiration` to `0`, effectively blacklisting them
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param clientAddress Client address
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// client will expire
+    function setClientWhitelistExpiration(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyMasterAdmin
+    {
+        providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress] = whitelistExpiration;
+        emit ClientWhitelistExpirationSet(
+            providerId,
+            clientAddress,
+            whitelistExpiration
+            );
+    }
+
+    /// @notice Called by the master admin to set the whitelisting expiration
+    /// time of the requester
+    /// @dev Note that the master admin can use this method to set the
+    /// requester's `whitelistExpiration` to `0`, effectively blacklisting them
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param requesterIndex Requester index from `RequesterStore.sol`
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// requester will expire
+    function setRequesterWhitelistExpiration(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyMasterAdmin
+    {
+        providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex] = whitelistExpiration;
+        emit RequesterWhitelistExpirationSet(
+            providerId,
+            requesterIndex,
+            whitelistExpiration
+            );
+    }
+
+    /// @notice Verifies the authorization status of a request
+    /// @dev This method has redundant arguments because all authorizer
+    /// contracts have to have the same interface and potential authorizer
+    /// contracts may require to access the arguments that are redundant here.
+    /// Note that we are also validating that the `designatedWallet` balance is
+    /// not `0`. The ideal condition to check would be if `designatedWallet`
+    /// has enough funds to fulfill the request. However, that is not a
+    /// condition that can be checked deterministically.
+    /// @param requestId Request ID
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param endpointId Endpoint ID
+    /// @param requesterIndex Requester index from `RequesterStore.sol`
+    /// @param designatedWallet Designated wallet
+    /// @param clientAddress Client address
+    /// @return status Authorization status of the request
+    function checkIfAuthorized(
+        bytes32 requestId,        // solhint-disable-line no-unused-vars
+        bytes32 providerId,
+        bytes32 endpointId,       // solhint-disable-line no-unused-vars
+        uint256 requesterIndex,
+        address designatedWallet,
+        address clientAddress
+        )
+        external
+        view
+        override
+        returns (bool status)
+    {
+        return designatedWallet.balance != 0
+            // solhint-disable-next-line not-rely-on-time
+            && (providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress] > now
+            // solhint-disable-next-line not-rely-on-time
+            || providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex] > now);
+    }
+}

--- a/packages/protocol/contracts/authorizers/SelfAuthorizer.sol
+++ b/packages/protocol/contracts/authorizers/SelfAuthorizer.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "../interfaces/IAirnode.sol";
+import "./interfaces/ISelfAuthorizer.sol";
+
+/// @title Authorizer contract where each provider is their own admin
+/// @notice This contract is for when the provider admin will manage access
+/// personally. The provider admin can also appoint admins (either wallets or
+/// contracts) to extend whitelistings up to a limited length. The admins
+/// cannot revoke whitelistings, but the provider admin can.
+contract SelfAuthorizer is ISelfAuthorizer {
+    struct Admin {
+        bool status;
+        uint256 maxWhitelistExtension;
+        }
+
+    IAirnode public airnode;
+    uint256 public immutable authorizerType = 2;
+    mapping(bytes32 => mapping(address => Admin)) public providerIdToAdmins;
+    mapping(bytes32 => mapping(address => uint256)) public providerIdToClientAddressToWhitelistExpiration;
+    mapping(bytes32 => mapping(uint256 => uint256)) public providerIdToRequesterIndexToWhitelistExpiration;
+
+    /// @dev Reverts if the caller is not the provider admin
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    modifier onlyProviderAdmin(bytes32 providerId)
+    {
+        (address providerAdmin, ) = airnode.getProvider(providerId);
+        require(
+            msg.sender == providerAdmin,
+            "Caller is not provider admin"
+            );
+        _;
+    }
+
+    /// @dev Reverts if the caller is not an admin
+    modifier onlyAdmin(bytes32 providerId)
+    {
+        require(
+            providerIdToAdmins[providerId][msg.sender].status,
+            "Caller is not an admin"
+            );
+        _;
+    }
+
+    /// @dev Reverts if `whitelistExpiration` is not in the future or is too
+    /// far in the future
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param whitelistExpiration Timestamp at which the whitelisting will
+    /// expire
+    modifier onlyValidExpiration(
+        bytes32 providerId,
+        uint256 whitelistExpiration
+        )
+    {
+        require(
+            // solhint-disable-next-line not-rely-on-time
+            whitelistExpiration >= now,
+            "Expiration is in past"
+            );
+        require(
+            // solhint-disable-next-line not-rely-on-time
+            whitelistExpiration <= now + providerIdToAdmins[providerId][msg.sender].maxWhitelistExtension,
+            "Expiration exceeds admin limit"
+            );
+        _;
+    }
+
+    /// @param _airnode Airnode contract address
+    constructor (address _airnode)
+        public
+    {
+        airnode = IAirnode(_airnode);
+    }
+
+    /// @notice Called by the provider admin to set the adminship parameters
+    /// of an address
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param adminAddress Address whose adminship parameters will be set
+    /// @param status Adminship status
+    /// @param maxWhitelistExtension Amount that the respective admin can
+    /// extend the whitelistings for
+    function setAdminParameters(
+        bytes32 providerId,
+        address adminAddress,
+        bool status,
+        uint256 maxWhitelistExtension
+        )
+        external
+        override
+        onlyProviderAdmin(providerId)
+    {
+        providerIdToAdmins[providerId][adminAddress] = Admin(
+            status,
+            maxWhitelistExtension
+            );
+        emit AdminParametersSet(
+            providerId,
+            adminAddress,
+            status,
+            maxWhitelistExtension
+            );
+    }
+
+    /// @notice Called by the admin to renounce their adminship
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    function renounceAdminship(bytes32 providerId)
+        external
+        override
+        onlyAdmin(providerId)
+    {
+        providerIdToAdmins[providerId][msg.sender].status = false;
+        emit AdminshipRenounced(
+            providerId,
+            msg.sender
+            );
+    }
+
+    /// @notice Called by the admin to extend the whitelisting of a client
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param clientAddress Client address
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// client will expire
+    function extendClientWhitelisting(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyAdmin(providerId)
+        onlyValidExpiration(
+            providerId,
+            whitelistExpiration
+            )
+    {
+        require(
+            whitelistExpiration > providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress],
+            "Expiration does not extend"
+            );
+        providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress] = whitelistExpiration;
+        emit ClientWhitelistingExtended(
+            providerId,
+            clientAddress,
+            whitelistExpiration,
+            msg.sender
+            );
+    }
+
+    /// @notice Called by the admin to extend the whitelisting of a requester
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param requesterIndex Requester index from `RequesterStore.sol`
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// requester will expire
+    function extendRequesterWhitelisting(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyAdmin(providerId)
+        onlyValidExpiration(
+            providerId,
+            whitelistExpiration
+            )
+    {
+        require(
+            whitelistExpiration > providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex],
+            "Expiration does not extend"
+            );
+        providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex] = whitelistExpiration;
+        emit RequesterWhitelistingExtended(
+            providerId,
+            requesterIndex,
+            whitelistExpiration,
+            msg.sender
+            );
+    }
+
+    /// @notice Called by the provider admin to set the whitelisting expiration
+    /// time of the client
+    /// @dev Note that the provider admin can use this method to set the
+    /// client's `whitelistExpiration` to `0`, effectively blacklisting them
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param clientAddress Client address
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// client will expire
+    function setClientWhitelistExpiration(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyProviderAdmin(providerId)
+    {
+        providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress] = whitelistExpiration;
+        emit ClientWhitelistExpirationSet(
+            providerId,
+            clientAddress,
+            whitelistExpiration
+            );
+    }
+
+    /// @notice Called by the provider admin to set the whitelisting expiration
+    /// time of the requester
+    /// @dev Note that the provider admin can use this method to set the
+    /// requester's `whitelistExpiration` to `0`, effectively blacklisting them
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param requesterIndex Requester index from `RequesterStore.sol`
+    /// @param whitelistExpiration Timestamp at which the whitelisting of the
+    /// requester will expire
+    function setRequesterWhitelistExpiration(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external
+        override
+        onlyProviderAdmin(providerId)
+    {
+        providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex] = whitelistExpiration;
+        emit RequesterWhitelistExpirationSet(
+            providerId,
+            requesterIndex,
+            whitelistExpiration
+            );
+    }
+
+    /// @notice Verifies the authorization status of a request
+    /// @dev This method has redundant arguments because all authorizer
+    /// contracts have to have the same interface and potential authorizer
+    /// contracts may require to access the arguments that are redundant here.
+    /// Note that we are also validating that the `designatedWallet` balance is
+    /// not `0`. The ideal condition to check would be if the
+    /// `designatedWallet` has enough funds to fulfill the request. However,
+    /// that is not a condition that can be checked deterministically.
+    /// @param requestId Request ID
+    /// @param providerId Provider ID from `ProviderStore.sol`
+    /// @param endpointId Endpoint ID
+    /// @param requesterIndex Requester index from `RequesterStore.sol`
+    /// @param designatedWallet Designated wallet
+    /// @param clientAddress Client address
+    /// @return status Authorization status of the request
+    function checkIfAuthorized(
+        bytes32 requestId,        // solhint-disable-line no-unused-vars
+        bytes32 providerId,
+        bytes32 endpointId,       // solhint-disable-line no-unused-vars
+        uint256 requesterIndex,
+        address designatedWallet,
+        address clientAddress
+        )
+        external
+        view
+        override
+        returns (bool status)
+    {
+        return designatedWallet.balance != 0
+            // solhint-disable-next-line not-rely-on-time
+            && (providerIdToClientAddressToWhitelistExpiration[providerId][clientAddress] > now
+            // solhint-disable-next-line not-rely-on-time
+            || providerIdToRequesterIndexToWhitelistExpiration[providerId][requesterIndex] > now);
+    }
+}

--- a/packages/protocol/contracts/authorizers/interfaces/IMasterAuthorizer.sol
+++ b/packages/protocol/contracts/authorizers/interfaces/IMasterAuthorizer.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "./IAuthorizer.sol";
+
+interface IMasterAuthorizer is IAuthorizer {
+    event MasterAdminshipTransferred(
+        address previousMasterAdmin,
+        address newMasterAdmin
+        );
+    event AdminParametersSet(
+        address indexed adminAddress,
+        bool status,
+        uint256 maxWhitelistExtension
+        );
+    event AdminshipRenounced(address indexed adminAddress);
+    event ClientWhitelistingExtended(
+        bytes32 indexed providerId,
+        address indexed clientAddress,
+        uint256 whitelistExpiration,
+        address indexed adminAddress
+        );
+    event RequesterWhitelistingExtended(
+        bytes32 indexed providerId,
+        uint256 indexed requesterIndex,
+        uint256 whitelistExpiration,
+        address indexed adminAddress
+        );
+    event ClientWhitelistExpirationSet(
+        bytes32 indexed providerId,
+        address indexed clientAddress,
+        uint256 whitelistExpiration
+        );
+    event RequesterWhitelistExpirationSet(
+        bytes32 indexed providerId,
+        uint256 indexed requesterIndex,
+        uint256 whitelistExpiration
+        );
+
+    function transferMasterAdminship(address _masterAdmin)
+        external;
+
+    function setAdminParameters(
+        address adminAddress,
+        bool status,
+        uint256 maxWhitelistExtension
+        )
+        external;
+
+    function renounceAdminship()
+        external;
+
+    function extendClientWhitelisting(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external;
+
+    function extendRequesterWhitelisting(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external;
+
+    function setClientWhitelistExpiration(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external;
+
+    function setRequesterWhitelistExpiration(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external;
+}

--- a/packages/protocol/contracts/authorizers/interfaces/ISelfAuthorizer.sol
+++ b/packages/protocol/contracts/authorizers/interfaces/ISelfAuthorizer.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "./IAuthorizer.sol";
+
+interface ISelfAuthorizer is IAuthorizer {
+    event AdminParametersSet(
+        bytes32 indexed providerId,
+        address indexed adminAddress,
+        bool status,
+        uint256 maxWhitelistExtension
+        );
+    event AdminshipRenounced(
+        bytes32 indexed providerId,
+        address indexed adminAddress
+        );
+    event ClientWhitelistingExtended(
+        bytes32 indexed providerId,
+        address indexed clientAddress,
+        uint256 whitelistExpiration,
+        address indexed adminAddress
+        );
+    event RequesterWhitelistingExtended(
+        bytes32 indexed providerId,
+        uint256 indexed requesterIndex,
+        uint256 whitelistExpiration,
+        address indexed adminAddress
+        );
+    event ClientWhitelistExpirationSet(
+        bytes32 indexed providerId,
+        address indexed clientAddress,
+        uint256 whitelistExpiration
+        );
+    event RequesterWhitelistExpirationSet(
+        bytes32 indexed providerId,
+        uint256 indexed requesterIndex,
+        uint256 whitelistExpiration
+        );
+
+    function setAdminParameters(
+        bytes32 providerId,
+        address adminAddress,
+        bool status,
+        uint256 maxWhitelistExtension
+        )
+        external;
+
+    function renounceAdminship(bytes32 providerId)
+        external;
+
+    function extendClientWhitelisting(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external;
+
+    function extendRequesterWhitelisting(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external;
+
+    function setClientWhitelistExpiration(
+        bytes32 providerId,
+        address clientAddress,
+        uint256 whitelistExpiration
+        )
+        external;
+
+    function setRequesterWhitelistExpiration(
+        bytes32 providerId,
+        uint256 requesterIndex,
+        uint256 whitelistExpiration
+        )
+        external;
+}

--- a/packages/protocol/test/authorizers/MasterAuthorizer.sol.js
+++ b/packages/protocol/test/authorizers/MasterAuthorizer.sol.js
@@ -1,0 +1,457 @@
+const { expect } = require('chai');
+
+let roles;
+let masterAuthorizer;
+const providerId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+const requesterIndex = 123;
+const adminMaxWhitelistExtension = 100;
+const requestId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+const endpointId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+
+beforeEach(async () => {
+  const accounts = await ethers.getSigners();
+  roles = {
+    deployer: accounts[0],
+    masterAdmin: accounts[1],
+    newMasterAdmin: accounts[2],
+    admin: accounts[3],
+    client: accounts[4],
+    randomPerson: accounts[9],
+  };
+  const masterAuthorizerFactory = await ethers.getContractFactory('MasterAuthorizer', roles.deployer);
+  masterAuthorizer = await masterAuthorizerFactory.deploy(roles.masterAdmin.address);
+});
+
+describe('constructor', function () {
+  it('initializes correctly', async function () {
+    expect(await masterAuthorizer.authorizerType()).to.equal(1);
+    expect(await masterAuthorizer.masterAdmin()).to.equal(roles.masterAdmin.address);
+  });
+});
+
+describe('transferMasterAdminship', function () {
+  context('Caller is the master admin', async function () {
+    context('Address to be transferred to is non-zero', async function () {
+      context('Address to be transferred to is different', async function () {
+        it('transfers master adminship', async function () {
+          await expect(
+            masterAuthorizer.connect(roles.masterAdmin).transferMasterAdminship(roles.newMasterAdmin.address)
+          )
+            .to.emit(masterAuthorizer, 'MasterAdminshipTransferred')
+            .withArgs(roles.masterAdmin.address, roles.newMasterAdmin.address);
+        });
+      });
+      context('Address to be transferred to is the same', async function () {
+        it('reverts', async function () {
+          await expect(
+            masterAuthorizer.connect(roles.masterAdmin).transferMasterAdminship(roles.masterAdmin.address)
+          ).to.be.revertedWith('Input will not update state');
+        });
+      });
+    });
+    context('Address to be transferred to is zero', async function () {
+      it('reverts', async function () {
+        await expect(
+          masterAuthorizer.connect(roles.masterAdmin).transferMasterAdminship(ethers.constants.AddressZero)
+        ).to.be.revertedWith('Used zero address');
+      });
+    });
+  });
+  context('Caller is not the master admin', async function () {
+    it('reverts', async function () {
+      await expect(
+        masterAuthorizer.connect(roles.randomPerson).transferMasterAdminship(roles.newMasterAdmin.address)
+      ).to.be.revertedWith('Caller is not master admin');
+    });
+  });
+});
+
+describe('setAdminParameters', function () {
+  context('Caller is the master admin', async function () {
+    it('sets admin parameters', async function () {
+      // Give adminship
+      await expect(
+        masterAuthorizer
+          .connect(roles.masterAdmin)
+          .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension)
+      )
+        .to.emit(masterAuthorizer, 'AdminParametersSet')
+        .withArgs(roles.admin.address, true, adminMaxWhitelistExtension);
+      expect((await masterAuthorizer.admins(roles.admin.address)).status).to.equal(true);
+      expect((await masterAuthorizer.admins(roles.admin.address)).maxWhitelistExtension).to.equal(
+        adminMaxWhitelistExtension
+      );
+      // Revoke adminship
+      await expect(
+        masterAuthorizer
+          .connect(roles.masterAdmin)
+          .setAdminParameters(roles.admin.address, false, adminMaxWhitelistExtension * 2)
+      )
+        .to.emit(masterAuthorizer, 'AdminParametersSet')
+        .withArgs(roles.admin.address, false, adminMaxWhitelistExtension * 2);
+      expect((await masterAuthorizer.admins(roles.admin.address)).status).to.equal(false);
+      expect((await masterAuthorizer.admins(roles.admin.address)).maxWhitelistExtension).to.equal(
+        adminMaxWhitelistExtension * 2
+      );
+    });
+  });
+  context('Caller is not the master admin', async function () {
+    it('reverts', async function () {
+      await expect(
+        masterAuthorizer
+          .connect(roles.randomPerson)
+          .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension)
+      ).to.be.revertedWith('Caller is not master admin');
+    });
+  });
+});
+
+describe('renounceAdminship', function () {
+  context('Caller is an admin', async function () {
+    it('renounces adminship', async function () {
+      await masterAuthorizer
+        .connect(roles.masterAdmin)
+        .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+      await expect(masterAuthorizer.connect(roles.admin).renounceAdminship())
+        .to.emit(masterAuthorizer, 'AdminshipRenounced')
+        .withArgs(roles.admin.address);
+    });
+  });
+  context('Caller is not an admin', async function () {
+    it('revert', async function () {
+      await expect(masterAuthorizer.connect(roles.randomPerson).renounceAdminship()).to.be.revertedWith(
+        'Caller is not an admin'
+      );
+    });
+  });
+});
+
+describe('extendClientWhitelisting', function () {
+  context('Caller is an admin', async function () {
+    context('Expiration is not in past', async function () {
+      context('Expiration does not exceed admin limit', async function () {
+        context('Expiration does extend whitelisting', async function () {
+          it('extends client whitelisting', async function () {
+            await masterAuthorizer
+              .connect(roles.masterAdmin)
+              .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await expect(
+              masterAuthorizer
+                .connect(roles.admin)
+                .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2)
+            )
+              .to.emit(masterAuthorizer, 'ClientWhitelistingExtended')
+              .withArgs(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2, roles.admin.address);
+            expect(
+              await masterAuthorizer.providerIdToClientAddressToWhitelistExpiration(providerId, roles.client.address)
+            ).to.equal(now + adminMaxWhitelistExtension / 2);
+          });
+        });
+        context('Expiration does not extend whitelisting', async function () {
+          it('reverts', async function () {
+            await masterAuthorizer
+              .connect(roles.masterAdmin)
+              .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await masterAuthorizer
+              .connect(roles.admin)
+              .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2);
+            await expect(
+              masterAuthorizer
+                .connect(roles.admin)
+                .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2)
+            ).to.be.revertedWith('Expiration does not extend');
+          });
+        });
+      });
+      context('Expiration exceed admin limit', async function () {
+        it('reverts', async function () {
+          await masterAuthorizer
+            .connect(roles.masterAdmin)
+            .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await expect(
+            masterAuthorizer
+              .connect(roles.admin)
+              .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2)
+          ).to.be.revertedWith('Expiration exceeds admin limit');
+        });
+      });
+    });
+    context('Expiration is in past', async function () {
+      it('reverts', async function () {
+        await masterAuthorizer
+          .connect(roles.masterAdmin)
+          .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+        const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+        await expect(
+          masterAuthorizer
+            .connect(roles.admin)
+            .extendClientWhitelisting(providerId, roles.client.address, now - adminMaxWhitelistExtension)
+        ).to.be.revertedWith('Expiration is in past');
+      });
+    });
+  });
+  context('Caller is not an admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        masterAuthorizer
+          .connect(roles.admin)
+          .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2)
+      ).to.be.revertedWith('Caller is not an admin');
+    });
+  });
+});
+
+describe('extendRequesterWhitelisting', function () {
+  context('Caller is an admin', async function () {
+    context('Expiration is not in past', async function () {
+      context('Expiration does not exceed admin limit', async function () {
+        context('Expiration does extend whitelisting', async function () {
+          it('extends requester whitelisting', async function () {
+            await masterAuthorizer
+              .connect(roles.masterAdmin)
+              .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await expect(
+              masterAuthorizer
+                .connect(roles.admin)
+                .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2)
+            )
+              .to.emit(masterAuthorizer, 'RequesterWhitelistingExtended')
+              .withArgs(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2, roles.admin.address);
+            expect(
+              await masterAuthorizer.providerIdToRequesterIndexToWhitelistExpiration(providerId, requesterIndex)
+            ).to.equal(now + adminMaxWhitelistExtension / 2);
+          });
+        });
+        context('Expiration does not extend whitelisting', async function () {
+          it('reverts', async function () {
+            await masterAuthorizer
+              .connect(roles.masterAdmin)
+              .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await masterAuthorizer
+              .connect(roles.admin)
+              .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2);
+            await expect(
+              masterAuthorizer
+                .connect(roles.admin)
+                .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2)
+            ).to.be.revertedWith('Expiration does not extend');
+          });
+        });
+      });
+      context('Expiration exceed admin limit', async function () {
+        it('reverts', async function () {
+          await masterAuthorizer
+            .connect(roles.masterAdmin)
+            .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await expect(
+            masterAuthorizer
+              .connect(roles.admin)
+              .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2)
+          ).to.be.revertedWith('Expiration exceeds admin limit');
+        });
+      });
+    });
+    context('Expiration is in past', async function () {
+      it('reverts', async function () {
+        await masterAuthorizer
+          .connect(roles.masterAdmin)
+          .setAdminParameters(roles.admin.address, true, adminMaxWhitelistExtension);
+        const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+        await expect(
+          masterAuthorizer
+            .connect(roles.admin)
+            .extendRequesterWhitelisting(providerId, requesterIndex, now - adminMaxWhitelistExtension)
+        ).to.be.revertedWith('Expiration is in past');
+      });
+    });
+  });
+  context('Caller is not an admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        masterAuthorizer
+          .connect(roles.admin)
+          .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2)
+      ).to.be.revertedWith('Caller is not an admin');
+    });
+  });
+});
+
+describe('setClientWhitelistExpiration', function () {
+  context('Caller is the master admin', async function () {
+    it('sets client whitelist expiration', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        masterAuthorizer
+          .connect(roles.masterAdmin)
+          .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2)
+      )
+        .to.emit(masterAuthorizer, 'ClientWhitelistExpirationSet')
+        .withArgs(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+    });
+  });
+  context('Caller is not the master admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        masterAuthorizer
+          .connect(roles.randomPerson)
+          .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2)
+      ).to.be.revertedWith('Caller is not master admin');
+    });
+  });
+});
+
+describe('setRequesterWhitelistExpiration', function () {
+  context('Caller is the master admin', async function () {
+    it('sets requester whitelist expiration', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        masterAuthorizer
+          .connect(roles.masterAdmin)
+          .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2)
+      )
+        .to.emit(masterAuthorizer, 'RequesterWhitelistExpirationSet')
+        .withArgs(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+    });
+  });
+  context('Caller is not the master admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        masterAuthorizer
+          .connect(roles.randomPerson)
+          .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2)
+      ).to.be.revertedWith('Caller is not master admin');
+    });
+  });
+});
+
+describe('checkIfAuthorized', function () {
+  context('Designated wallet balance is not zero', async function () {
+    context('Client is whitelisted', async function () {
+      context('Requester is whitelisted', async function () {
+        it('returns true', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await masterAuthorizer
+            .connect(roles.masterAdmin)
+            .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+          await masterAuthorizer
+            .connect(roles.masterAdmin)
+            .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+          expect(
+            await masterAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted', async function () {
+        it('returns true', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await masterAuthorizer
+            .connect(roles.masterAdmin)
+            .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+          expect(
+            await masterAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(true);
+        });
+      });
+    });
+    context('Client is not whitelisted', async function () {
+      context('Requester is whitelisted', async function () {
+        it('returns true', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await masterAuthorizer
+            .connect(roles.masterAdmin)
+            .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+          expect(
+            await masterAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted', async function () {
+        it('returns false', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          expect(
+            await masterAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(false);
+        });
+      });
+    });
+  });
+  context('Designated wallet balance is zero', async function () {
+    it('returns false', async function () {
+      const designatedWallet = ethers.Wallet.createRandom();
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await masterAuthorizer
+        .connect(roles.masterAdmin)
+        .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+      await masterAuthorizer
+        .connect(roles.masterAdmin)
+        .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+      expect(
+        await masterAuthorizer.checkIfAuthorized(
+          requestId,
+          providerId,
+          endpointId,
+          requesterIndex,
+          designatedWallet.address,
+          roles.client.address
+        )
+      ).to.equal(false);
+    });
+  });
+});

--- a/packages/protocol/test/authorizers/SelfAuthorizer.sol.js
+++ b/packages/protocol/test/authorizers/SelfAuthorizer.sol.js
@@ -1,0 +1,427 @@
+const { expect } = require('chai');
+
+let roles;
+let selfAuthorizer;
+let airnode;
+let providerId;
+const requesterIndex = 123;
+const adminMaxWhitelistExtension = 100;
+const requestId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+const endpointId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+
+beforeEach(async () => {
+  const accounts = await ethers.getSigners();
+  roles = {
+    deployer: accounts[0],
+    providerMasterWallet: accounts[1],
+    providerAdmin: accounts[2],
+    admin: accounts[3],
+    client: accounts[4],
+    randomPerson: accounts[9],
+  };
+  const airnodeFactory = await ethers.getContractFactory('Airnode', roles.deployer);
+  airnode = await airnodeFactory.deploy();
+  const selfAuthorizerFactory = await ethers.getContractFactory('SelfAuthorizer', roles.deployer);
+  selfAuthorizer = await selfAuthorizerFactory.deploy(airnode.address);
+  providerId = await airnode
+    .connect(roles.providerMasterWallet)
+    .callStatic.createProvider(roles.providerAdmin.address, 'xpub...');
+  await airnode.connect(roles.providerMasterWallet).createProvider(roles.providerAdmin.address, 'xpub...');
+});
+
+describe('constructor', function () {
+  it('initializes correctly', async function () {
+    expect(await selfAuthorizer.authorizerType()).to.equal(2);
+    expect(await selfAuthorizer.airnode()).to.equal(airnode.address);
+  });
+});
+
+describe('setAdminParameters', function () {
+  context('Caller is the provider admin', async function () {
+    it('sets admin parameters', async function () {
+      // Give adminship
+      await expect(
+        selfAuthorizer
+          .connect(roles.providerAdmin)
+          .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension)
+      )
+        .to.emit(selfAuthorizer, 'AdminParametersSet')
+        .withArgs(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+      expect((await selfAuthorizer.providerIdToAdmins(providerId, roles.admin.address)).status).to.equal(true);
+      expect((await selfAuthorizer.providerIdToAdmins(providerId, roles.admin.address)).maxWhitelistExtension).to.equal(
+        adminMaxWhitelistExtension
+      );
+      // Revoke adminship
+      await expect(
+        selfAuthorizer
+          .connect(roles.providerAdmin)
+          .setAdminParameters(providerId, roles.admin.address, false, adminMaxWhitelistExtension * 2)
+      )
+        .to.emit(selfAuthorizer, 'AdminParametersSet')
+        .withArgs(providerId, roles.admin.address, false, adminMaxWhitelistExtension * 2);
+      expect((await selfAuthorizer.providerIdToAdmins(providerId, roles.admin.address)).status).to.equal(false);
+      expect((await selfAuthorizer.providerIdToAdmins(providerId, roles.admin.address)).maxWhitelistExtension).to.equal(
+        adminMaxWhitelistExtension * 2
+      );
+    });
+  });
+  context('Caller is not the provider admin', async function () {
+    it('reverts', async function () {
+      await expect(
+        selfAuthorizer
+          .connect(roles.randomPerson)
+          .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension)
+      ).to.be.revertedWith('Caller is not provider admin');
+    });
+  });
+});
+
+describe('renounceAdminship', function () {
+  context('Caller is an admin', async function () {
+    it('renounces adminship', async function () {
+      await selfAuthorizer
+        .connect(roles.providerAdmin)
+        .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+      await expect(selfAuthorizer.connect(roles.admin).renounceAdminship(providerId))
+        .to.emit(selfAuthorizer, 'AdminshipRenounced')
+        .withArgs(providerId, roles.admin.address);
+    });
+  });
+  context('Caller is not an admin', async function () {
+    it('revert', async function () {
+      await expect(selfAuthorizer.connect(roles.randomPerson).renounceAdminship(providerId)).to.be.revertedWith(
+        'Caller is not an admin'
+      );
+    });
+  });
+});
+
+describe('extendClientWhitelisting', function () {
+  context('Caller is an admin', async function () {
+    context('Expiration is not in past', async function () {
+      context('Expiration does not exceed admin limit', async function () {
+        context('Expiration does extend whitelisting', async function () {
+          it('extends client whitelisting', async function () {
+            await selfAuthorizer
+              .connect(roles.providerAdmin)
+              .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await expect(
+              selfAuthorizer
+                .connect(roles.admin)
+                .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2)
+            )
+              .to.emit(selfAuthorizer, 'ClientWhitelistingExtended')
+              .withArgs(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2, roles.admin.address);
+            expect(
+              await selfAuthorizer.providerIdToClientAddressToWhitelistExpiration(providerId, roles.client.address)
+            ).to.equal(now + adminMaxWhitelistExtension / 2);
+          });
+        });
+        context('Expiration does not extend whitelisting', async function () {
+          it('reverts', async function () {
+            await selfAuthorizer
+              .connect(roles.providerAdmin)
+              .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await selfAuthorizer
+              .connect(roles.admin)
+              .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2);
+            await expect(
+              selfAuthorizer
+                .connect(roles.admin)
+                .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2)
+            ).to.be.revertedWith('Expiration does not extend');
+          });
+        });
+      });
+      context('Expiration exceed admin limit', async function () {
+        it('reverts', async function () {
+          await selfAuthorizer
+            .connect(roles.providerAdmin)
+            .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await expect(
+            selfAuthorizer
+              .connect(roles.admin)
+              .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2)
+          ).to.be.revertedWith('Expiration exceeds admin limit');
+        });
+      });
+    });
+    context('Expiration is in past', async function () {
+      it('reverts', async function () {
+        await selfAuthorizer
+          .connect(roles.providerAdmin)
+          .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+        const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+        await expect(
+          selfAuthorizer
+            .connect(roles.admin)
+            .extendClientWhitelisting(providerId, roles.client.address, now - adminMaxWhitelistExtension)
+        ).to.be.revertedWith('Expiration is in past');
+      });
+    });
+  });
+  context('Caller is not an admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfAuthorizer
+          .connect(roles.admin)
+          .extendClientWhitelisting(providerId, roles.client.address, now + adminMaxWhitelistExtension / 2)
+      ).to.be.revertedWith('Caller is not an admin');
+    });
+  });
+});
+
+describe('extendRequesterWhitelisting', function () {
+  context('Caller is an admin', async function () {
+    context('Expiration is not in past', async function () {
+      context('Expiration does not exceed admin limit', async function () {
+        context('Expiration does extend whitelisting', async function () {
+          it('extends requester whitelisting', async function () {
+            await selfAuthorizer
+              .connect(roles.providerAdmin)
+              .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await expect(
+              selfAuthorizer
+                .connect(roles.admin)
+                .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2)
+            )
+              .to.emit(selfAuthorizer, 'RequesterWhitelistingExtended')
+              .withArgs(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2, roles.admin.address);
+            expect(
+              await selfAuthorizer.providerIdToRequesterIndexToWhitelistExpiration(providerId, requesterIndex)
+            ).to.equal(now + adminMaxWhitelistExtension / 2);
+          });
+        });
+        context('Expiration does not extend whitelisting', async function () {
+          it('reverts', async function () {
+            await selfAuthorizer
+              .connect(roles.providerAdmin)
+              .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+            const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+            await selfAuthorizer
+              .connect(roles.admin)
+              .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2);
+            await expect(
+              selfAuthorizer
+                .connect(roles.admin)
+                .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2)
+            ).to.be.revertedWith('Expiration does not extend');
+          });
+        });
+      });
+      context('Expiration exceed admin limit', async function () {
+        it('reverts', async function () {
+          await selfAuthorizer
+            .connect(roles.providerAdmin)
+            .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await expect(
+            selfAuthorizer
+              .connect(roles.admin)
+              .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2)
+          ).to.be.revertedWith('Expiration exceeds admin limit');
+        });
+      });
+    });
+    context('Expiration is in past', async function () {
+      it('reverts', async function () {
+        await selfAuthorizer
+          .connect(roles.providerAdmin)
+          .setAdminParameters(providerId, roles.admin.address, true, adminMaxWhitelistExtension);
+        const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+        await expect(
+          selfAuthorizer
+            .connect(roles.admin)
+            .extendRequesterWhitelisting(providerId, requesterIndex, now - adminMaxWhitelistExtension)
+        ).to.be.revertedWith('Expiration is in past');
+      });
+    });
+  });
+  context('Caller is not an admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfAuthorizer
+          .connect(roles.admin)
+          .extendRequesterWhitelisting(providerId, requesterIndex, now + adminMaxWhitelistExtension / 2)
+      ).to.be.revertedWith('Caller is not an admin');
+    });
+  });
+});
+
+describe('setClientWhitelistExpiration', function () {
+  context('Caller is the provider admin', async function () {
+    it('sets client whitelist expiration', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfAuthorizer
+          .connect(roles.providerAdmin)
+          .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2)
+      )
+        .to.emit(selfAuthorizer, 'ClientWhitelistExpirationSet')
+        .withArgs(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+    });
+  });
+  context('Caller is not the provider admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfAuthorizer
+          .connect(roles.randomPerson)
+          .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2)
+      ).to.be.revertedWith('Caller is not provider admin');
+    });
+  });
+});
+
+describe('setRequesterWhitelistExpiration', function () {
+  context('Caller is the provider admin', async function () {
+    it('sets requester whitelist expiration', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfAuthorizer
+          .connect(roles.providerAdmin)
+          .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2)
+      )
+        .to.emit(selfAuthorizer, 'RequesterWhitelistExpirationSet')
+        .withArgs(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+    });
+  });
+  context('Caller is not the provider admin', async function () {
+    it('reverts', async function () {
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfAuthorizer
+          .connect(roles.randomPerson)
+          .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2)
+      ).to.be.revertedWith('Caller is not provider admin');
+    });
+  });
+});
+
+describe('checkIfAuthorized', function () {
+  context('Designated wallet balance is not zero', async function () {
+    context('Client is whitelisted', async function () {
+      context('Requester is whitelisted', async function () {
+        it('returns true', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await selfAuthorizer
+            .connect(roles.providerAdmin)
+            .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+          await selfAuthorizer
+            .connect(roles.providerAdmin)
+            .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+          expect(
+            await selfAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted', async function () {
+        it('returns true', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await selfAuthorizer
+            .connect(roles.providerAdmin)
+            .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+          expect(
+            await selfAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(true);
+        });
+      });
+    });
+    context('Client is not whitelisted', async function () {
+      context('Requester is whitelisted', async function () {
+        it('returns true', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+          await selfAuthorizer
+            .connect(roles.providerAdmin)
+            .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+          expect(
+            await selfAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted', async function () {
+        it('returns false', async function () {
+          const designatedWallet = ethers.Wallet.createRandom();
+          await roles.client.sendTransaction({
+            to: designatedWallet.address,
+            value: 1,
+          });
+          expect(
+            await selfAuthorizer.checkIfAuthorized(
+              requestId,
+              providerId,
+              endpointId,
+              requesterIndex,
+              designatedWallet.address,
+              roles.client.address
+            )
+          ).to.equal(false);
+        });
+      });
+    });
+  });
+  context('Designated wallet balance is zero', async function () {
+    it('returns false', async function () {
+      const designatedWallet = ethers.Wallet.createRandom();
+      const now = (await waffle.provider.getBlock(await waffle.provider.getBlockNumber())).timestamp;
+      await selfAuthorizer
+        .connect(roles.providerAdmin)
+        .setClientWhitelistExpiration(providerId, roles.client.address, now + adminMaxWhitelistExtension * 2);
+      await selfAuthorizer
+        .connect(roles.providerAdmin)
+        .setRequesterWhitelistExpiration(providerId, requesterIndex, now + adminMaxWhitelistExtension * 2);
+      expect(
+        await selfAuthorizer.checkIfAuthorized(
+          requestId,
+          providerId,
+          endpointId,
+          requesterIndex,
+          designatedWallet.address,
+          roles.client.address
+        )
+      ).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
`MasterAuthorizer.sol`: Has a master admin (e.g., the API3 DAO) that can appoint admins (e.g., the integrations team multisig). Admins can only extend whitelistings up to an amount determined by the master admin, while the master admin has full control over whitelistings.

`SelfAuthorizer.sol`: Similar to `MasterAuthorizer.sol`, but each provider acts as their own master admin. This allows them to set authorization policies without depending on the API3 DAO (through ChainAPI for example).

Both clients and requesters are allowed to be whitelisted (we're only expecting to whitelist clients). Most providers are expected to use both of these authorizers (`MasterAuthorizer.sol` for API3 and `SelfAuthorizer.sol` for ChainAPI and self-use). A request being authorized by either will mean that the request will be fulfilled.