### PR TITLE
Replace Bluebird with native promise implementation

### DIFF
--- a/packages/node/__dev__/invoke.ts
+++ b/packages/node/__dev__/invoke.ts
@@ -7,6 +7,4 @@ async function invoke() {
   await local.startCoordinator();
 }
 
-invoke()
-  .then(() => process.exit(0))
-  .catch(() => process.exit(1));
+invoke();

--- a/packages/node/__dev__/invoke.ts
+++ b/packages/node/__dev__/invoke.ts
@@ -7,4 +7,6 @@ async function invoke() {
   await local.startCoordinator();
 }
 
-invoke();
+invoke()
+  .then(() => process.exit(0))
+  .catch(() => process.exit(1));

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,9 +26,7 @@
     "@airnode/ois": "^0.1.0",
     "@airnode/operation": "^0.1.0",
     "@airnode/protocol": "^0.1.0",
-    "@types/bluebird": "^3.5.32",
     "aws-sdk": "^2.753.0",
-    "bluebird": "^3.7.2",
     "date-fns": "^2.16.1"
   }
 }

--- a/packages/node/src/utils/promise-utils.test.ts
+++ b/packages/node/src/utils/promise-utils.test.ts
@@ -1,4 +1,3 @@
-import { TimeoutError } from 'bluebird';
 import { go, goTimeout, promiseTimeout, retryOnTimeout, retryOperation } from './promise-utils';
 
 describe('go', () => {
@@ -34,8 +33,9 @@ describe('goTimeout', () => {
     const fn = new Promise((res) => {
       setTimeout(() => res("Won't be reached"), 20);
     });
-    const res = await goTimeout(15, fn);
-    expect(res).toEqual([new TimeoutError('operation timed out'), null]);
+    const [err, res] = await goTimeout(15, fn);
+    expect(res).toEqual(null);
+    expect(err?.message).toContain('operation timed out');
   });
 });
 
@@ -48,7 +48,7 @@ describe('promiseTimeout', () => {
     try {
       await promiseTimeout(15, fn);
     } catch (e) {
-      expect(e).toEqual(new TimeoutError('operation timed out'));
+      expect(e.message).toContain('operation timed out');
     }
   });
 });
@@ -117,13 +117,13 @@ describe('retryOnTimeout', () => {
   it('retries on timeout until the maximum timeout is reached', async () => {
     expect.assertions(3);
 
-    const operation = { perform: () => Promise.reject(new TimeoutError('operation timed out')) };
+    const operation = { perform: () => Promise.reject(new Error('operation timed out')) };
     const spy = jest.spyOn(operation, 'perform');
 
     try {
       await retryOnTimeout(50, operation.perform, { delay: 2 });
     } catch (e) {
-      expect(e).toEqual(new TimeoutError('operation timed out'));
+      expect(e.message).toContain('operation timed out');
     }
     expect(spy.mock.calls.length).toBeGreaterThan(5);
     expect(spy.mock.calls.length).toBeLessThan(30);

--- a/packages/node/src/utils/promise-utils.test.ts
+++ b/packages/node/src/utils/promise-utils.test.ts
@@ -35,7 +35,7 @@ describe('goTimeout', () => {
     });
     const [err, res] = await goTimeout(15, fn);
     expect(res).toEqual(null);
-    expect(err?.message).toContain('operation timed out');
+    expect(err?.message).toContain('Operation timed out');
   });
 });
 
@@ -48,7 +48,7 @@ describe('promiseTimeout', () => {
     try {
       await promiseTimeout(15, fn);
     } catch (e) {
-      expect(e.message).toContain('operation timed out');
+      expect(e.message).toContain('Operation timed out');
     }
   });
 });
@@ -117,13 +117,13 @@ describe('retryOnTimeout', () => {
   it('retries on timeout until the maximum timeout is reached', async () => {
     expect.assertions(3);
 
-    const operation = { perform: () => Promise.reject(new Error('operation timed out')) };
+    const operation = { perform: () => Promise.reject(new Error('Operation timed out')) };
     const spy = jest.spyOn(operation, 'perform');
 
     try {
       await retryOnTimeout(50, operation.perform, { delay: 2 });
     } catch (e) {
-      expect(e.message).toContain('operation timed out');
+      expect(e.message).toContain('Operation timed out');
     }
     expect(spy.mock.calls.length).toBeGreaterThan(5);
     expect(spy.mock.calls.length).toBeLessThan(30);

--- a/packages/node/src/utils/promise-utils.ts
+++ b/packages/node/src/utils/promise-utils.ts
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird';
 import { DEFAULT_RETRY_OPERATION_TIMEOUT } from '../constants';
 
 // Adapted from:
@@ -25,22 +24,15 @@ export function goTimeout<T>(ms: number, fn: Promise<T>): Promise<Response<T>> {
   return go(promiseTimeout(ms, fn));
 }
 
-// A native implementation of the following function might look like:
-//
-//   function promiseTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
-//     const timeout = new Promise((_res, reject) => {
-//       setTimeout(() => {
-//         reject(new Error(`Timed out in ${ms} ms.`));
-//       }, ms);
-//     });
-//     return Promise.race([promise, timeout]);
-//   }
-//
-// The problem with this is that that the slow promise still runs until it resolves.
-// This means that the serverless function will not exit until the entire timeout
-// duration has been reached which is a problem.
 export function promiseTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
-  return Bluebird.resolve(promise).timeout(ms);
+  const timeout = new Promise((_res, reject) => {
+    const id = setTimeout(() => {
+      clearTimeout(id);
+      reject(new Error(`operation timed out in ${ms} ms.`));
+    }, ms);
+  });
+
+  return Promise.race([promise, timeout]) as Promise<T>;
 }
 
 export function wait(ms: number) {


### PR DESCRIPTION
### Description

We only use Bluebird for promise timeouts. After some investigation and comments by @Siegrift it seemed like it could be replaced with native JS promises (using `Promise.race`). The initial comments are no longer applicable