### PR TITLE
 Update deployer Dockerization process

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,61 @@
-FROM node:12.19.0-alpine3.12
+# Build preparation
+FROM node:12-alpine as buildPrep
 
-# ENV NODE_ENV production
+ARG yarnRegistry
 
-WORKDIR /airnode
-COPY . /airnode
+ENV airnodeDir="/opt/airnode"
+ENV deployerDir="${airnodeDir}/packages/deployer" \
+    YARN_REGISTRY=${yarnRegistry}
 
-# Need git to install dependencies
-RUN apk update \
-    && apk add git
+RUN apk add --update python make g++ && \
+    mkdir -p ${deployerDir}
 
-RUN yarn run bootstrap
-RUN yarn run build
+WORKDIR ${deployerDir}
 
-ENTRYPOINT ["docker/entrypoint.sh"]
+# Actual build
+FROM buildPrep as buildBuild
+
+COPY tsconfig.build.json ${airnodeDir}
+COPY packages/deployer ${deployerDir}
+
+RUN yarn install && \
+    yarn build
+
+# Necessary NPM packages
+FROM buildPrep as buildDependencies
+
+COPY packages/deployer/package.json ${deployerDir}
+COPY packages/deployer/yarn.lock ${deployerDir}
+
+ENV NODE_ENV production
+
+RUN yarn install --prod
+
+# Run image
+FROM node:12-alpine
+
+ENV name="airnode-deployer" \
+    terraformURL="https://releases.hashicorp.com/terraform/0.15.3/terraform_0.15.3_linux_amd64.zip" \
+    buildDeployerDir="/opt/airnode/packages/deployer" \
+    deployerDir="/opt/deployer" \
+    deployerBin="/usr/local/bin/deployer"
+
+LABEL application=${name} \
+      description="Arinode Deployer CLI"
+
+RUN apk add --update --no-cache su-exec git
+RUN wget ${terraformURL} && \
+    unzip *.zip -d /bin && \
+    rm -rf *.zip
+RUN mkdir -p ${deployerDir}
+
+WORKDIR ${deployerDir}
+
+COPY --from=buildBuild ${buildDeployerDir}/dist ${deployerDir}
+COPY --from=buildDependencies ${buildDeployerDir}/node_modules ${deployerDir}/node_modules
+COPY docker/entrypoint.sh /entrypoint.sh
+
+RUN ln -s ${deployerDir}/bin/deployer.js ${deployerBin} && \
+    chmod +x ${deployerBin}
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-yarn lerna run --scope @airnode/deployer sls:config
-yarn cli:deployer ${@}
+DEPLOYER_BINARY="/usr/local/bin/deployer"
+USER_ID="${USER_ID:-0}"
+GROUP_ID="${GROUP_ID:-0}"
+
+su-exec ${USER_ID}:${GROUP_ID} ${DEPLOYER_BINARY} "$@"

--- a/packages/deployer/src/handlers/aws/index.ts
+++ b/packages/deployer/src/handlers/aws/index.ts
@@ -1,6 +1,9 @@
-import rawConfig from '../../config-data/config.json';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as node from '@airnode/node';
 
+const configFile = path.resolve(`${__dirname}/../../config-data/config.json`);
+const rawConfig = JSON.parse(fs.readFileSync(configFile, 'utf8'));
 const config = node.config.parseConfig(rawConfig[0]);
 
 function encodeBody(data: node.WorkerResponse): string {

--- a/packages/deployer/terraform/airnode/main.tf
+++ b/packages/deployer/terraform/airnode/main.tf
@@ -7,7 +7,7 @@ module "initializeProvider" {
 
   name                = "initializeProvider"
   handler             = "handlers/aws/index.initializeProvider"
-  source_file         = "${path.module}/../../.webpack/handlers/aws/index.js"
+  source_file         = var.handler_file
   timeout             = 20
   infrastructure_name = var.infrastructure_name
   stage               = var.stage
@@ -21,7 +21,7 @@ module "callApi" {
 
   name                = "callApi"
   handler             = "handlers/aws/index.callApi"
-  source_file         = "${path.module}/../../.webpack/handlers/aws/index.js"
+  source_file         = var.handler_file
   timeout             = 30
   infrastructure_name = var.infrastructure_name
   stage               = var.stage
@@ -35,7 +35,7 @@ module "processProviderRequests" {
 
   name                = "processProviderRequests"
   handler             = "handlers/aws/index.processProviderRequests"
-  source_file         = "${path.module}/../../.webpack/handlers/aws/index.js"
+  source_file         = var.handler_file
   timeout             = 10
   infrastructure_name = var.infrastructure_name
   stage               = var.stage
@@ -49,7 +49,7 @@ module "startCoordinator" {
 
   name                = "startCoordinator"
   handler             = "handlers/aws/index.startCoordinator"
-  source_file         = "${path.module}/../../.webpack/handlers/aws/index.js"
+  source_file         = var.handler_file
   timeout             = 60
   infrastructure_name = var.infrastructure_name
   stage               = var.stage

--- a/packages/deployer/terraform/airnode/modules/function/main.tf
+++ b/packages/deployer/terraform/airnode/modules/function/main.tf
@@ -12,8 +12,8 @@ EOC
   }
 
   triggers = {
-    source_file_hash        = fileexists("${local.tmp_source_dir}/${var.source_file}") ? filesha256(var.source_file) : ""
-    configuration_file_hash = fileexists("${local.tmp_configuration_dir}/${var.configuration_file}") ? filesha256(var.configuration_file) : ""
+    // Run always
+    trigger = uuid()
   }
 }
 
@@ -55,7 +55,7 @@ resource "aws_lambda_function" "lambda" {
   ]
 
   environment {
-    variables = jsondecode(file(var.secrets_file))
+    variables = fileexists(var.secrets_file) ? jsondecode(file(var.secrets_file)) : {}
   }
 }
 

--- a/packages/deployer/terraform/airnode/variables.tf
+++ b/packages/deployer/terraform/airnode/variables.tf
@@ -24,3 +24,7 @@ variable "configuration_file" {
 variable "secrets_file" {
   description = "Airnode secrets file"
 }
+
+variable "handler_file" {
+  description = "Airnode handler source code file"
+}


### PR DESCRIPTION
At first, I wanted to install the deployer from registry but decided against it. I think it would complicate the development and container testing process. So, I decided to build the deployer during the container build. But just the deployer, its dependencies are pulled from the registry. It felt like a nice compromise but I'm open to suggestions.

The resulting Docker image is around 500MB big and that's as low I was able to get due to all the dependencies.

I'm using [`su-exec`](https://github.com/ncopa/su-exec) to run deployer as user/group specified via `USER_ID`/`GROUP_ID` environment variables in order to set the correct access rights for the `receipt.json` output.

I'm providing a build argumment `yarnRegistry` that can be set to a custom Yarn respository URL for testing purposes.

As for the usage, it's a bit cumbersome mainly due to the defaults CLI is currently using and directory placement it's expecting. So, the command to run the deployment migh look something like:
```bash
docker run -it --rm --env-file aws.env -e USER_ID=1000 -e GROUP_ID=1000 -v $(pwd)/config.json:/config.json -v $(pwd)/secrets.env:/secrets.env -v $(pwd)/output:/output airnode-deployer:latest deploy -c /config.json -s /secrets.env -o /output/receipt.json
```
I would very much like to get rid of the duplicate path specification (once for the mount and once for the deployer cli itself) but I'm not sure it would be easily possible. I'll do some testing and I'll see.

Close #335