### PR TITLE
Use context instead of describe

### DIFF
--- a/packages/protocol/test/AirnodeParameterStore.js
+++ b/packages/protocol/test/AirnodeParameterStore.js
@@ -1,4 +1,4 @@
-/* globals ethers */
+/* globals context ethers */
 
 const { expect } = require('chai');
 
@@ -65,7 +65,7 @@ describe('setAirnodeParameters', function () {
 });
 
 describe('requestWithdrawal', function () {
-  describe('Caller is requester admin', async function () {
+  context('Caller is requester admin', async function () {
     it('requests withdrawal', async function () {
       // Generate random addresses as the authorizer contracts
       const authorizers = Array.from({ length: 5 }, () =>
@@ -102,7 +102,7 @@ describe('requestWithdrawal', function () {
         );
     });
   });
-  describe('Caller not requester admin', async function () {
+  context('Caller not requester admin', async function () {
     it('reverts', async function () {
       // Generate random addresses as the authorizer contracts
       const authorizers = Array.from({ length: 5 }, () =>
@@ -123,8 +123,8 @@ describe('requestWithdrawal', function () {
 });
 
 describe('fulfillWithdrawal', function () {
-  describe('Fulfillment parameters are correct', async function () {
-    describe('Withdrawal destination is payable', async function () {
+  context('Fulfillment parameters are correct', async function () {
+    context('Withdrawal destination is payable', async function () {
       it('fulfills withdrawal request', async function () {
         // Generate random addresses as the authorizer contracts
         const authorizers = Array.from({ length: 5 }, () =>
@@ -185,7 +185,7 @@ describe('fulfillWithdrawal', function () {
         expect(await waffle.provider.getBalance(roles.requesterAdmin.address)).to.equal(expectedRequesterAdminBalance);
       });
     });
-    describe('Withdrawal destination is not payable', async function () {
+    context('Withdrawal destination is not payable', async function () {
       it('reverts', async function () {
         // Generate random addresses as the authorizer contracts
         const authorizers = Array.from({ length: 5 }, () =>
@@ -222,7 +222,7 @@ describe('fulfillWithdrawal', function () {
       });
     });
   });
-  describe('Fulfillment parameters are incorrect', async function () {
+  context('Fulfillment parameters are incorrect', async function () {
     it('reverts', async function () {
       // Generate random addresses as the authorizer contracts
       const authorizers = Array.from({ length: 5 }, () =>
@@ -291,7 +291,7 @@ describe('fulfillWithdrawal', function () {
       ).to.be.revertedWith('No such withdrawal request');
     });
   });
-  describe('Fulfilling wallet is incorrect', async function () {
+  context('Fulfilling wallet is incorrect', async function () {
     it('reverts', async function () {
       // Generate random addresses as the authorizer contracts
       const authorizers = Array.from({ length: 5 }, () =>
@@ -330,7 +330,7 @@ describe('fulfillWithdrawal', function () {
 });
 
 describe('checkAuthorizationStatus', function () {
-  describe('authorizers array is empty', async function () {
+  context('authorizers array is empty', async function () {
     it('returns false', async function () {
       const authorizers = [];
       // Set the Airnode parameters
@@ -350,7 +350,7 @@ describe('checkAuthorizationStatus', function () {
       ).to.equal(false);
     });
   });
-  describe('All authorizers return false', async function () {
+  context('All authorizers return false', async function () {
     it('returns false', async function () {
       const authorizers = [authorizerAlwaysFalse.address, authorizerAlwaysFalse.address, authorizerAlwaysFalse.address];
       // Set the Airnode parameters
@@ -370,7 +370,7 @@ describe('checkAuthorizationStatus', function () {
       ).to.equal(false);
     });
   });
-  describe('authorizers array contains a zero address', async function () {
+  context('authorizers array contains a zero address', async function () {
     it('returns true', async function () {
       const authorizers = [authorizerAlwaysFalse.address, ethers.constants.AddressZero];
       // Set the Airnode parameters
@@ -390,7 +390,7 @@ describe('checkAuthorizationStatus', function () {
       ).to.equal(true);
     });
   });
-  describe('At least one of the authorizers returns true', async function () {
+  context('At least one of the authorizers returns true', async function () {
     it('returns true', async function () {
       const authorizers = [authorizerAlwaysFalse.address, authorizerAlwaysTrue.address, authorizerAlwaysFalse.address];
       // Set the Airnode parameters

--- a/packages/protocol/test/AirnodeRrp.sol.js
+++ b/packages/protocol/test/AirnodeRrp.sol.js
@@ -1,4 +1,4 @@
-/* globals ethers */
+/* globals context ethers */
 
 const { expect } = require('chai');
 
@@ -56,7 +56,7 @@ beforeEach(async () => {
 });
 
 describe('makeRequest', function () {
-  describe('Client is endorsed by requester', async function () {
+  context('Client is endorsed by requester', async function () {
     it('makes a regular request', async function () {
       // Have the requester endorse the client
       await airnodeRrp
@@ -100,7 +100,7 @@ describe('makeRequest', function () {
         );
     });
   });
-  describe('Client is not endorsed by requester', async function () {
+  context('Client is not endorsed by requester', async function () {
     it('reverts', async function () {
       await expect(
         airnodeRrpClient
@@ -119,7 +119,7 @@ describe('makeRequest', function () {
 });
 
 describe('makeFullRequest', function () {
-  describe('Client is endorsed by requester', async function () {
+  context('Client is endorsed by requester', async function () {
     it('makes a full request', async function () {
       // Have the requester endorse the client
       await airnodeRrp
@@ -164,7 +164,7 @@ describe('makeFullRequest', function () {
         );
     });
   });
-  describe('Client is not endorsed by requester', async function () {
+  context('Client is not endorsed by requester', async function () {
     it('reverts', async function () {
       await expect(
         airnodeRrpClient
@@ -184,8 +184,8 @@ describe('makeFullRequest', function () {
 });
 
 describe('fulfill', function () {
-  describe('Regular request has been made', async function () {
-    describe('Fulfillment parameters are correct', async function () {
+  context('Regular request has been made', async function () {
+    context('Fulfillment parameters are correct', async function () {
       it('fulfills', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -223,7 +223,7 @@ describe('fulfill', function () {
           .withArgs(airnodeId, requestId, fulfillStatusCode, fulfillData);
       });
     });
-    describe('Fulfillment parameters are incorrect', async function () {
+    context('Fulfillment parameters are incorrect', async function () {
       it('reverts', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -287,7 +287,7 @@ describe('fulfill', function () {
         ).to.be.revertedWith('No such request');
       });
     });
-    describe('Fulfilling wallet is incorrect', async function () {
+    context('Fulfilling wallet is incorrect', async function () {
       it('reverts', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -324,8 +324,8 @@ describe('fulfill', function () {
       });
     });
   });
-  describe('Full request has been made', async function () {
-    describe('Fulfillment parameters are correct', async function () {
+  context('Full request has been made', async function () {
+    context('Fulfillment parameters are correct', async function () {
       it('fulfills', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -364,7 +364,7 @@ describe('fulfill', function () {
           .withArgs(airnodeId, requestId, fulfillStatusCode, fulfillData);
       });
     });
-    describe('Fulfillment parameters are incorrect', async function () {
+    context('Fulfillment parameters are incorrect', async function () {
       it('reverts', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -429,7 +429,7 @@ describe('fulfill', function () {
         ).to.be.revertedWith('No such request');
       });
     });
-    describe('Fulfilling wallet is incorrect', async function () {
+    context('Fulfilling wallet is incorrect', async function () {
       it('reverts', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -470,8 +470,8 @@ describe('fulfill', function () {
 });
 
 describe('fail', function () {
-  describe('Regular request has been made', async function () {
-    describe('Fulfillment parameters are correct', async function () {
+  context('Regular request has been made', async function () {
+    context('Fulfillment parameters are correct', async function () {
       it('fails successfully', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -507,7 +507,7 @@ describe('fail', function () {
           .withArgs(airnodeId, requestId);
       });
     });
-    describe('Fulfillment parameters are incorrect', async function () {
+    context('Fulfillment parameters are incorrect', async function () {
       it('reverts', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -563,7 +563,7 @@ describe('fail', function () {
         ).to.be.revertedWith('No such request');
       });
     });
-    describe('Fulfilling wallet is incorrect', async function () {
+    context('Fulfilling wallet is incorrect', async function () {
       it('reverts', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -598,8 +598,8 @@ describe('fail', function () {
       });
     });
   });
-  describe('Full request has been made', async function () {
-    describe('Fulfillment parameters are correct', async function () {
+  context('Full request has been made', async function () {
+    context('Fulfillment parameters are correct', async function () {
       it('fails successfully', async function () {
         // Have the requester endorse the client
         await airnodeRrp
@@ -635,7 +635,7 @@ describe('fail', function () {
           .to.emit(airnodeRrp, 'ClientRequestFailed')
           .withArgs(airnodeId, requestId);
       });
-      describe('Fulfillment parameters are incorrect', async function () {
+      context('Fulfillment parameters are incorrect', async function () {
         it('reverts', async function () {
           // Have the requester endorse the client
           await airnodeRrp
@@ -691,7 +691,7 @@ describe('fail', function () {
               .fail(requestId, airnodeId, fulfillAddress, falseFulfillFunctionId, { gasLimit: 500000 })
           ).to.be.revertedWith('No such request');
         });
-        describe('Fulfilling wallet is incorrect', async function () {
+        context('Fulfilling wallet is incorrect', async function () {
           it('reverts', async function () {
             // Have the requester endorse the client
             await airnodeRrp

--- a/packages/protocol/test/AirnodeRrpClient.sol.js
+++ b/packages/protocol/test/AirnodeRrpClient.sol.js
@@ -1,4 +1,4 @@
-/* globals ethers */
+/* globals context ethers */
 
 const { expect } = require('chai');
 
@@ -26,14 +26,14 @@ describe('constructor', function () {
 });
 
 describe('onlyAirnodeRrp', function () {
-  describe('Caller is the Airnode RRP contract', async function () {
+  context('Caller is the Airnode RRP contract', async function () {
     it('does not revert', async function () {
       await expect(
         airnodeRrpClient.connect(roles.airnodeRrp).fulfill(requestId, fulfillStatusCode, fulfillData)
       ).to.not.be.revertedWith('Caller not Airnode RRP');
     });
   });
-  describe('Caller is not the Airnode RRP contract', async function () {
+  context('Caller is not the Airnode RRP contract', async function () {
     it('reverts', async function () {
       await expect(
         airnodeRrpClient.connect(roles.randomPerson).fulfill(requestId, fulfillStatusCode, fulfillData)

--- a/packages/protocol/test/Convenience.sol.js
+++ b/packages/protocol/test/Convenience.sol.js
@@ -1,4 +1,4 @@
-/* globals ethers */
+/* globals context ethers */
 
 const { expect } = require('chai');
 
@@ -35,8 +35,8 @@ beforeEach(async () => {
 });
 
 describe('setAirnodeParametersAndForwardFunds', function () {
-  describe('Called with non-zero value', async function () {
-    describe('Airnode admin is payable', async function () {
+  context('Called with non-zero value', async function () {
+    context('Airnode admin is payable', async function () {
       it('sets the Airnode parameters and forwards funds', async function () {
         // Generate random addresses as the authorizer contracts
         const authorizers = Array.from({ length: 5 }, () =>
@@ -70,7 +70,7 @@ describe('setAirnodeParametersAndForwardFunds', function () {
         expect(await waffle.provider.getBalance(roles.airnodeAdmin.address)).to.equal(expectedAirnodeAdminBalance);
       });
     });
-    describe('Airnode admin is not payable', async function () {
+    context('Airnode admin is not payable', async function () {
       it('reverts', async function () {
         // Generate random addresses as the authorizer contracts
         const authorizers = Array.from({ length: 5 }, () =>
@@ -88,7 +88,7 @@ describe('setAirnodeParametersAndForwardFunds', function () {
       });
     });
   });
-  describe('Called with zero value', async function () {
+  context('Called with zero value', async function () {
     it('sets Airnode parameters', async function () {
       // Generate random addresses as the authorizer contracts
       const authorizers = Array.from({ length: 5 }, () =>
@@ -162,7 +162,7 @@ describe('getTemplates', function () {
 });
 
 describe('checkAuthorizationStatuses', function () {
-  describe('Parameter lengths are equal', async function () {
+  context('Parameter lengths are equal', async function () {
     it('returns authorization statuses', async function () {
       const authorizers = [ethers.constants.AddressZero];
       // Set Airnode parameters
@@ -188,7 +188,7 @@ describe('checkAuthorizationStatuses', function () {
       }
     });
   });
-  describe('Parameter lengths are not equal', async function () {
+  context('Parameter lengths are not equal', async function () {
     it('reverts', async function () {
       const authorizers = [ethers.constants.AddressZero];
       // Set Airnode parameters

--- a/packages/protocol/test/RequesterStore.sol.js
+++ b/packages/protocol/test/RequesterStore.sol.js
@@ -1,4 +1,4 @@
-/* globals ethers */
+/* globals context ethers */
 
 const { expect } = require('chai');
 
@@ -40,7 +40,7 @@ describe('createRequester', function () {
 });
 
 describe('setRequesterAdmin', function () {
-  describe('Caller is requester admin', async function () {
+  context('Caller is requester admin', async function () {
     it('sets the requester admin', async function () {
       // Create the requester
       await airnodeRrp.connect(roles.requesterAdmin1).createRequester(roles.requesterAdmin1.address);
@@ -56,7 +56,7 @@ describe('setRequesterAdmin', function () {
       expect(await airnodeRrp.requesterIndexToAdmin(requesterIndex1)).to.equal(roles.updatedRequesterAdmin1.address);
     });
   });
-  describe('Caller not requester admin', async function () {
+  context('Caller not requester admin', async function () {
     it('reverts', async function () {
       // Create the requester
       await airnodeRrp.connect(roles.requesterAdmin1).createRequester(roles.requesterAdmin1.address);
@@ -69,7 +69,7 @@ describe('setRequesterAdmin', function () {
 });
 
 describe('setClientEndorsementStatus', function () {
-  describe('Caller is requester admin', async function () {
+  context('Caller is requester admin', async function () {
     it('sets the client endorsement status and initializes the client request nonce', async function () {
       // Create the requester
       await airnodeRrp.connect(roles.requesterAdmin1).createRequester(roles.requesterAdmin1.address);
@@ -107,7 +107,7 @@ describe('setClientEndorsementStatus', function () {
       ).to.equal(false);
     });
   });
-  describe('Caller not requester admin', async function () {
+  context('Caller not requester admin', async function () {
     it('reverts', async function () {
       // Create the requester
       await airnodeRrp.connect(roles.requesterAdmin1).createRequester(roles.requesterAdmin1.address);

--- a/packages/protocol/test/authorizers/Api3Authorizer.sol.js
+++ b/packages/protocol/test/authorizers/Api3Authorizer.sol.js
@@ -1,4 +1,4 @@
-/* globals ethers */
+/* globals context ethers */
 
 const { expect } = require('chai');
 
@@ -31,13 +31,13 @@ beforeEach(async () => {
 });
 
 describe('constructor', function () {
-  describe('Meta admin address is non-zero', function () {
+  context('Meta admin address is non-zero', function () {
     it('initializes correctly', async function () {
       expect(await api3Authorizer.authorizerType()).to.equal(1);
       expect(await api3Authorizer.metaAdmin()).to.equal(roles.metaAdmin.address);
     });
   });
-  describe('Meta admin address is zero', function () {
+  context('Meta admin address is zero', function () {
     it('reverts', async function () {
       const api3AuthorizerFactory = await ethers.getContractFactory('Api3Authorizer', roles.deployer);
       await expect(api3AuthorizerFactory.deploy(ethers.constants.AddressZero)).to.be.revertedWith('Zero address');
@@ -46,15 +46,15 @@ describe('constructor', function () {
 });
 
 describe('setMetaAdmin', function () {
-  describe('Caller is the meta admin', async function () {
-    describe('Address to be set as meta admin is non-zero', async function () {
+  context('Caller is the meta admin', async function () {
+    context('Address to be set as meta admin is non-zero', async function () {
       it('transfers master adminship', async function () {
         await expect(api3Authorizer.connect(roles.metaAdmin).setMetaAdmin(roles.newMetaAdmin.address))
           .to.emit(api3Authorizer, 'SetMetaAdmin')
           .withArgs(roles.newMetaAdmin.address);
       });
     });
-    describe('Address to be set as meta admin is non-zero', async function () {
+    context('Address to be set as meta admin is non-zero', async function () {
       it('reverts', async function () {
         await expect(
           api3Authorizer.connect(roles.metaAdmin).setMetaAdmin(ethers.constants.AddressZero)
@@ -62,7 +62,7 @@ describe('setMetaAdmin', function () {
       });
     });
   });
-  describe('Caller is not the meta admin', async function () {
+  context('Caller is not the meta admin', async function () {
     it('reverts', async function () {
       await expect(
         api3Authorizer.connect(roles.randomPerson).setMetaAdmin(roles.newMetaAdmin.address)
@@ -72,7 +72,7 @@ describe('setMetaAdmin', function () {
 });
 
 describe('setAdminStatus', function () {
-  describe('Caller is the meta admin', async function () {
+  context('Caller is the meta admin', async function () {
     it('sets admin status', async function () {
       // Give admin status
       await expect(api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.admin.address, AdminStatus.Admin))
@@ -104,7 +104,7 @@ describe('setAdminStatus', function () {
       expect(await api3Authorizer.adminStatuses(roles.superAdmin.address)).to.equal(AdminStatus.Unauthorized);
     });
   });
-  describe('Caller is not the meta admin', async function () {
+  context('Caller is not the meta admin', async function () {
     it('reverts', async function () {
       await expect(
         api3Authorizer.connect(roles.randomPerson).setAdminStatus(roles.admin.address, AdminStatus.Admin)
@@ -117,7 +117,7 @@ describe('setAdminStatus', function () {
 });
 
 describe('renounceAdminStatus', function () {
-  describe('Caller is an admin', async function () {
+  context('Caller is an admin', async function () {
     it('renounces admin status', async function () {
       await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.admin.address, AdminStatus.Admin);
       await expect(api3Authorizer.connect(roles.admin).renounceAdminStatus())
@@ -126,7 +126,7 @@ describe('renounceAdminStatus', function () {
       expect(await api3Authorizer.adminStatuses(roles.admin.address)).to.equal(AdminStatus.Unauthorized);
     });
   });
-  describe('Caller is a super admin', async function () {
+  context('Caller is a super admin', async function () {
     it('renounces admin status', async function () {
       await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.superAdmin.address, AdminStatus.SuperAdmin);
       await expect(api3Authorizer.connect(roles.superAdmin).renounceAdminStatus())
@@ -135,7 +135,7 @@ describe('renounceAdminStatus', function () {
       expect(await api3Authorizer.adminStatuses(roles.superAdmin.address)).to.equal(AdminStatus.Unauthorized);
     });
   });
-  describe('Caller is not an admin', async function () {
+  context('Caller is not an admin', async function () {
     it('reverts', async function () {
       await expect(api3Authorizer.connect(roles.randomPerson).renounceAdminStatus()).to.be.revertedWith('Unauthorized');
     });
@@ -143,8 +143,8 @@ describe('renounceAdminStatus', function () {
 });
 
 describe('extendWhitelistExpiration', function () {
-  describe('Caller is an admin', function () {
-    describe('Provided expiration extends', function () {
+  context('Caller is an admin', function () {
+    context('Provided expiration extends', function () {
       it('extends whitelist expiration', async function () {
         await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.admin.address, AdminStatus.Admin);
         const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
@@ -160,7 +160,7 @@ describe('extendWhitelistExpiration', function () {
         ).to.equal(expiration);
       });
     });
-    describe('Provided expiration does not extend', function () {
+    context('Provided expiration does not extend', function () {
       it('reverts', async function () {
         await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.admin.address, AdminStatus.Admin);
         const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
@@ -172,8 +172,8 @@ describe('extendWhitelistExpiration', function () {
       });
     });
   });
-  describe('Caller is a super admin', async function () {
-    describe('Provided expiration extends', function () {
+  context('Caller is a super admin', async function () {
+    context('Provided expiration extends', function () {
       it('extends whitelist expiration', async function () {
         await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.superAdmin.address, AdminStatus.SuperAdmin);
         const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
@@ -191,7 +191,7 @@ describe('extendWhitelistExpiration', function () {
         ).to.equal(expiration);
       });
     });
-    describe('Provided expiration does not extend', function () {
+    context('Provided expiration does not extend', function () {
       it('reverts', async function () {
         await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.superAdmin.address, AdminStatus.SuperAdmin);
         const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
@@ -205,9 +205,9 @@ describe('extendWhitelistExpiration', function () {
       });
     });
   });
-  describe('Caller is the meta admin', function () {
-    describe('Provided airnodeId-clientAddress pair is whitelisted', function () {
-      describe('Provided expiration extends', function () {
+  context('Caller is the meta admin', function () {
+    context('Provided airnodeId-clientAddress pair is whitelisted', function () {
+      context('Provided expiration extends', function () {
         it('extends whitelist expiration', async function () {
           const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
           await api3Authorizer.connect(roles.metaAdmin).extendWhitelistExpiration(airnodeId, roles.client.address, now);
@@ -224,7 +224,7 @@ describe('extendWhitelistExpiration', function () {
           ).to.equal(expiration);
         });
       });
-      describe('Provided expiration does not extend', function () {
+      context('Provided expiration does not extend', function () {
         it('reverts', async function () {
           const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
           await api3Authorizer.connect(roles.metaAdmin).extendWhitelistExpiration(airnodeId, roles.client.address, now);
@@ -238,7 +238,7 @@ describe('extendWhitelistExpiration', function () {
       });
     });
   });
-  describe('Caller is not an admin', function () {
+  context('Caller is not an admin', function () {
     it('reverts', async function () {
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
       await expect(
@@ -249,7 +249,7 @@ describe('extendWhitelistExpiration', function () {
 });
 
 describe('setWhitelistExpiration', function () {
-  describe('Caller is a super admin', async function () {
+  context('Caller is a super admin', async function () {
     it('sets whitelist expiration', async function () {
       await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.superAdmin.address, AdminStatus.SuperAdmin);
 
@@ -265,7 +265,7 @@ describe('setWhitelistExpiration', function () {
       ).to.equal(expiration);
     });
   });
-  describe('Caller is the meta admin', async function () {
+  context('Caller is the meta admin', async function () {
     it('sets whitelist expiration', async function () {
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
       const expiration = now + 100;
@@ -280,7 +280,7 @@ describe('setWhitelistExpiration', function () {
     });
   });
 
-  describe('Caller is an admin', function () {
+  context('Caller is an admin', function () {
     it('reverts', async function () {
       await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.admin.address, AdminStatus.Admin);
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
@@ -289,7 +289,7 @@ describe('setWhitelistExpiration', function () {
       ).to.be.revertedWith('Unauthorized');
     });
   });
-  describe('Caller is not an admin', function () {
+  context('Caller is not an admin', function () {
     it('reverts', async function () {
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
       await expect(
@@ -300,7 +300,7 @@ describe('setWhitelistExpiration', function () {
 });
 
 describe('setWhitelistStatus', function () {
-  describe('Caller is a super admin', async function () {
+  context('Caller is a super admin', async function () {
     it('sets whitelist status', async function () {
       await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.superAdmin.address, AdminStatus.SuperAdmin);
 
@@ -333,7 +333,7 @@ describe('setWhitelistStatus', function () {
   });
 });
 
-describe('Caller is a meta admin', async function () {
+context('Caller is a meta admin', async function () {
   it('sets whitelist status', async function () {
     await expect(api3Authorizer.connect(roles.metaAdmin).setWhitelistStatus(airnodeId, roles.client.address, true))
       .to.emit(api3Authorizer, 'SetWhitelistStatus')
@@ -361,7 +361,7 @@ describe('Caller is a meta admin', async function () {
   });
 });
 
-describe('Caller is an admin', function () {
+context('Caller is an admin', function () {
   it('reverts', async function () {
     await api3Authorizer.connect(roles.metaAdmin).setAdminStatus(roles.admin.address, AdminStatus.Admin);
     await expect(
@@ -369,7 +369,7 @@ describe('Caller is an admin', function () {
     ).to.be.revertedWith('Unauthorized');
   });
 });
-describe('Caller is not an admin', function () {
+context('Caller is not an admin', function () {
   it('reverts', async function () {
     await expect(
       api3Authorizer.connect(roles.randomPerson).setWhitelistStatus(airnodeId, roles.client.address, true)
@@ -378,9 +378,9 @@ describe('Caller is not an admin', function () {
 });
 
 describe('isAuthorized', function () {
-  describe('Designated wallet balance is not zero', function () {
-    describe('Client is whitelisted', function () {
-      describe('Client whitelisting has not expired', function () {
+  context('Designated wallet balance is not zero', function () {
+    context('Client is whitelisted', function () {
+      context('Client whitelisting has not expired', function () {
         it('returns true', async function () {
           const designatedWallet = ethers.Wallet.createRandom();
           await roles.client.sendTransaction({
@@ -402,7 +402,7 @@ describe('isAuthorized', function () {
           ).to.equal(true);
         });
       });
-      describe('Client whitelisting has expired and whitelist status has not been set', function () {
+      context('Client whitelisting has expired and whitelist status has not been set', function () {
         it('returns false', async function () {
           const designatedWallet = ethers.Wallet.createRandom();
           await roles.client.sendTransaction({
@@ -422,7 +422,7 @@ describe('isAuthorized', function () {
         });
       });
     });
-    describe('Client whitelisting was set then revoked', function () {
+    context('Client whitelisting was set then revoked', function () {
       it('returns false', async function () {
         const designatedWallet = ethers.Wallet.createRandom();
         await roles.client.sendTransaction({
@@ -456,7 +456,7 @@ describe('isAuthorized', function () {
       });
     });
   });
-  describe('Designated wallet balance is zero', function () {
+  context('Designated wallet balance is zero', function () {
     it('returns false', async function () {
       const designatedWallet = ethers.Wallet.createRandom();
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;

--- a/packages/protocol/test/authorizers/SelfAuthorizer.sol.js
+++ b/packages/protocol/test/authorizers/SelfAuthorizer.sol.js
@@ -1,4 +1,4 @@
-/* globals ethers */
+/* globals context ethers */
 
 const { expect } = require('chai');
 
@@ -39,13 +39,13 @@ beforeEach(async () => {
 });
 
 describe('constructor', function () {
-  describe('Airnode RRP address is non-zero', function () {
+  context('Airnode RRP address is non-zero', function () {
     it('initializes correctly', async function () {
       expect(await selfAuthorizer.authorizerType()).to.equal(2);
       expect(await selfAuthorizer.airnodeRrp()).to.equal(airnodeRrp.address);
     });
   });
-  describe('Airnode RRP address is zero', function () {
+  context('Airnode RRP address is zero', function () {
     it('reverts', async function () {
       const selfAuthorizerFactory = await ethers.getContractFactory('SelfAuthorizer', roles.deployer);
       await expect(selfAuthorizerFactory.deploy(ethers.constants.AddressZero)).to.be.revertedWith('Zero address');
@@ -54,7 +54,7 @@ describe('constructor', function () {
 });
 
 describe('setAdminStatus', function () {
-  describe('Caller is the Airnode admin', async function () {
+  context('Caller is the Airnode admin', async function () {
     it('sets admin status', async function () {
       // Give admin status
       await expect(
@@ -100,7 +100,7 @@ describe('setAdminStatus', function () {
       );
     });
   });
-  describe('Caller is not the Airnode admin', async function () {
+  context('Caller is not the Airnode admin', async function () {
     it('reverts', async function () {
       await expect(
         selfAuthorizer.connect(roles.randomPerson).setAdminStatus(airnodeId, roles.admin.address, AdminStatus.Admin)
@@ -115,7 +115,7 @@ describe('setAdminStatus', function () {
 });
 
 describe('renounceAdminStatus', function () {
-  describe('Caller is an admin', async function () {
+  context('Caller is an admin', async function () {
     it('renounces admin status', async function () {
       await selfAuthorizer
         .connect(roles.airnodeAdmin)
@@ -128,7 +128,7 @@ describe('renounceAdminStatus', function () {
       );
     });
   });
-  describe('Caller is a super admin', async function () {
+  context('Caller is a super admin', async function () {
     it('renounces admin status', async function () {
       await selfAuthorizer
         .connect(roles.airnodeAdmin)
@@ -141,7 +141,7 @@ describe('renounceAdminStatus', function () {
       );
     });
   });
-  describe('Caller is not an admin', async function () {
+  context('Caller is not an admin', async function () {
     it('reverts', async function () {
       await expect(selfAuthorizer.connect(roles.randomPerson).renounceAdminStatus(airnodeId)).to.be.revertedWith(
         'Unauthorized'
@@ -151,8 +151,8 @@ describe('renounceAdminStatus', function () {
 });
 
 describe('extendWhitelistExpiration', function () {
-  describe('Caller is an admin', function () {
-    describe('Provided expiration extends', function () {
+  context('Caller is an admin', function () {
+    context('Provided expiration extends', function () {
       it('extends whitelist expiration', async function () {
         await selfAuthorizer
           .connect(roles.airnodeAdmin)
@@ -169,7 +169,7 @@ describe('extendWhitelistExpiration', function () {
         ).to.equal(expiration);
       });
     });
-    describe('Provided expiration does not extend', function () {
+    context('Provided expiration does not extend', function () {
       it('reverts', async function () {
         await selfAuthorizer
           .connect(roles.airnodeAdmin)
@@ -183,8 +183,8 @@ describe('extendWhitelistExpiration', function () {
       });
     });
   });
-  describe('Caller is a super admin', async function () {
-    describe('Provided expiration extends', function () {
+  context('Caller is a super admin', async function () {
+    context('Provided expiration extends', function () {
       it('extends whitelist expiration', async function () {
         await selfAuthorizer
           .connect(roles.airnodeAdmin)
@@ -203,7 +203,7 @@ describe('extendWhitelistExpiration', function () {
         ).to.equal(expiration);
       });
     });
-    describe('Provided expiration does not extend', function () {
+    context('Provided expiration does not extend', function () {
       it('reverts', async function () {
         await selfAuthorizer
           .connect(roles.airnodeAdmin)
@@ -219,8 +219,8 @@ describe('extendWhitelistExpiration', function () {
       });
     });
   });
-  describe('Caller is the Airnode admin', function () {
-    describe('Provided expiration extends', function () {
+  context('Caller is the Airnode admin', function () {
+    context('Provided expiration extends', function () {
       it('extends whitelist expiration', async function () {
         const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
         const expiration = now + 100;
@@ -236,7 +236,7 @@ describe('extendWhitelistExpiration', function () {
         ).to.equal(expiration);
       });
     });
-    describe('Provided expiration does not extend', function () {
+    context('Provided expiration does not extend', function () {
       it('reverts', async function () {
         const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
         await selfAuthorizer
@@ -251,7 +251,7 @@ describe('extendWhitelistExpiration', function () {
       });
     });
   });
-  describe('Caller is not an admin', function () {
+  context('Caller is not an admin', function () {
     it('reverts', async function () {
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
       await expect(
@@ -262,7 +262,7 @@ describe('extendWhitelistExpiration', function () {
 });
 
 describe('setWhitelistExpiration', function () {
-  describe('Caller is a super admin', async function () {
+  context('Caller is a super admin', async function () {
     it('sets whitelist expiration', async function () {
       await selfAuthorizer
         .connect(roles.airnodeAdmin)
@@ -287,7 +287,7 @@ describe('setWhitelistExpiration', function () {
       ).to.equal(now);
     });
   });
-  describe('Caller is the Airnode admin', async function () {
+  context('Caller is the Airnode admin', async function () {
     it('sets whitelist expiration', async function () {
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
       const expiration = now + 100;
@@ -309,7 +309,7 @@ describe('setWhitelistExpiration', function () {
       ).to.equal(now);
     });
   });
-  describe('Caller is an admin', function () {
+  context('Caller is an admin', function () {
     it('reverts', async function () {
       await selfAuthorizer
         .connect(roles.airnodeAdmin)
@@ -320,7 +320,7 @@ describe('setWhitelistExpiration', function () {
       ).to.be.revertedWith('Unauthorized');
     });
   });
-  describe('Caller is not an admin', function () {
+  context('Caller is not an admin', function () {
     it('reverts', async function () {
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
       await expect(
@@ -331,7 +331,7 @@ describe('setWhitelistExpiration', function () {
 });
 
 describe('setWhitelistStatus', function () {
-  describe('Caller is a super admin', async function () {
+  context('Caller is a super admin', async function () {
     it('sets Whitelist status', async function () {
       await selfAuthorizer
         .connect(roles.airnodeAdmin)
@@ -350,7 +350,7 @@ describe('setWhitelistStatus', function () {
       );
     });
   });
-  describe('Caller is the Airnode admin', async function () {
+  context('Caller is the Airnode admin', async function () {
     it('sets whitelist expiration', async function () {
       await expect(selfAuthorizer.connect(roles.airnodeAdmin).setWhitelistStatus(airnodeId, roles.client.address, true))
         .to.emit(selfAuthorizer, 'SetWhitelistStatus')
@@ -368,7 +368,7 @@ describe('setWhitelistStatus', function () {
       );
     });
   });
-  describe('Caller is an admin', function () {
+  context('Caller is an admin', function () {
     it('reverts', async function () {
       await selfAuthorizer
         .connect(roles.airnodeAdmin)
@@ -378,7 +378,7 @@ describe('setWhitelistStatus', function () {
       ).to.be.revertedWith('Unauthorized');
     });
   });
-  describe('Caller is not an admin', function () {
+  context('Caller is not an admin', function () {
     it('reverts', async function () {
       await expect(
         selfAuthorizer.connect(roles.randomPerson).setWhitelistStatus(airnodeId, roles.client.address, true)
@@ -388,9 +388,9 @@ describe('setWhitelistStatus', function () {
 });
 
 describe('isAuthorized', function () {
-  describe('Designated wallet balance is not zero', function () {
-    describe('Client is not Whitelisted', function () {
-      describe('Client whitelisting has not expired', function () {
+  context('Designated wallet balance is not zero', function () {
+    context('Client is not Whitelisted', function () {
+      context('Client whitelisting has not expired', function () {
         it('returns true', async function () {
           const designatedWallet = ethers.Wallet.createRandom();
           await roles.client.sendTransaction({
@@ -414,7 +414,7 @@ describe('isAuthorized', function () {
           ).to.equal(true);
         });
       });
-      describe('Client whitelisting has expired and whitelisting has not been set', function () {
+      context('Client whitelisting has expired and whitelisting has not been set', function () {
         it('returns false', async function () {
           const designatedWallet = ethers.Wallet.createRandom();
           await roles.client.sendTransaction({
@@ -434,7 +434,7 @@ describe('isAuthorized', function () {
         });
       });
     });
-    describe('Client whitelisting was set then revoked', function () {
+    context('Client whitelisting was set then revoked', function () {
       it('returns false', async function () {
         const designatedWallet = ethers.Wallet.createRandom();
         await roles.client.sendTransaction({
@@ -466,7 +466,7 @@ describe('isAuthorized', function () {
       });
     });
   });
-  describe('Designated wallet balance is zero', function () {
+  context('Designated wallet balance is zero', function () {
     it('returns false', async function () {
       const designatedWallet = ethers.Wallet.createRandom();
       const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;


### PR DESCRIPTION
### Description

In a recent PR, I removed some `context()` functions as I mistakenly thought the `protocol` package was using Jest. The `protocol` package uses `hardhat` which in turn uses Mocha. This PR reverts this change.