### PR TITLE
Xpub fixes

### DIFF
--- a/packages/protocol/contracts/admin/interfaces/IWhitelister.sol
+++ b/packages/protocol/contracts/admin/interfaces/IWhitelister.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.6;
 
 import "./IRankedAdminnable.sol";
 
-interface IWhitelister is IRankedAdminnable{
+interface IWhitelister is IRankedAdminnable {
     event ExtendedWhitelistExpiration(
         bytes32 indexed serviceId,
         address indexed user,

--- a/packages/protocol/contracts/rrp/ConvenienceUtils.sol
+++ b/packages/protocol/contracts/rrp/ConvenienceUtils.sol
@@ -6,27 +6,29 @@ import "./authorizers/interfaces/IRrpAuthorizer.sol";
 
 /// @title Contract that implements convenience functions
 contract ConvenienceUtils is IConvenienceUtils {
-    mapping(address => string) private airnodeToPublicKey;
+    /// @notice Called to get the extended public key of the Airnode
+    mapping(address => string) public override airnodeToXpub;
+
     mapping(address => address[]) private airnodeToAuthorizers;
 
-    /// @notice Called by the Airnode operator to set it's public key
+    /// @notice Called by the Airnode operator to announce its extended public
+    /// key
     /// @dev It is expected for the Airnode operator to call this function with
     /// the respective Airnode's default BIP 44 wallet (m/44'/60'/0'/0/0).
-    /// This public key set does not need to be made for the protocol to be used,
-    /// it is mainly for convenience.
+    /// This extended public key does not need to be announced on-chain for the
+    /// protocol to be used, it is mainly for convenience.
     /// @param xpub Extended public key of the Airnode
-    function setAirnodePublicKey(string calldata xpub) external override {
-        airnodeToPublicKey[msg.sender] = xpub;
-        emit SetAirnodePublicKey(msg.sender, xpub);
+    function setAirnodeXpub(string calldata xpub) external override {
+        airnodeToXpub[msg.sender] = xpub;
+        emit SetAirnodeXpub(msg.sender, xpub);
     }
 
-    /// @notice Called by the Airnode operator to set authorizers
+    /// @notice Called by the Airnode operator to announce the addresses of the
+    /// authorizer contracts it uses
     /// @dev It is expected for the Airnode operator to call this function with
     /// the respective Airnode's default BIP 44 wallet (m/44'/60'/0'/0/0).
-    /// This authorizers set does not need to be made for the protocol to be used,
-    /// it is mainly for convenience. This is only to allow the Airnode operator
-    /// to announce the authorizers it will be using. It is a trusted on-chain
-    /// announcement similar to xpub.
+    /// These authorizer contract addresses do not need to be announced
+    /// on-chain for the protocol to be used, it is mainly for convenience.
     /// @param authorizers Authorizer contract addresses that Airnode uses
     function setAirnodeAuthorizers(address[] calldata authorizers)
         external
@@ -34,21 +36,6 @@ contract ConvenienceUtils is IConvenienceUtils {
     {
         airnodeToAuthorizers[msg.sender] = authorizers;
         emit SetAirnodeAuthorizers(msg.sender, authorizers);
-    }
-
-    /// @notice Called to get the Airnode public key
-    /// @dev The information announced with this function is not trustless.
-    /// It is up to the user to verify that the announced `xpub` is correct by
-    /// checking if its default BIP 44 wallet matches the Airnode address.
-    /// @param airnode Airnode address
-    /// @return xpub Extended public key of the Airnode
-    function getAirnodePublicKey(address airnode)
-        external
-        view
-        override
-        returns (string memory xpub)
-    {
-        return airnodeToPublicKey[airnode];
     }
 
     /// @notice Called to get the Airnode authorizers

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3RequesterRrpAuthorizer.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3RequesterRrpAuthorizer.sol
@@ -4,4 +4,7 @@ pragma solidity 0.8.6;
 import "../../../admin/interfaces/IMetaAdminnable.sol";
 import "./IRequesterRrpAuthorizer.sol";
 
-interface IApi3RequesterRrpAuthorizer is IMetaAdminnable, IRequesterRrpAuthorizer {}
+interface IApi3RequesterRrpAuthorizer is
+    IMetaAdminnable,
+    IRequesterRrpAuthorizer
+{}

--- a/packages/protocol/contracts/rrp/interfaces/IConvenienceUtils.sol
+++ b/packages/protocol/contracts/rrp/interfaces/IConvenienceUtils.sol
@@ -2,18 +2,13 @@
 pragma solidity 0.8.6;
 
 interface IConvenienceUtils {
-    event SetAirnodePublicKey(address indexed airnode, string xpub);
+    event SetAirnodeXpub(address indexed airnode, string xpub);
 
     event SetAirnodeAuthorizers(address indexed airnode, address[] authorizers);
 
-    function setAirnodePublicKey(string calldata xpub) external;
+    function setAirnodeXpub(string calldata xpub) external;
 
     function setAirnodeAuthorizers(address[] calldata authorizers) external;
-
-    function getAirnodePublicKey(address airnode)
-        external
-        view
-        returns (string memory xpub);
 
     function getAirnodeAuthorizers(address airnode)
         external
@@ -37,4 +32,9 @@ interface IConvenienceUtils {
         address[] calldata sponsors,
         address[] calldata requesters
     ) external view returns (bool[] memory statuses);
+
+    function airnodeToXpub(address airnode)
+        external
+        view
+        returns (string memory xpub);
 }

--- a/packages/protocol/test/ConvenienceUtils.sol.js
+++ b/packages/protocol/test/ConvenienceUtils.sol.js
@@ -33,15 +33,15 @@ beforeEach(async () => {
   });
 });
 
-describe('setAirnodePublicKey', function () {
+describe('setAirnodeXpub', function () {
   it('sets Airnode public key', async function () {
-    const initialPublicKey = await airnodeRrp.getAirnodePublicKey(airnodeAddress);
+    const initialPublicKey = await airnodeRrp.airnodeToXpub(airnodeAddress);
     expect(initialPublicKey).to.equal('');
     const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic).connect(hre.ethers.provider);
-    await expect(airnodeRrp.connect(airnodeWallet).setAirnodePublicKey(airnodeXpub, { gasLimit: 500000 }))
-      .to.emit(airnodeRrp, 'SetAirnodePublicKey')
+    await expect(airnodeRrp.connect(airnodeWallet).setAirnodeXpub(airnodeXpub, { gasLimit: 500000 }))
+      .to.emit(airnodeRrp, 'SetAirnodeXpub')
       .withArgs(airnodeAddress, airnodeXpub);
-    const setPublicKey = await airnodeRrp.getAirnodePublicKey(airnodeAddress);
+    const setPublicKey = await airnodeRrp.airnodeToXpub(airnodeAddress);
     expect(setPublicKey).to.equal(airnodeXpub);
   });
 });
@@ -57,15 +57,6 @@ describe('setAirnodeAuthorizers', function () {
       .withArgs(airnodeAddress, authorizers);
     const setAuthorizers = await airnodeRrp.getAirnodeAuthorizers(airnodeAddress);
     expect(setAuthorizers).to.deep.equal(authorizers);
-  });
-});
-
-describe('getAirnodePublicKey', function () {
-  it('gets Airnode public key', async function () {
-    const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic).connect(hre.ethers.provider);
-    await airnodeRrp.connect(airnodeWallet).setAirnodePublicKey(airnodeXpub, { gasLimit: 500000 });
-    const setPublicKey = await airnodeRrp.getAirnodePublicKey(airnodeAddress);
-    expect(setPublicKey).to.equal(airnodeXpub);
   });
 });
 


### PR DESCRIPTION
Public key and extended public key are different things, so renamed references to the public key as xpub.
We only need a getter for the authorizers, so made the xpub mapping public and removed the respective getter.
Please review and merge yourselves.