### PR TITLE
Add initial `version` 0.1.0 to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "airnode",
+  "version": "0.1.0",
   "license": "MIT",
   "engines": {
     "node": "^12.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airnode",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "license": "MIT",
   "engines": {
     "node": "^12.13.1"


### PR DESCRIPTION
Can't install without a valid "version" in `package.json`

```cli
❯ yarn add https://github.com/api3dao/airnode                                           ─╯
yarn add v1.22.10
[1/5] Validating package.json...
[2/5] Resolving packages...
error Can't add "airnode": invalid package version undefined.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```