### PR TITLE
info field is not valid in apiSpecifications

### DIFF
--- a/packages/node/__dev__/config.json.example
+++ b/packages/node/__dev__/config.json.example
@@ -41,9 +41,6 @@
       "version": "1.2.3",
       "title": "currency-converter-ois",
       "apiSpecifications": {
-        "info": {
-          "title": "Currency Converter API"
-        },
         "servers": [
           {
             "url": "http://localhost:5000"


### PR DESCRIPTION
Discussed with @bbenligiray that info field is not valid in apiSpecifications