### PR TITLE
Fix CI build-test script to make it run on PR against master

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,10 @@
 name: Continuous Build
 
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+    - master
 
 jobs:
   documentation:
@@ -203,4 +207,3 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           type: ${{ job.status }}
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
-


### PR DESCRIPTION
I had a look why https://github.com/api3dao/airnode/pull/271 has passed the CI checks and was able to be merged.

The reason is that @sitch is using forked repo and.
1) He `pushed` the commit in his repo - not triggering any CI, because it is a fork.
2) He opened a PR, but against airnode repo - but CI `build-test` workflow runs only on push.

This will make the workflow execute on PR against master as well.