### PR TITLE
Memoryless aggregator

### DIFF
--- a/packages/protocol/contracts/dapis/aggregators/Aggregator.sol
+++ b/packages/protocol/contracts/dapis/aggregators/Aggregator.sol
@@ -10,7 +10,7 @@ abstract contract Aggregator {
     /// method runs
     /// @param values Values to be aggregated
     function aggregateInplace(int256[] memory values)
-        internal
+        public
         view
         virtual
         returns (int256);

--- a/packages/protocol/contracts/dapis/aggregators/DApi.sol
+++ b/packages/protocol/contracts/dapis/aggregators/DApi.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.2;
+
+/// @title The abstract contract that generalizes dAPI contracts
+abstract contract DApi {
+  // TODO
+}

--- a/packages/protocol/contracts/dapis/aggregators/MemorylessDApi.sol
+++ b/packages/protocol/contracts/dapis/aggregators/MemorylessDApi.sol
@@ -55,7 +55,7 @@ contract MemorylessDApi is DApi, AirnodeRrpClient {
     }
 
     modifier onlyOwner(){
-        require(msg.sender == _owner, 'only the owner can call this function');
+        require(msg.sender == _owner, "only owner can call this function");
         _;
     }
 

--- a/packages/protocol/contracts/dapis/aggregators/MemorylessDApi.sol
+++ b/packages/protocol/contracts/dapis/aggregators/MemorylessDApi.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.2;
+
+import "../../AirnodeRrpClient.sol";
+import "./Median.sol";
+import "./DApi.sol";
+
+/**
+ * @title A sample dAPI/aggregator contract
+ * @dev only owner can trigger request
+ */
+contract MemorylessDApi is DApi, AirnodeRrpClient {
+    Aggregator public aggregator;
+
+    bytes32[] public templateIds;
+    uint256 public requesterIndex;
+    address public designatedWallet;
+    uint128 public minimumResponses;
+
+    int256 public aggregatedAnswer;
+
+    address immutable _owner;
+    address immutable fulfillAddress;
+    bytes4 immutable fulfillFunctionId;
+    mapping (bytes32 => bool) private _pendingRequests;
+    // individual answers from Airnodes are stored in an array
+    int256[] _individualAnswers;
+
+    event NewUpdateRequested(uint256 timestamp);
+    event RequestFulfilled(uint256 requestId);
+    event AggregatedAnswerUpdated(uint256 timestamp, uint256 aggregatedAnswer);
+    
+    constructor
+    (
+        address _airnodeRrpAddress,
+        address _aggregatorAddress,
+        bytes32[] memory _templateIds,
+        uint256 _requesterIndex,
+        address _designatedWallet,
+        uint128 _minimumResponses
+    )
+        AirnodeRrpClient(_airnodeRrpAddress)
+    {
+        aggregator = Aggregator(_aggregatorAddress); 
+
+        _owner = msg.sender;
+        updateRequestData(
+            _templateIds,
+            _requesterIndex,
+            _designatedWallet,
+            _minimumResponses
+        );
+        fulfillAddress = address(this);
+        fulfillFunctionId = bytes4(keccak256("onFulfill(bytes32,uint256,bytes)"));
+    }
+
+    modifier onlyOwner(){
+        require(msg.sender == _owner, 'only the owner can call this function');
+        _;
+    }
+
+    
+
+    /**
+     * @notice Creates a request to each Airnode via the template array.
+     * @dev This call assumes no additional parameters are required. That is,
+     * all necessary parameters for all future requests are in the `Template`
+     * struct referenced by `templateIds`.
+     */
+    function requestUpdatedAnswer()
+    external
+    onlyOwner
+    {
+        bytes32 requestId;
+
+        for (uint i = 0; i < templateIds.length; i++) {
+            requestId = airnodeRrp.makeRequest(
+                templateIds[i],
+                requesterIndex,
+                designatedWallet,
+                fulfillAddress,
+                fulfillFunctionId,
+                "" // no additional parameters passed
+            );
+        }
+        // must empty existing responses since contract is "memoryless"
+        _emptyAnswerArray();
+        emit NewUpdateRequested(block.timestamp);
+    }
+
+    /**
+     * @notice Handles fulfill from Airnode
+     * @dev `statusCode` being zero indicates a successful fulfillment, while
+     * non-zero values indicate error (the meanings of these values are
+     * implementation-dependent).
+     */
+    function onFulfill
+    (
+        bytes32 requestId,
+        uint256 statusCode,
+        bytes calldata data
+    )
+        external
+    {
+        if (statusCode == 0 && _pendingRequests[requestId]) {
+            
+            int256 decodedData = abi.decode(data, (int256));
+            _individualAnswers.push(decodedData);
+
+            delete _pendingRequests[requestId];
+            
+            if (_individualAnswers.length >= minimumResponses) {
+              aggregatedAnswer = aggregator.aggregateInplace(_individualAnswers);
+            }
+        }
+    }
+
+    function updateRequestData
+    (
+        bytes32[] memory _templateIds,
+        uint256 _requesterIndex,
+        address _designatedWallet,
+        uint128 _minimumResponses
+    )
+        public
+        onlyOwner
+    {
+        // TODO: validate
+        templateIds = _templateIds;
+        requesterIndex = _requesterIndex;
+        designatedWallet = _designatedWallet;
+        minimumResponses = _minimumResponses;
+    }
+
+    function _emptyAnswerArray() private
+    {
+        for (uint i=0; i<_individualAnswers.length; i++) {
+            delete _individualAnswers[i];
+        }
+    }
+}
+


### PR DESCRIPTION
After implementing this, I think a "memoryless" aggregator is actually a bad idea lulz. In particular, when you create a new request, you have to delete all existing responses (from the previous request) and ignore any incoming responses that aren't for the current request. Idk, maybe it works in certain contexts.

Questions:
- Do we want to make the aggregator “type” changeable?
- Were you intending to make the dAPI inherit from `Aggregator`? I'm asking since you made the aggregator functions internal. What are the pros/cons of inheritance vs just calling an on-chain aggregator? The latter makes more sense to me, but I'm not an expert on this.
  - This is sorta related to the first question: if it inherits, you can't just 'switch out' aggregation methods, right?
- I just realized that we'll be recomputing the median (if that's the chosen method) multiple times and we would have modified the array (essentially sorting it) the first time. This means aggregation calls after the first should be cheaper *if* I change the default pivot to the middle element and not the first (like it is now) -- just autistic tingz.