### PR TITLE
Update to Node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.19.0-alpine3.12
+FROM node:14.16.0-alpine3.13
 
 ENV NODE_ENV production
 

--- a/Dockerfile-client
+++ b/Dockerfile-client
@@ -1,4 +1,4 @@
-FROM node:12.19.0-alpine3.12
+FROM node:14.16.0-alpine3.13
 
 ENV NODE_ENV production
 
@@ -15,7 +15,7 @@ RUN yarn run bootstrap
 RUN yarn run build
 
 RUN echo '*/1 * * * * cd /airnode && yarn run dev:invoke' > local-cron
-RUN /usr/bin/crontab /airnode/local-cron 
+RUN /usr/bin/crontab /airnode/local-cron
 
 CMD cp out/config.json /airnode/packages/node/__dev__/config.json | true \
     && /usr/sbin/crond -f -l 8

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "airnode",
   "license": "MIT",
   "engines": {
-    "node": "^12.13.1"
+    "node": "^14.16.0"
   },
   "scripts": {
     "bootstrap": "yarn install && lerna bootstrap",


### PR DESCRIPTION
Closes #222

Using 14.16.0-alpine3.13 rather than 14.16.0-alpine3.12 because 14.16.0-alpine3.12 was giving errors and was not able to run the docker.

No breaking changes in the codebase.

Tested:
- Building and running all the repo tests.
- Running dev:invoke locally
- Running dockerfile-client (pushed a branch with node14 so the git clone of the docker was getting the new version)

After: 
https://github.com/api3dao/airnode/pull/243 is merged

We should merge pre-alpha into master for having #222 #228 and #224 into master (will create an issue for tracking)