### PR TITLE
Simplify tests

### DIFF
--- a/packages/node/src/evm/authorization/authorization-fetching.test.ts
+++ b/packages/node/src/evm/authorization/authorization-fetching.test.ts
@@ -162,7 +162,7 @@ describe('fetchAuthorizationStatus', () => {
     airnodeRrp = new ethers.Contract('address', ['ABI']);
   });
 
-  it('fetches individual authorization statuses if the group cannot be fetched', async () => {
+  it('fetches group authorization status if it can be fetched', async () => {
     checkAuthorizationStatusMock.mockResolvedValueOnce(true);
     const apiCall = fixtures.requests.buildApiCall();
     const [logs, res] = await authorization.fetchAuthorizationStatus(airnodeRrp, airnodeId, apiCall);

--- a/packages/node/src/evm/handlers/initialize-provider.test.ts
+++ b/packages/node/src/evm/handlers/initialize-provider.test.ts
@@ -108,15 +108,6 @@ describe('initializeProvider', () => {
     ]);
   });
 
-  it('does nothing if unable to verify or set Airnode parameters', async () => {
-    const getLogsSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getLogs');
-    getAirnodeParametersAndBlockNumberMock.mockResolvedValueOnce(null);
-    const state = fixtures.buildEVMProviderState();
-    const res = await initializeProvider(state);
-    expect(res).toEqual(null);
-    expect(getLogsSpy).not.toHaveBeenCalled();
-  });
-
   it('does nothing if requests cannot be fetched', async () => {
     getAirnodeParametersAndBlockNumberMock.mockResolvedValueOnce({
       admin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',

--- a/packages/node/src/evm/initialization.test.ts
+++ b/packages/node/src/evm/initialization.test.ts
@@ -18,75 +18,48 @@ import { ethers } from 'ethers';
 import * as wallet from './wallet';
 import * as initialization from './initialization';
 
-describe('airnodeParametersMatch', () => {
-  const options = {
-    airnodeAdmin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
-    authorizers: [ethers.constants.AddressZero],
-    masterHDNode: wallet.getMasterHDNode(),
-  };
+const initializationFunctions = ['airnodeParametersMatch', 'airnodeParametersExistOnchain'] as const;
 
-  const validData = {
-    airnodeAdmin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
-    authorizers: [ethers.constants.AddressZero],
-    blockNumber: 12,
-    xpub:
-      'xpub661MyMwAqRbcGeCE1g3KTUVGZsFDE3jMNinRPGCQGQsAp1nwinB9Pi16ihKPJw7qtaaTFuBHbRPeSc6w3AcMjxiHkAPfyp1hqQRbthv4Ryx',
-  };
+initializationFunctions.forEach((initFunction) => {
+  describe(initFunction, () => {
+    const options = {
+      airnodeAdmin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+      authorizers: [ethers.constants.AddressZero],
+      masterHDNode: wallet.getMasterHDNode(),
+    };
 
-  it('is true if the Airnode onchain parameters match the expected data', () => {
-    const res = initialization.airnodeParametersMatch(options, validData);
-    expect(res).toEqual(true);
-  });
+    const validData = {
+      airnodeAdmin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
+      authorizers: [ethers.constants.AddressZero],
+      blockNumber: 12,
+      xpub:
+        'xpub661MyMwAqRbcGeCE1g3KTUVGZsFDE3jMNinRPGCQGQsAp1nwinB9Pi16ihKPJw7qtaaTFuBHbRPeSc6w3AcMjxiHkAPfyp1hqQRbthv4Ryx',
+    };
 
-  it('is false if the Airnode admin does not exist', () => {
-    const invalidData = { ...validData, airnodeAdmin: '' };
-    const res = initialization.airnodeParametersMatch(options, invalidData);
-    expect(res).toEqual(false);
-  });
+    it('is true if the Airnode onchain parameters match the expected data', () => {
+      const res = initialization[initFunction](options, validData);
+      expect(res).toEqual(true);
+    });
 
-  it('is false if the authorizers do not match', () => {
-    const invalidData = { ...validData, authorizers: ['0xD5659F26A72A8D718d1955C42B3AE418edB001e0'] };
-    const res = initialization.airnodeParametersMatch(options, invalidData);
-    expect(res).toEqual(false);
-  });
-});
+    it('is false if the Airnode admin does not exist', () => {
+      const invalidData = { ...validData, airnodeAdmin: '' };
+      const res = initialization[initFunction](options, invalidData);
+      expect(res).toEqual(false);
+    });
 
-describe('airnodeParametersExistOnchain', () => {
-  const options = {
-    airnodeAdmin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
-    authorizers: [ethers.constants.AddressZero],
-    masterHDNode: wallet.getMasterHDNode(),
-  };
+    it('is false if the authorizers do not match', () => {
+      const invalidData = { ...validData, authorizers: ['0xD5659F26A72A8D718d1955C42B3AE418edB001e0'] };
+      const res = initialization[initFunction](options, invalidData);
+      expect(res).toEqual(false);
+    });
 
-  const validData = {
-    airnodeAdmin: '0x5e0051B74bb4006480A1b548af9F1F0e0954F410',
-    authorizers: [ethers.constants.AddressZero],
-    blockNumber: 12,
-    xpub:
-      'xpub661MyMwAqRbcGeCE1g3KTUVGZsFDE3jMNinRPGCQGQsAp1nwinB9Pi16ihKPJw7qtaaTFuBHbRPeSc6w3AcMjxiHkAPfyp1hqQRbthv4Ryx',
-  };
-
-  it('is true if the Airnode onchain parameters match the expected data', () => {
-    const res = initialization.airnodeParametersExistOnchain(options, validData);
-    expect(res).toEqual(true);
-  });
-
-  it('is false if the Airnode admin does not exist', () => {
-    const invalidData = { ...validData, airnodeAdmin: '' };
-    const res = initialization.airnodeParametersExistOnchain(options, invalidData);
-    expect(res).toEqual(false);
-  });
-
-  it('is false if the authorizers do not match', () => {
-    const invalidData = { ...validData, authorizers: ['0xD5659F26A72A8D718d1955C42B3AE418edB001e0'] };
-    const res = initialization.airnodeParametersExistOnchain(options, invalidData);
-    expect(res).toEqual(false);
-  });
-
-  it('is false if the extended public key does not match', () => {
-    const invalidData = { ...validData, xpub: '' };
-    const res = initialization.airnodeParametersExistOnchain(options, invalidData);
-    expect(res).toEqual(false);
+    if (initFunction === 'airnodeParametersExistOnchain') {
+      it('is false if the extended public key does not match', () => {
+        const invalidData = { ...validData, xpub: '' };
+        const res = initialization[initFunction](options, invalidData);
+        expect(res).toEqual(false);
+      });
+    }
   });
 });
 


### PR DESCRIPTION
Took a look at the tests and:
- Corrected test name to `fetches group authorization status if it can be fetched`
- Remove duplicated `does nothing if unable to verify or set Airnode parameters` test
- Tests which are copy pasted can be written in a for each pattern.