### PR TITLE
Fix ethers bundling

### DIFF
--- a/packages/deployer/webpack.config.js
+++ b/packages/deployer/webpack.config.js
@@ -12,5 +12,8 @@ module.exports = {
     libraryTarget: 'commonjs2',
     path: path.resolve(__dirname, '.webpack'),
   },
+  resolve: {
+    mainFields: ['main'],
+  },
   target: 'node',
 };


### PR DESCRIPTION
After we started bundling the node with our own webpack configuration, ethers started throwing `SERVER_ERROR: missing response`. See https://github.com/ethers-io/ethers.js/issues/1108 for details.

This PR applies this workaround https://github.com/ethers-io/ethers.js/issues/1108#issuecomment-731039919

As https://github.com/ethers-io/ethers.js/issues/1108#issuecomment-731041031 predicts, this increases the bundled file size from 7.7MB to 8.3MB. Not a huge deal.