### PR TITLE
config.json validation in deployer

### DIFF
--- a/packages/deployer/config/config.json.example
+++ b/packages/deployer/config/config.json.example
@@ -7,7 +7,7 @@
           "0x0000000000000000000000000000000000000000"
         ],
         "contracts": {
-          "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+          "AirnodeRRP": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
         },
         "id": "31337",
         "providerNames": [
@@ -28,7 +28,7 @@
       "securitySchemes": [
         {
           "oisTitle": "Currency Converter API",
-          "name": "Currency Converter Security Scheme",
+          "name": "Currency_Converter_Security_Scheme",
           "envName": "SS_CURRENCY_CONVERTER_API_CURRENCY_CONVERTER_SECURITY_SCHEME"
         }
       ]
@@ -57,9 +57,6 @@
         "version": "1.2.3",
         "title": "Currency Converter API",
         "apiSpecifications": {
-          "info": {
-            "title": "Currency Converter API"
-          },
           "servers": [
             {
               "url": "http://localhost:5000"
@@ -91,18 +88,16 @@
           },
           "components": {
             "securitySchemes": {
-              "Currency Converter Security Scheme": {
+              "Currency_Converter_Security_Scheme": {
                 "in": "query",
                 "type": "apiKey",
                 "name": "access_key"
               }
             }
           },
-          "security": [
-            {
-              "Currency Converter Security Scheme": []
-            }
-          ]
+          "security": {
+            "Currency_Converter_Security_Scheme": []
+          }
         },
         "endpoints": [
           {
@@ -132,10 +127,6 @@
               {
                 "name": "_times",
                 "default": "1000000"
-              },
-              {
-                "name": "_relay_metadata",
-                "default": "v1"
               }
             ],
             "parameters": [
@@ -152,6 +143,13 @@
                 "default": "1",
                 "operationParameter": {
                   "name": "amount",
+                  "in": "query"
+                }
+              },
+              {
+                "name": "date",
+                "operationParameter": {
+                  "name": "date",
                   "in": "query"
                 }
               }

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -20,6 +20,7 @@
     "@api3/node": "^0.1.0",
     "@api3/ois": "^0.1.0",
     "@api3/protocol": "^0.1.0",
+    "@api3/validator": "^1.0.0",
     "dotenv": "^8.2.0",
     "ethers": "^5.1.4",
     "lodash": "^4.17.21",

--- a/packages/deployer/src/cli/commands.ts
+++ b/packages/deployer/src/cli/commands.ts
@@ -23,9 +23,10 @@ export async function deploy(
   secretsFile: string,
   receiptFile: string,
   interactive: boolean,
-  nodeVersion: string
+  nodeVersion: string,
+  debug: boolean
 ) {
-  const configs = parseConfigFile(configFile, nodeVersion);
+  const configs = parseConfigFile(configFile, nodeVersion, debug);
   const secrets = parseSecretsFile(secretsFile);
 
   if (!secrets.MASTER_KEY_MNEMONIC) {

--- a/packages/deployer/src/cli/index.ts
+++ b/packages/deployer/src/cli/index.ts
@@ -52,13 +52,13 @@ yargs(hideBin(process.argv))
       configuration: {
         alias: ['c', 'config', 'conf'],
         description: 'Path to configuration file',
-        default: 'config/config.json',
+        default: 'config/config.json.example',
         type: 'string',
       },
       secrets: {
         alias: 's',
         description: 'Path to secrets file',
-        default: 'config/secrets.env',
+        default: 'config/secrets.env.example',
         type: 'string',
       },
       receipt: {

--- a/packages/deployer/src/cli/index.ts
+++ b/packages/deployer/src/cli/index.ts
@@ -76,7 +76,9 @@ yargs(hideBin(process.argv))
     async (args) => {
       logger.debugMode(args.debug as boolean);
       logger.debug(`Running command ${args._[0]} with arguments ${longArguments(args)}`);
-      await runCommand(() => deploy(args.configuration, args.secrets, args.receipt, args.interactive, nodeVersion));
+      await runCommand(() =>
+        deploy(args.configuration, args.secrets, args.receipt, args.interactive, nodeVersion, args.debug as boolean)
+      );
     }
   )
   .command(

--- a/packages/deployer/src/utils/files.ts
+++ b/packages/deployer/src/utils/files.ts
@@ -4,7 +4,7 @@ import { Configurations, Receipts } from 'src/types';
 import * as logger from '../utils/logger';
 import { validateWithTemplate } from '@api3/validator';
 
-export function parseConfigFile(configPath: string, nodeVersion: string) {
+export function parseConfigFile(configPath: string, nodeVersion: string, debug: boolean) {
   logger.debug('Parsing configuration file');
 
   let configs: Configurations;
@@ -13,10 +13,13 @@ export function parseConfigFile(configPath: string, nodeVersion: string) {
   if (res.messages.length) {
     if (!res.valid) {
       logger.fail(JSON.stringify(res.messages));
-      throw new Error('Invalid config.json');
-    }
 
-    logger.warn(JSON.stringify(res.messages));
+      if (!debug) {
+        throw new Error('Invalid config.json');
+      }
+    } else {
+      logger.warn(JSON.stringify(res.messages));
+    }
   }
 
   try {


### PR DESCRIPTION
1. Added validation when [parsing config](https://github.com/api3dao/airnode/blob/32c114dbcf38910a40ca676b81eb3bc1908b0ea2/packages/deployer/src/utils/files.ts#L7)
2. If deployer is launched in debug mode, deployment will be attempted even with incorrect `config.json`. Is it enough or should there be special hidden argument for this?
3. Validator checks entire `config.json`, as it seems config is parsed only once and after that it is passed between functions, any other checks [here](https://github.com/api3dao/airnode/blob/master/packages/deployer/src/evm/config.ts), would be redundant if im not missing anything.
4. Updated [config.json example](https://github.com/api3dao/airnode/blob/master/packages/deployer/config/config.json.example) to pass validation, however validator is based on [these docs](https://docs.api3.org/next/technology/deployment-files/config-json.html) and im not sure if they are up to date, are there any deployer test suites so i would be able to verify what works and what doesnt?

closes #136 