### PR TITLE
Splits airnodeToAnnouncement mapping into airnodeToPublicKey and airnodeToAuthorizers mappings

### DIFF
--- a/packages/protocol/contracts/rrp/interfaces/IConvenienceUtils.sol
+++ b/packages/protocol/contracts/rrp/interfaces/IConvenienceUtils.sol
@@ -2,21 +2,23 @@
 pragma solidity 0.8.6;
 
 interface IConvenienceUtils {
-    event SetAirnodeAnnouncement(
-        address airnode,
-        string xpub,
-        address[] authorizers
-    );
+    event SetAirnodePublicKey(address indexed airnode, string xpub);
 
-    function setAirnodeAnnouncement(
-        string calldata xpub,
-        address[] calldata authorizers
-    ) external;
+    event SetAirnodeAuthorizers(address indexed airnode, address[] authorizers);
 
-    function getAirnodeAnnouncement(address airnode)
+    function setAirnodePublicKey(string calldata xpub) external;
+
+    function setAirnodeAuthorizers(address[] calldata authorizers) external;
+
+    function getAirnodePublicKey(address airnode)
         external
         view
-        returns (string memory xpub, address[] memory authorizers);
+        returns (string memory xpub);
+
+    function getAirnodeAuthorizers(address airnode)
+        external
+        view
+        returns (address[] memory authorizers);
 
     function checkAuthorizationStatus(
         address[] calldata authorizers,

--- a/packages/protocol/test/ConvenienceUtils.sol.js
+++ b/packages/protocol/test/ConvenienceUtils.sol.js
@@ -33,32 +33,49 @@ beforeEach(async () => {
   });
 });
 
-describe('setAirnodeAnnouncement', function () {
-  it('sets Airnode announcement', async function () {
-    const initialAnnouncement = await airnodeRrp.getAirnodeAnnouncement(airnodeAddress);
-    expect(initialAnnouncement.xpub).to.equal('');
-    expect(initialAnnouncement.authorizers).to.deep.equal([]);
+describe('setAirnodePublicKey', function () {
+  it('sets Airnode public key', async function () {
+    const initialPublicKey = await airnodeRrp.getAirnodePublicKey(airnodeAddress);
+    expect(initialPublicKey).to.equal('');
     const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic).connect(hre.ethers.provider);
-    const authorizers = Array.from({ length: 5 }, () => utils.generateRandomAddress());
-    await expect(
-      airnodeRrp.connect(airnodeWallet).setAirnodeAnnouncement(airnodeXpub, authorizers, { gasLimit: 500000 })
-    )
-      .to.emit(airnodeRrp, 'SetAirnodeAnnouncement')
-      .withArgs(airnodeAddress, airnodeXpub, authorizers);
-    const setAnnouncement = await airnodeRrp.getAirnodeAnnouncement(airnodeAddress);
-    expect(setAnnouncement.xpub).to.equal(airnodeXpub);
-    expect(setAnnouncement.authorizers).to.deep.equal(authorizers);
+    await expect(airnodeRrp.connect(airnodeWallet).setAirnodePublicKey(airnodeXpub, { gasLimit: 500000 }))
+      .to.emit(airnodeRrp, 'SetAirnodePublicKey')
+      .withArgs(airnodeAddress, airnodeXpub);
+    const setPublicKey = await airnodeRrp.getAirnodePublicKey(airnodeAddress);
+    expect(setPublicKey).to.equal(airnodeXpub);
   });
 });
 
-describe('getAirnodeAnnouncement', function () {
-  it('gets Airnode announcement', async function () {
+describe('setAirnodeAuthorizers', function () {
+  it('sets Airnode authorizers', async function () {
+    const initialAuthorizers = await airnodeRrp.getAirnodeAuthorizers(airnodeAddress);
+    expect(initialAuthorizers.authorizers).to.be.undefined;
     const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic).connect(hre.ethers.provider);
     const authorizers = Array.from({ length: 5 }, () => utils.generateRandomAddress());
-    await airnodeRrp.connect(airnodeWallet).setAirnodeAnnouncement(airnodeXpub, authorizers, { gasLimit: 500000 });
-    const setAnnouncement = await airnodeRrp.getAirnodeAnnouncement(airnodeAddress);
-    expect(setAnnouncement.xpub).to.equal(airnodeXpub);
-    expect(setAnnouncement.authorizers).to.deep.equal(authorizers);
+    await expect(airnodeRrp.connect(airnodeWallet).setAirnodeAuthorizers(authorizers, { gasLimit: 500000 }))
+      .to.emit(airnodeRrp, 'SetAirnodeAuthorizers')
+      .withArgs(airnodeAddress, authorizers);
+    const setAuthorizers = await airnodeRrp.getAirnodeAuthorizers(airnodeAddress);
+    expect(setAuthorizers).to.deep.equal(authorizers);
+  });
+});
+
+describe('getAirnodePublicKey', function () {
+  it('gets Airnode public key', async function () {
+    const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic).connect(hre.ethers.provider);
+    await airnodeRrp.connect(airnodeWallet).setAirnodePublicKey(airnodeXpub, { gasLimit: 500000 });
+    const setPublicKey = await airnodeRrp.getAirnodePublicKey(airnodeAddress);
+    expect(setPublicKey).to.equal(airnodeXpub);
+  });
+});
+
+describe('getAirnodeAuthorizers', function () {
+  it('gets Airnode authorizers', async function () {
+    const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic).connect(hre.ethers.provider);
+    const authorizers = Array.from({ length: 5 }, () => utils.generateRandomAddress());
+    await airnodeRrp.connect(airnodeWallet).setAirnodeAuthorizers(authorizers, { gasLimit: 500000 });
+    const setAuthorizers = await airnodeRrp.getAirnodeAuthorizers(airnodeAddress);
+    expect(setAuthorizers).to.deep.equal(authorizers);
   });
 });
 


### PR DESCRIPTION
I wanted to make both mappings `public` in order to get automagic getters for them but I ended up creating `getAirnodePublicKey` and `getAirnodeAuthorizers` functions because the automatic getter for `airnodeToAuthorizers` was expecting 2 arguments (airnode address and index for authorizer array).

I expect `setAirnodePublicKey` to be called maybe only once while `setAirnodeAuthorizers` multiple times.