### PR TITLE
Fixes operation package after removing airnodeAdmin and requesterAdmin from the protocol contracts

### DIFF
--- a/packages/operation/src/evm/deploy/account-assignment.ts
+++ b/packages/operation/src/evm/deploy/account-assignment.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
-import { deriveExtendedPublicKey, deriveWalletFromPath } from '../utils';
 import { Airnode, DeployState as State, RequesterAccount } from '../../types';
+import { addressToDerivationPath, deriveExtendedPublicKey, deriveWalletFromPath } from '../utils';
 
 export async function assignAirnodeAccounts(state: State): Promise<State> {
   const airnodesByName: { [name: string]: Airnode } = {};
@@ -20,29 +20,14 @@ export async function assignAirnodeAccounts(state: State): Promise<State> {
 }
 
 export async function assignRequesterAccounts(state: State): Promise<State> {
-  const { AirnodeRrp } = state.contracts;
-
   const requestersById: { [id: string]: RequesterAccount } = {};
   for (const configRequester of state.config.requesters) {
     const requesterWallet = ethers.Wallet.createRandom().connect(state.provider);
     const requesterAddress = requesterWallet.address;
 
-    const tx = await AirnodeRrp!.connect(state.deployer).createRequester(requesterAddress);
-    await tx.wait();
-
-    const logs = await state.provider.getLogs({
-      fromBlock: 0,
-      address: AirnodeRrp!.address,
-    });
-
-    const log = logs.find((log) => log.transactionHash === tx.hash);
-    const parsedLog = AirnodeRrp!.interface.parseLog(log!);
-    const requesterIndex = parsedLog.args.requesterIndex;
-
     requestersById[configRequester.id] = {
       address: requesterAddress,
       designatedWallets: [],
-      requesterIndex,
       signer: requesterWallet,
     };
   }
@@ -58,7 +43,11 @@ export async function assignDesignatedWallets(state: State) {
 
     const designatedWallets = designatedAirnodeNames.map((airnodeName) => {
       const airnode = state.airnodesByName[airnodeName];
-      const wallet = deriveWalletFromPath(airnode.mnemonic, `m/0/${requester.requesterIndex}`, state.provider);
+      const wallet = deriveWalletFromPath(
+        airnode.mnemonic,
+        `m/0/${addressToDerivationPath(requester.address)}`,
+        state.provider
+      );
       return {
         address: wallet.address,
         airnodeName: airnodeName,

--- a/packages/operation/src/evm/deploy/airnodes.ts
+++ b/packages/operation/src/evm/deploy/airnodes.ts
@@ -10,7 +10,7 @@ export async function setAirnodeParameters(state: State): Promise<State> {
 
     const tx = await state.contracts
       .AirnodeRrp!.connect(airnode.signer)
-      .setAirnodeParametersAndForwardFunds(configAirnode.airnodeAdmin, airnode.xpub, authorizers, {
+      .setAirnodeParameters(airnode.xpub, authorizers, {
         value: ethers.utils.parseEther('1'),
       });
 

--- a/packages/operation/src/evm/deploy/requesters.ts
+++ b/packages/operation/src/evm/deploy/requesters.ts
@@ -12,9 +12,7 @@ export async function endorseClients(state: State): Promise<State> {
     for (const requesterId of configClient.endorsers) {
       const requester = state.requestersById[requesterId];
 
-      const tx = await AirnodeRrp!
-        .connect(requester.signer)
-        .setClientEndorsementStatus(requester.requesterIndex, client.address, true);
+      const tx = await AirnodeRrp!.connect(requester.signer).setClientEndorsementStatus(client.address, true);
 
       await tx.wait();
     }

--- a/packages/operation/src/evm/deploy/state.ts
+++ b/packages/operation/src/evm/deploy/state.ts
@@ -74,7 +74,6 @@ export function buildSaveableDeployment(state: State): Deployment {
       address: requester.address,
       id: configRequester.id,
       privateKey: requester.signer.privateKey,
-      requesterIndex: requester.requesterIndex.toString(),
     };
     return [...acc, data];
   }, []);

--- a/packages/operation/src/evm/utils.ts
+++ b/packages/operation/src/evm/utils.ts
@@ -25,6 +25,21 @@ export function getDesignatedWallet(mnemonic: string, requester: string, provide
   return deriveWalletFromPath(mnemonic, `m/0/${addressToDerivationPath(requester)}`, provider);
 }
 
+/**
+ * HD wallets allow us to create multiple accounts from a single mnemonic.
+ * Each requester creates a designated wallet for each provider to use
+ * in order for them to be able to respond to the requests their clients make.
+ *
+ * By convention derivation paths start with a master index
+ * followed by child indexes that can be any integer up to 2^31.
+ *
+ * Since addresses can be represented as 160bits (20bytes) we can then
+ * split it in chunks of 31bits and create a path with the following pattern:
+ * m/0/1st31bits/2nd31bits/3rd31bits/4th31bits/5th31bits/6th31bits.
+ *
+ * @param address A string representing a 20bytes hex address
+ * @returns The path derived from the address
+ */
 export function addressToDerivationPath(address: string): string {
   const requesterBN = ethers.BigNumber.from(address);
   const paths = [];

--- a/packages/operation/src/evm/utils.ts
+++ b/packages/operation/src/evm/utils.ts
@@ -21,10 +21,17 @@ export function deriveWalletFromPath(mnemonic: string, path: string, provider: e
   return new ethers.Wallet(designatorHdNode.privateKey, provider);
 }
 
-export function getDesignatedWallet(
-  mnemonic: string,
-  requesterIndex: string,
-  provider: ethers.providers.JsonRpcProvider
-) {
-  return deriveWalletFromPath(mnemonic, `m/0/${requesterIndex}`, provider);
+export function getDesignatedWallet(mnemonic: string, requester: string, provider: ethers.providers.JsonRpcProvider) {
+  return deriveWalletFromPath(mnemonic, `m/0/${addressToDerivationPath(requester)}`, provider);
+}
+
+export function addressToDerivationPath(address: string): string {
+  const requesterBN = ethers.BigNumber.from(address);
+  const paths = [];
+  // eslint-disable-next-line functional/no-let
+  for (let i = 0; i < 6; i++) {
+    const shiftedRequesterBN = requesterBN.shr(31 * i);
+    paths.push(shiftedRequesterBN.mask(31).toString());
+  }
+  return paths.join('/');
 }

--- a/packages/operation/src/types.ts
+++ b/packages/operation/src/types.ts
@@ -38,7 +38,6 @@ export interface DesignatedWallet {
 export interface RequesterAccount {
   readonly address: string;
   readonly designatedWallets: DesignatedWallet[];
-  readonly requesterIndex: ethers.BigNumber;
   readonly signer: ethers.Wallet;
 }
 
@@ -81,7 +80,6 @@ export interface DeployedRequester {
   readonly address: string;
   readonly id: string;
   readonly privateKey: string;
-  readonly requesterIndex: string;
 }
 
 // Deployment should ideally mirror the structure of the config file, but with


### PR DESCRIPTION
Had to disable `functional/no-let` es-lint rule because I wanted to use a for loop. Only disabled the rule in that particular line and not in the local es-lint file because I get the feeling that this function might be moved to a shared package since it's being used in multiple places.

Tests:
ran successfully:
1. `dev:background`
2. `dev:eth-deploy`
3. `dev:eth-requests`

`dev:invoke` failed because node package needs to be fixed first.