### PR TITLE
Standardize the .env file used by airnode-client and implements healthcheck

### DIFF
--- a/Docker-client.md
+++ b/Docker-client.md
@@ -22,5 +22,44 @@ Note that `nodeSettings.cloudProvider` should be `local`.
 ```sh
 docker run -it --rm \
     -v $(pwd):/airnode/out \
+    --restart unless-stopped
     api3/airnode-client:pre-alpha
+```
+
+5. The docker image comes with a [healthcheck status](https://docs.docker.com/engine/reference/builder/#healthcheck) that can be used to monitor the health of the `airnode-client`. If the container becomes unhealthy due to any reason, you should view the logs(in case of any errors) and then restart the container. (Note: healthy status of the container does not indicate that there is no error while running the `airnode-client`, it just ensures that the `airnode-client` is being executed every minute and not halting. It is advisable to view the logs to check the actual status).
+
+6. If you want the `airnode-client` to auto-restart incase of unhealthy status then you can run the following [image](https://github.com/willfarrell/docker-autoheal) that checks for unhealthy containers and restarts them.
+
+```
+docker run -d \
+    --name autoheal \
+    --restart=always \
+    -e AUTOHEAL_CONTAINER_LABEL=all \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    willfarrell/autoheal
+```
+
+# Logs
+
+To view the logs you can use the following command 
+
+```
+docker inspect --format "{{json .State.Health }}" <containter_name> | jq
+```
+
+Expected Output
+
+```
+{
+  "Status": "healthy",
+  "FailingStreak": 0,
+  "Log": [
+    {
+      "Start": "2021-03-19T02:40:22.1717628Z",
+      "End": "2021-03-19T02:40:50.9162687Z",
+      "ExitCode": 0,
+      "Output": "yarn run v1.22.5\n$ (cd packages/node && yarn run dev:invoke)\n$ (cd __dev__ && ts-node invoke.ts)\n[2021-03-19 02:40:50.214] INFO Coordinator starting...                                                           Coordinator-ID:a82f50c2736cf3db\n[2021-03-19 02:40:50.788] INFO Fetching current block and provider admin details...                              Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.788] INFO Current block:14                                                                  Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.788] INFO Admin address:0x2886De6bbd66DB353C5Ce2e91359e7C39C962fd7                          Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.788] INFO Provider extended public key:xpub661MyMwAqRbcGeCE1g3KTUVGZsFDE3jMNinRPGCQGQsAp1nwinB9Pi16ihKPJw7qtaaTFuBHbRPeSc6w3AcMjxiHkAPfyp1hqQRbthv4Ryx  Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.816] INFO Pending requests: 0 API call(s), 0 withdrawal(s)                                  Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.830] INFO Initialized EVM provider:evm-local                                                Coordinator-ID:a82f50c2736cf3db\n[2021-03-19 02:40:50.830] INFO Forking to initialize providers complete                                          Coordinator-ID:a82f50c2736cf3db\n[2021-03-19 02:40:50.831] INFO No actionable requests detected. Returning...                                     Coordinator-ID:a82f50c2736cf3db\nDone in 28.21s.\n"
+    },
+  ]
+}
 ```

--- a/Docker-client.md
+++ b/Docker-client.md
@@ -10,7 +10,6 @@ mv Dockerfile Dockerfile-deployer && \
 ```
 
 2. Ensure that your `.env` file looks like [`.env.example`](https://github.com/api3dao/airnode/blob/pre-alpha/packages/node/__dev__/.env.example) and is the current working directory.
-Also, **do not** use quotations around your mnemonic or other variables.
 
 3. Also ensure that [`config.json`](https://github.com/api3dao/airnode/blob/pre-alpha/packages/node/__dev__/config.json.example) is also in the current working directory.
 Note that `nodeSettings.cloudProvider` should be `local`.
@@ -20,46 +19,24 @@ Note that `nodeSettings.cloudProvider` should be `local`.
 *If you are using Windows, use CMD (and not PowerShell), replace `\` with `^` and `$(pwd)` with `%cd%`.*
 
 ```sh
-docker run -it --rm \
+docker run -it --init --rm \
     -v $(pwd):/airnode/out \
-    --restart unless-stopped
     api3/airnode-client:pre-alpha
 ```
 
-5. The docker image comes with a [healthcheck status](https://docs.docker.com/engine/reference/builder/#healthcheck) that can be used to monitor the health of the `airnode-client`. If the container becomes unhealthy due to any reason, you should view the logs(in case of any errors) and then restart the container. (Note: healthy status of the container does not indicate that there is no error while running the `airnode-client`, it just ensures that the `airnode-client` is being executed every minute and not halting. It is advisable to view the logs to check the actual status).
+## HealthCheck
 
-6. If you want the `airnode-client` to auto-restart incase of unhealthy status then you can run the following [image](https://github.com/willfarrell/docker-autoheal) that checks for unhealthy containers and restarts them.
+The docker image comes with a [healthcheck status](https://docs.docker.com/engine/reference/builder/#healthcheck) that can be used to monitor the health of the `airnode-client`. If the container becomes unhealthy due to any reason, you should view the logs(in case of any errors) and then restart the container.
 
-```
-docker run -d \
-    --name autoheal \
-    --restart=always \
-    -e AUTOHEAL_CONTAINER_LABEL=all \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    willfarrell/autoheal
-```
+## Developement
 
-# Logs
-
-To view the logs you can use the following command 
+If you're using `airnode-client` with a local hardhat node running on port 8545, please specify the `chains.providers` as 
 
 ```
-docker inspect --format "{{json .State.Health }}" <containter_name> | jq
-```
-
-Expected Output
-
-```
-{
-  "Status": "healthy",
-  "FailingStreak": 0,
-  "Log": [
-    {
-      "Start": "2021-03-19T02:40:22.1717628Z",
-      "End": "2021-03-19T02:40:50.9162687Z",
-      "ExitCode": 0,
-      "Output": "yarn run v1.22.5\n$ (cd packages/node && yarn run dev:invoke)\n$ (cd __dev__ && ts-node invoke.ts)\n[2021-03-19 02:40:50.214] INFO Coordinator starting...                                                           Coordinator-ID:a82f50c2736cf3db\n[2021-03-19 02:40:50.788] INFO Fetching current block and provider admin details...                              Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.788] INFO Current block:14                                                                  Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.788] INFO Admin address:0x2886De6bbd66DB353C5Ce2e91359e7C39C962fd7                          Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.788] INFO Provider extended public key:xpub661MyMwAqRbcGeCE1g3KTUVGZsFDE3jMNinRPGCQGQsAp1nwinB9Pi16ihKPJw7qtaaTFuBHbRPeSc6w3AcMjxiHkAPfyp1hqQRbthv4Ryx  Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.816] INFO Pending requests: 0 API call(s), 0 withdrawal(s)                                  Coordinator-ID:a82f50c2736cf3db, Provider:evm-local, Chain:EVM, Chain-ID:31337\n[2021-03-19 02:40:50.830] INFO Initialized EVM provider:evm-local                                                Coordinator-ID:a82f50c2736cf3db\n[2021-03-19 02:40:50.830] INFO Forking to initialize providers complete                                          Coordinator-ID:a82f50c2736cf3db\n[2021-03-19 02:40:50.831] INFO No actionable requests detected. Returning...                                     Coordinator-ID:a82f50c2736cf3db\nDone in 28.21s.\n"
-    },
-  ]
-}
+"providers": [
+  {
+    "name": "evm-local",
+    "url": "http://host.docker.internal:8545/"
+  }
+]
 ```

--- a/Docker-client.md
+++ b/Docker-client.md
@@ -21,7 +21,6 @@ Note that `nodeSettings.cloudProvider` should be `local`.
 
 ```sh
 docker run -it --rm \
-    --env-file .env \
     -v $(pwd):/airnode/out \
     api3/airnode-client:pre-alpha
 ```

--- a/Dockerfile-client
+++ b/Dockerfile-client
@@ -18,4 +18,5 @@ RUN echo '*/1 * * * * cd /airnode && yarn run dev:invoke' > local-cron
 RUN /usr/bin/crontab /airnode/local-cron 
 
 CMD cp out/config.json /airnode/packages/node/__dev__/config.json | true \
+    && cp out/.env /airnode/packages/node/__dev__/.env | true \
     && /usr/sbin/crond -f -l 8

--- a/Dockerfile-client
+++ b/Dockerfile-client
@@ -14,8 +14,11 @@ RUN yarn add dotenv
 RUN yarn run bootstrap
 RUN yarn run build
 
-RUN echo '*/1 * * * * cd /airnode && yarn run dev:invoke' > local-cron
+RUN echo '*/1 * * * * echo "AirNode Running"' > local-cron
 RUN /usr/bin/crontab /airnode/local-cron 
+
+HEALTHCHECK --interval=1m --timeout=50s --start-period=10s \
+   CMD cd /airnode && yarn run dev:invoke || kill 1
 
 CMD cp out/config.json /airnode/packages/node/__dev__/config.json | true \
     && cp out/.env /airnode/packages/node/__dev__/.env | true \

--- a/Dockerfile-client
+++ b/Dockerfile-client
@@ -3,7 +3,8 @@ FROM node:12.19.0-alpine3.12
 ENV NODE_ENV production
 
 RUN apk update \
-    && apk add git
+    && apk add git \
+    && apk add strace
 
 RUN git clone --single-branch --branch pre-alpha https://github.com/api3dao/airnode.git
 WORKDIR /airnode
@@ -14,11 +15,12 @@ RUN yarn add dotenv
 RUN yarn run bootstrap
 RUN yarn run build
 
-RUN echo '*/1 * * * * echo "AirNode Running"' > local-cron
+RUN echo '*/1 * * * * cd /airnode && yarn run dev:invoke' > local-cron
 RUN /usr/bin/crontab /airnode/local-cron 
 
-HEALTHCHECK --interval=1m --timeout=50s --start-period=10s \
-   CMD cd /airnode && yarn run dev:invoke || kill 1
+HEALTHCHECK --interval=5m --timeout=2m \
+    CMD (strace -p $(pgrep crond) -s9999 -o cronLog.txt) & sleep 70 ; kill $! \
+        && cat cronLog.txt | grep crond > /dev/null; if [ 0 != $? ]; then kill 1; fi && rm cronLog.txt
 
 CMD cp out/config.json /airnode/packages/node/__dev__/config.json | true \
     && cp out/.env /airnode/packages/node/__dev__/.env | true \


### PR DESCRIPTION
Tested it using a config.json and .env in the root directly and it was successfully fulfilling requests.

Closes #228 
and 
Closes #224 