### PR TITLE
update authorizer contract and tests according to new specs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,5 +10,6 @@
 **/.serverless/**
 **/coverage/**
 **/dist/**
+**/.webpack/**
 
 *.json

--- a/packages/protocol/contracts/authorizers/interfaces/IApi3Authorizer.sol
+++ b/packages/protocol/contracts/authorizers/interfaces/IApi3Authorizer.sol
@@ -26,10 +26,9 @@ interface IApi3Authorizer is IAuthorizer {
     bytes32 indexed airnodeId,
     address indexed clientAddress,
     uint256 expiration,
+    bool status,
     address indexed admin
   );
-
-  event SetBlacklistStatus(address indexed clientAddress, bool status, address indexed admin);
 
   function setMetaAdmin(address _metaAdmin) external;
 
@@ -46,8 +45,7 @@ interface IApi3Authorizer is IAuthorizer {
   function setWhitelistExpiration(
     bytes32 airnodeId,
     address clientAddress,
-    uint256 expiration
+    uint256 expiration,
+    bool status
   ) external;
-
-  function setBlacklistStatus(address clientAddress, bool status) external;
 }

--- a/packages/protocol/contracts/authorizers/interfaces/IApi3Authorizer.sol
+++ b/packages/protocol/contracts/authorizers/interfaces/IApi3Authorizer.sol
@@ -6,7 +6,7 @@ import "./IAuthorizer.sol";
 interface IApi3Authorizer is IAuthorizer {
   // Unauthorized (0):  Cannot do anything
   // Admin (1):         Can extend whitelistings
-  // Super admin (2):   Can set (i.e., extend or revoke) whitelistings, blacklist
+  // Super admin (2):   Can set, extend, revoke whitelistings
   enum AdminStatus { Unauthorized, Admin, SuperAdmin }
 
   event SetMetaAdmin(address metaAdmin);
@@ -26,6 +26,12 @@ interface IApi3Authorizer is IAuthorizer {
     bytes32 indexed airnodeId,
     address indexed clientAddress,
     uint256 expiration,
+    address indexed admin
+  );
+
+  event SetWhitelistStatus(
+    bytes32 indexed airnodeId,
+    address indexed clientAddress,
     bool status,
     address indexed admin
   );
@@ -45,7 +51,12 @@ interface IApi3Authorizer is IAuthorizer {
   function setWhitelistExpiration(
     bytes32 airnodeId,
     address clientAddress,
-    uint256 expiration,
+    uint256 expiration
+  ) external;
+
+  function setWhitelistStatus(
+    bytes32 airnodeId,
+    address clientAddress,
     bool status
   ) external;
 }

--- a/packages/protocol/contracts/authorizers/interfaces/ISelfAuthorizer.sol
+++ b/packages/protocol/contracts/authorizers/interfaces/ISelfAuthorizer.sol
@@ -6,7 +6,7 @@ import "./IAuthorizer.sol";
 interface ISelfAuthorizer is IAuthorizer {
   // Unauthorized (0):  Cannot do anything
   // Admin (1):         Can extend whitelistings
-  // Super admin (2):   Can set (i.e., extend or revoke) whitelistings, blacklist
+  // Super admin (2):   Can set, extend or revoke whitelistings
   enum AdminStatus { Unauthorized, Admin, SuperAdmin }
 
   event SetAdminStatus(bytes32 indexed airnodeId, address indexed admin, AdminStatus status);
@@ -27,7 +27,7 @@ interface ISelfAuthorizer is IAuthorizer {
     address indexed admin
   );
 
-  event SetBlacklistStatus(
+  event SetWhitelistStatus(
     bytes32 indexed airnodeId,
     address indexed clientAddress,
     bool status,
@@ -54,7 +54,7 @@ interface ISelfAuthorizer is IAuthorizer {
     uint256 expiration
   ) external;
 
-  function setBlacklistStatus(
+  function setWhitelistStatus(
     bytes32 airnodeId,
     address clientAddress,
     bool status

--- a/packages/protocol/test/authorizers/SelfAuthorizer.sol.js
+++ b/packages/protocol/test/authorizers/SelfAuthorizer.sol.js
@@ -328,40 +328,40 @@ describe('setWhitelistExpiration', function () {
   });
 });
 
-describe('setBlacklistStatus', function () {
+describe('setWhitelistStatus', function () {
   context('Caller is a super admin', async function () {
-    it('sets blacklist status', async function () {
+    it('sets Whitelist status', async function () {
       await selfAuthorizer
         .connect(roles.airnodeAdmin)
         .setAdminStatus(airnodeId, roles.superAdmin.address, AdminStatus.SuperAdmin);
-      await expect(selfAuthorizer.connect(roles.superAdmin).setBlacklistStatus(airnodeId, roles.client.address, true))
-        .to.emit(selfAuthorizer, 'SetBlacklistStatus')
+      await expect(selfAuthorizer.connect(roles.superAdmin).setWhitelistStatus(airnodeId, roles.client.address, true))
+        .to.emit(selfAuthorizer, 'SetWhitelistStatus')
         .withArgs(airnodeId, roles.client.address, true, roles.superAdmin.address);
-      expect(await selfAuthorizer.airnodeIdToClientAddressToBlacklistStatus(airnodeId, roles.client.address)).to.equal(
+      expect(await selfAuthorizer.airnodeIdToClientAddressToWhitelistStatus(airnodeId, roles.client.address)).to.equal(
         true
       );
-      await expect(selfAuthorizer.connect(roles.superAdmin).setBlacklistStatus(airnodeId, roles.client.address, false))
-        .to.emit(selfAuthorizer, 'SetBlacklistStatus')
+      await expect(selfAuthorizer.connect(roles.superAdmin).setWhitelistStatus(airnodeId, roles.client.address, false))
+        .to.emit(selfAuthorizer, 'SetWhitelistStatus')
         .withArgs(airnodeId, roles.client.address, false, roles.superAdmin.address);
-      expect(await selfAuthorizer.airnodeIdToClientAddressToBlacklistStatus(airnodeId, roles.client.address)).to.equal(
+      expect(await selfAuthorizer.airnodeIdToClientAddressToWhitelistStatus(airnodeId, roles.client.address)).to.equal(
         false
       );
     });
   });
   context('Caller is the Airnode admin', async function () {
     it('sets whitelist expiration', async function () {
-      await expect(selfAuthorizer.connect(roles.airnodeAdmin).setBlacklistStatus(airnodeId, roles.client.address, true))
-        .to.emit(selfAuthorizer, 'SetBlacklistStatus')
+      await expect(selfAuthorizer.connect(roles.airnodeAdmin).setWhitelistStatus(airnodeId, roles.client.address, true))
+        .to.emit(selfAuthorizer, 'SetWhitelistStatus')
         .withArgs(airnodeId, roles.client.address, true, roles.airnodeAdmin.address);
-      expect(await selfAuthorizer.airnodeIdToClientAddressToBlacklistStatus(airnodeId, roles.client.address)).to.equal(
+      expect(await selfAuthorizer.airnodeIdToClientAddressToWhitelistStatus(airnodeId, roles.client.address)).to.equal(
         true
       );
       await expect(
-        selfAuthorizer.connect(roles.airnodeAdmin).setBlacklistStatus(airnodeId, roles.client.address, false)
+        selfAuthorizer.connect(roles.airnodeAdmin).setWhitelistStatus(airnodeId, roles.client.address, false)
       )
-        .to.emit(selfAuthorizer, 'SetBlacklistStatus')
+        .to.emit(selfAuthorizer, 'SetWhitelistStatus')
         .withArgs(airnodeId, roles.client.address, false, roles.airnodeAdmin.address);
-      expect(await selfAuthorizer.airnodeIdToClientAddressToBlacklistStatus(airnodeId, roles.client.address)).to.equal(
+      expect(await selfAuthorizer.airnodeIdToClientAddressToWhitelistStatus(airnodeId, roles.client.address)).to.equal(
         false
       );
     });
@@ -372,14 +372,14 @@ describe('setBlacklistStatus', function () {
         .connect(roles.airnodeAdmin)
         .setAdminStatus(airnodeId, roles.admin.address, AdminStatus.Admin);
       await expect(
-        selfAuthorizer.connect(roles.admin).setBlacklistStatus(airnodeId, roles.client.address, true)
+        selfAuthorizer.connect(roles.admin).setWhitelistStatus(airnodeId, roles.client.address, true)
       ).to.be.revertedWith('Unauthorized');
     });
   });
   context('Caller is not an admin', function () {
     it('reverts', async function () {
       await expect(
-        selfAuthorizer.connect(roles.randomPerson).setBlacklistStatus(airnodeId, roles.client.address, true)
+        selfAuthorizer.connect(roles.randomPerson).setWhitelistStatus(airnodeId, roles.client.address, true)
       ).to.be.revertedWith('Unauthorized');
     });
   });
@@ -387,7 +387,7 @@ describe('setBlacklistStatus', function () {
 
 describe('isAuthorized', function () {
   context('Designated wallet balance is not zero', function () {
-    context('Client is not blacklisted', function () {
+    context('Client is not Whitelisted', function () {
       context('Client whitelisting has not expired', function () {
         it('returns true', async function () {
           const designatedWallet = ethers.Wallet.createRandom();
@@ -412,7 +412,7 @@ describe('isAuthorized', function () {
           ).to.equal(true);
         });
       });
-      context('Client whitelisting has expired', function () {
+      context('Client whitelisting has expired and whitelisting has not been set', function () {
         it('returns false', async function () {
           const designatedWallet = ethers.Wallet.createRandom();
           await roles.client.sendTransaction({
@@ -432,17 +432,25 @@ describe('isAuthorized', function () {
         });
       });
     });
-    context('Client is blacklisted', function () {
+    context('Client whitelisting was set then revoked', function () {
       it('returns false', async function () {
         const designatedWallet = ethers.Wallet.createRandom();
         await roles.client.sendTransaction({
           to: designatedWallet.address,
           value: 1,
         });
-        const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
-        const expiration = now + 100;
-        selfAuthorizer.connect(roles.airnodeAdmin).setWhitelistExpiration(airnodeId, roles.client.address, expiration);
-        selfAuthorizer.connect(roles.airnodeAdmin).setBlacklistStatus(airnodeId, roles.client.address, true);
+        await selfAuthorizer.connect(roles.airnodeAdmin).setWhitelistStatus(airnodeId, roles.client.address, true);
+        expect(
+          await selfAuthorizer.isAuthorized(
+            requestId,
+            airnodeId,
+            endpointId,
+            requesterIndex,
+            designatedWallet.address,
+            roles.client.address
+          )
+        ).to.equal(true);
+        await selfAuthorizer.connect(roles.airnodeAdmin).setWhitelistStatus(airnodeId, roles.client.address, false);
         expect(
           await selfAuthorizer.isAuthorized(
             requestId,


### PR DESCRIPTION
This new Authorizer has a bool `airnodeIdToClientAddressToWhitelist`  that can be set along with the expiration. The client is only authorized if both the bool and the expiration satisfy. The `setWhitelistExpiration` can both set and unset `airnodeIdToClientAddressToWhitelist` thereby granting/revoking the whitelisting.  

The  old isAuthorized tests seem to be worded wrong, I've updated them but they should be changed