### PR TITLE
Api3TokenLock Integration and tests

### DIFF
--- a/packages/protocol/contracts/rrp/authorizers/Api3TokenLock.sol
+++ b/packages/protocol/contracts/rrp/authorizers/Api3TokenLock.sol
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import "./Api3RequesterRrpAuthorizer.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "./interfaces/IApi3Token.sol";
+import "./interfaces/IApi3TokenLock.sol";
+
+/// @title The contract used to lock API3 Tokens in order to gain access to Airnodes
+contract Api3TokenLock is IApi3TokenLock, Ownable {
+    string private constant ERROR_UNAUTHORIZED = "Unauthorized";
+    string private constant ERROR_ZERO_ADDRESS = "Zero address";
+    string private constant ERROR_ZERO_AMOUNT = "Zero amount";
+    string private constant ERROR_INSUFFICIENT_AMOUNT = "Insufficient amount";
+    string private constant ERROR_ALREADY_LOCKED = "Already locked";
+    string private constant ERROR_NOT_LOCKED = "No amount locked";
+    string private constant ERROR_LOCK_PERIOD_NOT_EXPIRED =
+        "Locking period not expired";
+    string private constant ERROR_LOCK_PERIOD_ZERO = "Zero lock period";
+    string private constant ERROR_CLIENT_BLACKLISTED = "Client blacklisted";
+    string private constant ERROR_CLIENT_NOT_BLACKLISTED =
+        "Client not blacklisted";
+
+    /// @dev Address of api3RequesterRrpAuthorizer contract
+    address public api3RequesterRrpAuthorizer;
+    /// @dev Address of Api3Token
+    address public api3Token;
+    /// @dev The Minimum locking time (in seconds)
+    uint256 public minimumLockingTime;
+    /// @dev Lock amount for each user
+    uint256 public lockAmount;
+
+    /// @dev Represents the locked amounts, periods and whitelist counts
+    /// of an airnode-client pair
+    struct AirnodeClient {
+        mapping(address => uint256) lockAmountAt;
+        mapping(address => uint256) canUnlockAt;
+        uint256 whitelistCount;
+    }
+
+    /// @dev Meta admin sets the admin statuses of addresses and has super
+    /// admin privileges
+    address public metaAdmin;
+    /// @dev Stores information about admins
+    mapping(address => AdminStatus) public adminStatuses;
+
+    /// @dev Stores information about all token locks for airnode-client pair
+    mapping(bytes32 => mapping(address => AirnodeClient)) public tokenLocks;
+
+    /// @dev Stores information for blacklisted clients
+    mapping(address => bool) public clientAddressToBlacklistStatus;
+
+    /// @dev Sets the values for {_metaAdmin}, {_minimumLockingTime} and {_lockAmount}
+    /// @param _metaAdmin The address that will be set as meta admin
+    /// @param _minimumLockingTime The minimum lock time of API3 tokens for users
+    /// @param _lockAmount The lock amount
+    constructor(
+        address _metaAdmin,
+        uint256 _minimumLockingTime,
+        uint256 _lockAmount
+    ) {
+        require(_metaAdmin != address(0), ERROR_ZERO_ADDRESS);
+        require(_lockAmount != 0, ERROR_ZERO_AMOUNT);
+
+        minimumLockingTime = _minimumLockingTime;
+        lockAmount = _lockAmount;
+        metaAdmin = _metaAdmin;
+    }
+
+    /// @notice Called by the meta admin to set the meta admin
+    /// @param _metaAdmin Address that will be set as the meta admin
+    function setMetaAdmin(address _metaAdmin) external override {
+        require(msg.sender == metaAdmin, ERROR_UNAUTHORIZED);
+        require(_metaAdmin != address(0), ERROR_ZERO_ADDRESS);
+        metaAdmin = _metaAdmin;
+        emit SetMetaAdmin(metaAdmin);
+    }
+
+    /// @notice Called by the meta admin to set the admin status of an address
+    /// @param _admin Address whose admin status will be set
+    /// @param _status Admin status
+    function setAdminStatus(address _admin, AdminStatus _status)
+        external
+        override
+    {
+        require(msg.sender == metaAdmin, ERROR_UNAUTHORIZED);
+        adminStatuses[_admin] = _status;
+        emit SetAdminStatus(_admin, _status);
+    }
+
+    /// @notice Called by admin to set the address of the API3 Authorizer contract
+    /// @param _api3RequesterRrpAuthorizer Address of the new API3 Authorizer
+    function setApi3RequesterRrpAuthorizer(address _api3RequesterRrpAuthorizer)
+        external
+        override
+    {
+        require(
+            adminStatuses[msg.sender] == AdminStatus.Admin,
+            ERROR_UNAUTHORIZED
+        );
+        require(_api3RequesterRrpAuthorizer != address(0), ERROR_ZERO_ADDRESS);
+        api3RequesterRrpAuthorizer = _api3RequesterRrpAuthorizer;
+        emit SetApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer);
+    }
+
+    /// @notice Called by admin to set the address of the API3 Token
+    /// @param _api3Token Address of the new API3 Token
+    function setApi3Token(address _api3Token) external override {
+        require(
+            adminStatuses[msg.sender] == AdminStatus.Admin,
+            ERROR_UNAUTHORIZED
+        );
+        require(_api3Token != address(0), ERROR_ZERO_ADDRESS);
+        api3Token = _api3Token;
+
+        bool isBurner = IApi3Token(api3Token).getBurnerStatus(address(this));
+        if (!isBurner) {
+            IApi3Token(api3Token).updateBurnerStatus(true);
+        }
+
+        emit SetApi3Token(api3Token);
+    }
+
+    /// @notice Called by owner to set the minimum locking time
+    /// @param _minimumLockingTime The new minimum locking time
+    function setMinimumLockingTime(uint256 _minimumLockingTime)
+        external
+        override
+        onlyOwner
+    {
+        minimumLockingTime = _minimumLockingTime;
+        emit SetMinimumLockingTime(_minimumLockingTime);
+    }
+
+    /// @notice Called by owner to set the locking amount
+    /// @param _lockAmount The new lock amount
+    function setLockAmount(uint256 _lockAmount) external override onlyOwner {
+        require(_lockAmount != 0, ERROR_ZERO_AMOUNT);
+        lockAmount = _lockAmount;
+        emit SetLockAmount(_lockAmount);
+    }
+
+    /// @notice Called by owner to set the blacklist status of a client
+    /// @param clientAddress Client address
+    /// @param status Blacklist status to be set
+    function setBlacklistStatus(address clientAddress, bool status)
+        external
+        override
+        onlyOwner
+    {
+        clientAddressToBlacklistStatus[clientAddress] = status;
+        emit SetBlacklistStatus(clientAddress, status, msg.sender);
+    }
+
+    /// @notice Locks API3 Tokens to gain access to Airnodes.
+    /// Airnode-client pair gets authorized as long as there is at least one token lock for given pair.
+    /// @dev The amount to be locked is determined by a memory variable set by
+    /// the owners of the contract.
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    function lock(bytes32 _airnodeId, address _clientAddress)
+        external
+        override
+    {
+        AirnodeClient storage airnodeClient = tokenLocks[_airnodeId][
+            _clientAddress
+        ];
+        require(
+            airnodeClient.lockAmountAt[msg.sender] == 0,
+            ERROR_ALREADY_LOCKED
+        );
+        require(
+            !clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_BLACKLISTED
+        );
+
+        uint256 expirationTime = block.timestamp + minimumLockingTime;
+        airnodeClient.lockAmountAt[msg.sender] = lockAmount;
+        airnodeClient.canUnlockAt[msg.sender] = expirationTime;
+        airnodeClient.whitelistCount++;
+
+        assert(
+            IApi3Token(api3Token).transferFrom(
+                msg.sender,
+                address(this),
+                lockAmount
+            )
+        );
+
+        if (airnodeClient.whitelistCount == 1) {
+            IApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer)
+                .setWhitelistExpiration(
+                _airnodeId,
+                _clientAddress,
+                type(uint64).max
+            );
+        }
+
+        emit Lock(_airnodeId, _clientAddress, msg.sender, lockAmount);
+    }
+
+    /// @notice Unlocks the API3 tokens for a given airnode-client pair.
+    /// Airnode-client pair will be unauthorized if no token lock for the pair is found.
+    /// @dev Checks whether the user (msg.sender) has already locked anything,
+    /// if the locked period has expired and if the client address is blacklisted
+    /// Transfers to msg.sender the locked amount.
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    function unlock(bytes32 _airnodeId, address _clientAddress)
+        external
+        override
+    {
+        AirnodeClient storage airnodeClient = tokenLocks[_airnodeId][
+            _clientAddress
+        ];
+        require(airnodeClient.lockAmountAt[msg.sender] != 0, ERROR_NOT_LOCKED);
+        require(
+            airnodeClient.canUnlockAt[msg.sender] != 0,
+            ERROR_LOCK_PERIOD_ZERO
+        );
+        require(
+            airnodeClient.canUnlockAt[msg.sender] <= block.timestamp,
+            ERROR_LOCK_PERIOD_NOT_EXPIRED
+        );
+        require(
+            !clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_BLACKLISTED
+        );
+        uint256 amount = airnodeClient.lockAmountAt[msg.sender];
+
+        airnodeClient.lockAmountAt[msg.sender] = 0;
+        airnodeClient.canUnlockAt[msg.sender] = 0;
+        airnodeClient.whitelistCount--;
+
+        if (airnodeClient.whitelistCount == 0) {
+            IApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer)
+                .setWhitelistExpiration(_airnodeId, _clientAddress, 0);
+        }
+
+        assert(IApi3Token(api3Token).transfer(msg.sender, amount));
+
+        emit Unlock(_airnodeId, _clientAddress, msg.sender, amount);
+    }
+
+    /// @notice User calls this when the lock amount has been decreased and wants
+    /// to withdraw the redundantly locked tokens
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    function withdraw(bytes32 _airnodeId, address _clientAddress)
+        external
+        override
+    {
+        require(
+            tokenLocks[_airnodeId][_clientAddress].lockAmountAt[msg.sender] >
+                lockAmount,
+            ERROR_INSUFFICIENT_AMOUNT
+        );
+        require(
+            !clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_BLACKLISTED
+        );
+        uint256 withdrawAmount = tokenLocks[_airnodeId][_clientAddress]
+        .lockAmountAt[msg.sender] - lockAmount;
+        tokenLocks[_airnodeId][_clientAddress].lockAmountAt[
+            msg.sender
+        ] = lockAmount;
+        assert(IApi3Token(api3Token).transfer(msg.sender, withdrawAmount));
+
+        emit Withdraw(_airnodeId, _clientAddress, msg.sender, withdrawAmount);
+    }
+
+    /// @notice Transfers the user's lock period and tokens to another client
+    /// @param _airnodeId The airnode id
+    /// @param _fromClientAddress The client from which the transfer will be done
+    /// @param _toClientAddress The target client to which the transfer will be done
+    function transfer(
+        bytes32 _airnodeId,
+        address _fromClientAddress,
+        address _toClientAddress
+    ) external override {
+        AirnodeClient storage from = tokenLocks[_airnodeId][_fromClientAddress];
+        AirnodeClient storage to = tokenLocks[_airnodeId][_toClientAddress];
+        require(
+            from.lockAmountAt[msg.sender] != 0,
+            "locked amount must be != 0"
+        );
+        require(to.lockAmountAt[msg.sender] == 0, "locked amount must be 0");
+        require(
+            !clientAddressToBlacklistStatus[_fromClientAddress],
+            "From Client blacklisted"
+        );
+        require(
+            !clientAddressToBlacklistStatus[_toClientAddress],
+            "To Client blacklisted"
+        );
+
+        uint256 amount = from.lockAmountAt[msg.sender];
+        from.lockAmountAt[msg.sender] = 0;
+        to.lockAmountAt[msg.sender] = amount;
+
+        uint256 expirationTime = from.canUnlockAt[msg.sender];
+        from.canUnlockAt[msg.sender] = 0;
+        to.canUnlockAt[msg.sender] = expirationTime;
+
+        from.whitelistCount--;
+        if (from.whitelistCount == 0) {
+            IApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer)
+                .setWhitelistExpiration(_airnodeId, _fromClientAddress, 0);
+        }
+
+        to.whitelistCount++;
+        if (to.whitelistCount == 1) {
+            IApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer)
+                .setWhitelistExpiration(
+                _airnodeId,
+                _toClientAddress,
+                type(uint64).max
+            );
+        }
+
+        emit Transfer(
+            _airnodeId,
+            _fromClientAddress,
+            _toClientAddress,
+            msg.sender,
+            amount,
+            expirationTime
+        );
+    }
+
+    /// @notice Burns tokens for a user of an airnode-client pair.
+    /// Can only be done when the client is blacklisted.
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    /// @param _burnTarget The address of the user
+    function burn(
+        bytes32 _airnodeId,
+        address _clientAddress,
+        address _burnTarget
+    ) external override {
+        AirnodeClient storage airnodeClient = tokenLocks[_airnodeId][
+            _clientAddress
+        ];
+        require(
+            airnodeClient.lockAmountAt[_burnTarget] != 0,
+            ERROR_ZERO_AMOUNT
+        );
+        require(
+            clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_NOT_BLACKLISTED
+        );
+
+        uint256 amount = airnodeClient.lockAmountAt[_burnTarget];
+
+        airnodeClient.canUnlockAt[_burnTarget] = 0;
+        airnodeClient.lockAmountAt[_burnTarget] = 0;
+        airnodeClient.whitelistCount--;
+
+        if (airnodeClient.whitelistCount == 0) {
+            IApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer)
+                .setWhitelistExpiration(_airnodeId, _clientAddress, 0);
+        }
+
+        IApi3Token(api3Token).burn(amount);
+
+        emit Burn(_airnodeId, _clientAddress, _burnTarget);
+    }
+
+    /// @dev Returns the locked amount for a target address to an airnode-client pair
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    /// @param _target The address of the user
+    function lockAmountAt(
+        bytes32 _airnodeId,
+        address _clientAddress,
+        address _target
+    ) public view returns (uint256) {
+        return tokenLocks[_airnodeId][_clientAddress].lockAmountAt[_target];
+    }
+
+    /// @dev Returns the unlock period for a target address to an airnode-client pair
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    /// @param _target The address of the user
+    function canUnlockAt(
+        bytes32 _airnodeId,
+        address _clientAddress,
+        address _target
+    ) public view returns (uint256) {
+        return tokenLocks[_airnodeId][_clientAddress].canUnlockAt[_target];
+    }
+}

--- a/packages/protocol/contracts/rrp/authorizers/Api3TokenLock.sol
+++ b/packages/protocol/contracts/rrp/authorizers/Api3TokenLock.sol
@@ -5,10 +5,9 @@ import "./Api3RequesterRrpAuthorizer.sol";
 import "./interfaces/IApi3Token.sol";
 import "./interfaces/IApi3TokenLock.sol";
 import "../../admin/MetaAdminnable.sol";
-import "../../admin/RankedAdminnable.sol";
 
 /// @title The contract used to lock API3 Tokens in order to gain access to Airnodes
-contract Api3TokenLock is RankedAdminnable, MetaAdminnable, IApi3TokenLock {
+contract Api3TokenLock is MetaAdminnable, IApi3TokenLock {
     enum AdminRank {
         Unauthorized,
         Admin
@@ -76,9 +75,10 @@ contract Api3TokenLock is RankedAdminnable, MetaAdminnable, IApi3TokenLock {
     function getRank(bytes32 adminnedId, address admin)
         public
         view
-        override(MetaAdminnable, RankedAdminnable)
+        override(MetaAdminnable)
         returns (uint256)
     {
+        if (adminnedId == bytes32(abi.encode(admin))) return MAX_RANK;
         return MetaAdminnable.getRank(bytes32(0), admin);
     }
 
@@ -160,7 +160,7 @@ contract Api3TokenLock is RankedAdminnable, MetaAdminnable, IApi3TokenLock {
         address _airnode,
         address _requesterAddress,
         bool _status
-    ) external override onlyWithRank(bytes32(0), MAX_RANK) {
+    ) external override onlyWithRank(bytes32(abi.encode(_airnode)), MAX_RANK) {
         airnodeToRequesterToBlacklistStatus[_airnode][
             _requesterAddress
         ] = _status;

--- a/packages/protocol/contracts/rrp/authorizers/Api3TokenLockExternal.sol
+++ b/packages/protocol/contracts/rrp/authorizers/Api3TokenLockExternal.sol
@@ -4,14 +4,9 @@ pragma solidity 0.8.6;
 import "./interfaces/IApi3Token.sol";
 import "./interfaces/IApi3TokenLockExternal.sol";
 import "../../admin/MetaAdminnable.sol";
-import "../../admin/RankedAdminnable.sol";
 
 /// @title The contract used to lock API3 Tokens in order to gain access to Airnodes
-contract Api3TokenLockExternal is
-    RankedAdminnable,
-    MetaAdminnable,
-    IApi3TokenLockExternal
-{
+contract Api3TokenLockExternal is MetaAdminnable, IApi3TokenLockExternal {
     enum AdminRank {
         Unauthorized,
         Admin
@@ -77,7 +72,7 @@ contract Api3TokenLockExternal is
     function getRank(bytes32 adminnedId, address admin)
         public
         view
-        override(MetaAdminnable, RankedAdminnable)
+        override(MetaAdminnable)
         returns (uint256)
     {
         if (adminnedId == bytes32(abi.encode(admin))) return MAX_RANK;

--- a/packages/protocol/contracts/rrp/authorizers/Api3TokenLockExternal.sol
+++ b/packages/protocol/contracts/rrp/authorizers/Api3TokenLockExternal.sol
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "./interfaces/IApi3Token.sol";
+import "./interfaces/IApi3TokenLockExternal.sol";
+
+/// @title The contract used to lock API3 Tokens in order to gain access to Airnodes
+contract Api3TokenLockExternal is IApi3TokenLockExternal, Ownable {
+    string private constant ERROR_UNAUTHORIZED = "Unauthorized";
+    string private constant ERROR_ZERO_ADDRESS = "Zero address";
+    string private constant ERROR_ZERO_AMOUNT = "Zero amount";
+    string private constant ERROR_INSUFFICIENT_AMOUNT = "Insufficient amount";
+    string private constant ERROR_ALREADY_LOCKED = "Already locked";
+    string private constant ERROR_NOT_LOCKED = "No amount locked";
+    string private constant ERROR_LOCK_PERIOD_NOT_EXPIRED =
+        "Locking period not expired";
+    string private constant ERROR_LOCK_PERIOD_ZERO = "Zero lock period";
+    string private constant ERROR_CLIENT_BLACKLISTED = "Client blacklisted";
+    string private constant ERROR_CLIENT_NOT_BLACKLISTED =
+        "Client not blacklisted";
+
+    /// @dev Address of Api3Token
+    address public api3Token;
+    /// @dev The Minimum locking time (in seconds)
+    uint256 public minimumLockingTime;
+    /// @dev Lock amount for each user
+    uint256 public lockAmount;
+
+    /// @dev Represents the locked amounts, periods and whitelist counts
+    /// of a chainId-airnode-client pair
+    struct AirnodeClient {
+        mapping(address => uint256) lockAmountAt;
+        mapping(address => uint256) canUnlockAt;
+        uint256 whitelistCount;
+    }
+
+    /// @dev Meta admin sets the admin statuses of addresses and has super
+    /// admin privileges
+    address public metaAdmin;
+    /// @dev Stores information about admins
+    mapping(address => AdminStatus) public adminStatuses;
+
+    /// @dev Stores information about all token locks for chainId-airnode-client pair
+    mapping(uint256 => mapping(bytes32 => mapping(address => AirnodeClient)))
+        public tokenLocks;
+
+    /// @dev Stores information for blacklisted clients
+    mapping(address => bool) public clientAddressToBlacklistStatus;
+
+    /// @dev Sets the values for {_metaAdmin}, {_minimumLockingTime} and {_lockAmount}
+    /// @param _metaAdmin The address that will be set as meta admin
+    /// @param _minimumLockingTime The minimum lock time of API3 tokens for users
+    /// @param _lockAmount The lock amount
+    constructor(
+        address _metaAdmin,
+        uint256 _minimumLockingTime,
+        uint256 _lockAmount
+    ) {
+        require(_metaAdmin != address(0), ERROR_ZERO_ADDRESS);
+        require(_lockAmount != 0, ERROR_ZERO_AMOUNT);
+
+        minimumLockingTime = _minimumLockingTime;
+        lockAmount = _lockAmount;
+        metaAdmin = _metaAdmin;
+    }
+
+    /// @notice Called by the meta admin to set the meta admin
+    /// @param _metaAdmin Address that will be set as the meta admin
+    function setMetaAdmin(address _metaAdmin) external override {
+        require(msg.sender == metaAdmin, ERROR_UNAUTHORIZED);
+        require(_metaAdmin != address(0), ERROR_ZERO_ADDRESS);
+        metaAdmin = _metaAdmin;
+        emit SetMetaAdmin(metaAdmin);
+    }
+
+    /// @notice Called by the meta admin to set the admin status of an address
+    /// @param _admin Address whose admin status will be set
+    /// @param _status Admin status
+    function setAdminStatus(address _admin, AdminStatus _status)
+        external
+        override
+    {
+        require(msg.sender == metaAdmin, ERROR_UNAUTHORIZED);
+        adminStatuses[_admin] = _status;
+        emit SetAdminStatus(_admin, _status);
+    }
+
+    /// @notice Called by admin to set the address of the API3 Token
+    /// @param _api3Token Address of the new API3 Token
+    function setApi3Token(address _api3Token) external override {
+        require(
+            adminStatuses[msg.sender] == AdminStatus.Admin,
+            ERROR_UNAUTHORIZED
+        );
+        require(_api3Token != address(0), ERROR_ZERO_ADDRESS);
+        api3Token = _api3Token;
+
+        bool isBurner = IApi3Token(api3Token).getBurnerStatus(address(this));
+        if (!isBurner) {
+            IApi3Token(api3Token).updateBurnerStatus(true);
+        }
+
+        emit SetApi3Token(api3Token);
+    }
+
+    /// @notice Called by owner to set the minimum locking time
+    /// @param _minimumLockingTime The new minimum locking time
+    function setMinimumLockingTime(uint256 _minimumLockingTime)
+        external
+        override
+        onlyOwner
+    {
+        minimumLockingTime = _minimumLockingTime;
+        emit SetMinimumLockingTime(_minimumLockingTime);
+    }
+
+    /// @notice Called by owner to set the locking amount
+    /// @param _lockAmount The new lock amount
+    function setLockAmount(uint256 _lockAmount) external override onlyOwner {
+        require(_lockAmount != 0, ERROR_ZERO_AMOUNT);
+        lockAmount = _lockAmount;
+        emit SetLockAmount(_lockAmount);
+    }
+
+    /// @notice Called by owner to set the blacklist status of a client
+    /// @param clientAddress Client address
+    /// @param status Blacklist status to be set
+    function setBlacklistStatus(address clientAddress, bool status)
+        external
+        override
+        onlyOwner
+    {
+        clientAddressToBlacklistStatus[clientAddress] = status;
+        emit SetBlacklistStatus(clientAddress, status, msg.sender);
+    }
+
+    /// @notice Locks API3 Tokens to gain access to Airnodes on a given chain.
+    /// Airnode-client pair gets authorized as long as there is at least one token lock for given pair.
+    /// @dev The amount to be locked is determined by a memory variable set by
+    /// the owners of the contract.
+    /// @param _chainId The chain id
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    function lock(
+        uint256 _chainId,
+        bytes32 _airnodeId,
+        address _clientAddress
+    ) external override {
+        AirnodeClient storage target = tokenLocks[_chainId][_airnodeId][
+            _clientAddress
+        ];
+        require(target.lockAmountAt[msg.sender] == 0, ERROR_ALREADY_LOCKED);
+        require(
+            !clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_BLACKLISTED
+        );
+
+        uint256 expirationTime = block.timestamp + minimumLockingTime;
+        target.lockAmountAt[msg.sender] = lockAmount;
+        target.canUnlockAt[msg.sender] = expirationTime;
+        target.whitelistCount++;
+
+        assert(
+            IApi3Token(api3Token).transferFrom(
+                msg.sender,
+                address(this),
+                lockAmount
+            )
+        );
+
+        if (target.whitelistCount == 1) {
+            emit Authorize(
+                _chainId,
+                _airnodeId,
+                _clientAddress,
+                type(uint64).max
+            );
+        }
+
+        emit Lock(_chainId, _airnodeId, _clientAddress, msg.sender, lockAmount);
+    }
+
+    /// @notice Unlocks the API3 tokens for a given airnode-client pair on a given chain.
+    /// Airnode-client pair will be unauthorized if no token lock for the pair is found.
+    /// @dev Checks whether the user (msg.sender) has already locked anything,
+    /// if the locked period has expired and if the client address is blacklisted
+    /// Transfers to msg.sender the locked amount.
+    /// @param _chainId The chain id
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    function unlock(
+        uint256 _chainId,
+        bytes32 _airnodeId,
+        address _clientAddress
+    ) external override {
+        AirnodeClient storage target = tokenLocks[_chainId][_airnodeId][
+            _clientAddress
+        ];
+        require(target.lockAmountAt[msg.sender] != 0, ERROR_NOT_LOCKED);
+        require(target.canUnlockAt[msg.sender] != 0, ERROR_LOCK_PERIOD_ZERO);
+        require(
+            target.canUnlockAt[msg.sender] <= block.timestamp,
+            ERROR_LOCK_PERIOD_NOT_EXPIRED
+        );
+        require(
+            !clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_BLACKLISTED
+        );
+        uint256 amount = target.lockAmountAt[msg.sender];
+
+        target.lockAmountAt[msg.sender] = 0;
+        target.canUnlockAt[msg.sender] = 0;
+        target.whitelistCount--;
+
+        if (target.whitelistCount == 0) {
+            emit Authorize(_chainId, _airnodeId, _clientAddress, 0);
+        }
+
+        assert(IApi3Token(api3Token).transfer(msg.sender, amount));
+
+        emit Unlock(_chainId, _airnodeId, _clientAddress, msg.sender, amount);
+    }
+
+    /// @notice User calls this when the lock amount has been decreased and wants
+    /// to withdraw the redundantly locked tokens
+    /// @param _chainId The chain id
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    function withdraw(
+        uint256 _chainId,
+        bytes32 _airnodeId,
+        address _clientAddress
+    ) external override {
+        require(
+            tokenLocks[_chainId][_airnodeId][_clientAddress].lockAmountAt[
+                msg.sender
+            ] > lockAmount,
+            ERROR_INSUFFICIENT_AMOUNT
+        );
+        require(
+            !clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_BLACKLISTED
+        );
+
+        uint256 withdrawAmount = tokenLocks[_chainId][_airnodeId][
+            _clientAddress
+        ]
+        .lockAmountAt[msg.sender] - lockAmount;
+        tokenLocks[_chainId][_airnodeId][_clientAddress].lockAmountAt[
+            msg.sender
+        ] = lockAmount;
+
+        assert(IApi3Token(api3Token).transfer(msg.sender, withdrawAmount));
+
+        emit Withdraw(
+            _chainId,
+            _airnodeId,
+            _clientAddress,
+            msg.sender,
+            withdrawAmount
+        );
+    }
+
+    /// @notice Transfers the user's lock period and tokens to another client
+    /// @param _chainId The chain id
+    /// @param _airnodeId The airnode id
+    /// @param _fromClientAddress The client from which the transfer will be done
+    /// @param _toClientAddress The target client to which the transfer will be done
+    function transfer(
+        uint256 _chainId,
+        bytes32 _airnodeId,
+        address _fromClientAddress,
+        address _toClientAddress
+    ) external override {
+        AirnodeClient storage from = tokenLocks[_chainId][_airnodeId][
+            _fromClientAddress
+        ];
+        AirnodeClient storage to = tokenLocks[_chainId][_airnodeId][
+            _toClientAddress
+        ];
+        require(
+            from.lockAmountAt[msg.sender] != 0,
+            "locked amount must be != 0"
+        );
+        require(to.lockAmountAt[msg.sender] == 0, "locked amount must be 0");
+        require(
+            !clientAddressToBlacklistStatus[_fromClientAddress],
+            "From Client blacklisted"
+        );
+        require(
+            !clientAddressToBlacklistStatus[_toClientAddress],
+            "To Client blacklisted"
+        );
+
+        uint256 amount = from.lockAmountAt[msg.sender];
+        from.lockAmountAt[msg.sender] = 0;
+        to.lockAmountAt[msg.sender] = amount;
+
+        uint256 expirationTime = from.canUnlockAt[msg.sender];
+        from.canUnlockAt[msg.sender] = 0;
+        to.canUnlockAt[msg.sender] = expirationTime;
+
+        from.whitelistCount--;
+        if (from.whitelistCount == 0) {
+            emit Authorize(_chainId, _airnodeId, _fromClientAddress, 0);
+        }
+
+        to.whitelistCount++;
+        if (to.whitelistCount == 1) {
+            emit Authorize(
+                _chainId,
+                _airnodeId,
+                _toClientAddress,
+                type(uint64).max
+            );
+        }
+
+        emit Transfer(
+            _chainId,
+            _airnodeId,
+            _fromClientAddress,
+            _toClientAddress,
+            msg.sender,
+            amount,
+            expirationTime
+        );
+    }
+
+    /// @notice Burns tokens for a user of an airnode-client pair.
+    /// Can only be done when the client is blacklisted.
+    /// @param _chainId The chain id
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    /// @param _burnTarget The address of the user
+    function burn(
+        uint256 _chainId,
+        bytes32 _airnodeId,
+        address _clientAddress,
+        address _burnTarget
+    ) external override {
+        AirnodeClient storage target = tokenLocks[_chainId][_airnodeId][
+            _clientAddress
+        ];
+        require(target.lockAmountAt[_burnTarget] != 0, ERROR_ZERO_AMOUNT);
+        require(
+            clientAddressToBlacklistStatus[_clientAddress],
+            ERROR_CLIENT_NOT_BLACKLISTED
+        );
+
+        uint256 amount = target.lockAmountAt[_burnTarget];
+
+        target.canUnlockAt[_burnTarget] = 0;
+        target.lockAmountAt[_burnTarget] = 0;
+        target.whitelistCount--;
+
+        if (target.whitelistCount == 0) {
+            emit Authorize(_chainId, _airnodeId, _clientAddress, 0);
+        }
+
+        IApi3Token(api3Token).burn(amount);
+
+        emit Burn(_chainId, _airnodeId, _clientAddress, _burnTarget);
+    }
+
+    /// @dev Returns the locked amount for a target address to a chainId-airnode-client
+    /// @param _chainId The chain id
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    /// @param _target The address of the user
+    function lockAmountAt(
+        uint256 _chainId,
+        bytes32 _airnodeId,
+        address _clientAddress,
+        address _target
+    ) public view returns (uint256) {
+        return
+            tokenLocks[_chainId][_airnodeId][_clientAddress].lockAmountAt[
+                _target
+            ];
+    }
+
+    /// @dev Returns the unlock period for a target address to a chainId-airnode-client
+    /// @param _chainId The chain id
+    /// @param _airnodeId The airnode id
+    /// @param _clientAddress The client address
+    /// @param _target The address of the user
+    function canUnlockAt(
+        uint256 _chainId,
+        bytes32 _airnodeId,
+        address _clientAddress,
+        address _target
+    ) public view returns (uint256) {
+        return
+            tokenLocks[_chainId][_airnodeId][_clientAddress].canUnlockAt[
+                _target
+            ];
+    }
+}

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3Token.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3Token.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IApi3Token is IERC20 {
+    event MinterStatusUpdated(address indexed minterAddress, bool minterStatus);
+
+    event BurnerStatusUpdated(address indexed burnerAddress, bool burnerStatus);
+
+    function updateMinterStatus(address minterAddress, bool minterStatus)
+        external;
+
+    function updateBurnerStatus(bool burnerStatus) external;
+
+    function mint(address account, uint256 amount) external;
+
+    function burn(uint256 amount) external;
+
+    function getMinterStatus(address minterAddress)
+        external
+        view
+        returns (bool minterStatus);
+
+    function getBurnerStatus(address burnerAddress)
+        external
+        view
+        returns (bool burnerStatus);
+}

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3Token.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3Token.sol
@@ -17,11 +17,6 @@ interface IApi3Token is IERC20 {
 
     function burn(uint256 amount) external;
 
-    function getMinterStatus(address minterAddress)
-        external
-        view
-        returns (bool minterStatus);
-
     function getBurnerStatus(address burnerAddress)
         external
         view

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLock.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLock.sol
@@ -2,15 +2,6 @@
 pragma solidity 0.8.6;
 
 interface IApi3TokenLock {
-    enum AdminStatus {
-        Unauthorized,
-        Admin
-    }
-
-    event SetMetaAdmin(address metaAdmin);
-
-    event SetAdminStatus(address indexed admin, AdminStatus status);
-
     event SetApi3RequesterRrpAuthorizer(address api3RequesterRrpAuthorizer);
 
     event SetApi3Token(address api3Token);
@@ -20,45 +11,42 @@ interface IApi3TokenLock {
     event SetLockAmount(uint256 lockAmount);
 
     event SetBlacklistStatus(
-        address indexed clientAddress,
+        address airnode,
+        address indexed requesterAddress,
         bool status,
         address indexed admin
     );
 
     event Lock(
-        bytes32 airnodeId,
-        address clientAddress,
-        address requester,
+        address airnode,
+        address requesterAddress,
+        address sponsor,
         uint256 lockedAmount
     );
 
     event Unlock(
-        bytes32 airnodeId,
-        address clientAddress,
-        address requester,
+        address airnode,
+        address requesterAddress,
+        address sponsor,
         uint256 lockedAmount
     );
 
     event Transfer(
-        bytes32 airnodeId,
-        address fromClientAddress,
-        address toClientAddress,
-        address requester,
+        address airnode,
+        address fromRequesterAddress,
+        address toRequesterAddress,
+        address sponsor,
         uint256 amount,
         uint256 expirationTime
     );
-    event Burn(bytes32 airnodeId, address clientAddress, address requester);
+    event Burn(address airnode, address requesterAddress, address sponsor);
 
     event Withdraw(
-        bytes32 airnodeId,
-        address clientAddress,
-        address requester,
+        address airnode,
+        address requesterAddress,
+        address sponsor,
         uint256 amount
     );
-
-    function setMetaAdmin(address metaAdmin) external;
-
-    function setAdminStatus(address admin, AdminStatus status) external;
 
     function setApi3RequesterRrpAuthorizer(address api3RequesterRrpAuthorizer)
         external;
@@ -69,23 +57,27 @@ interface IApi3TokenLock {
 
     function setLockAmount(uint256 lockAmount) external;
 
-    function setBlacklistStatus(address clientAddress, bool status) external;
+    function setBlacklistStatus(
+        address airnode,
+        address requesterAddress,
+        bool status
+    ) external;
 
-    function lock(bytes32 airnodeId, address clientAddress) external;
+    function lock(address airnode, address requesterAddress) external;
 
-    function unlock(bytes32 airnodeId, address clientAddress) external;
+    function unlock(address airnode, address requesterAddress) external;
 
-    function withdraw(bytes32 airnodeId, address clientAddress) external;
+    function withdraw(address airnode, address requesterAddress) external;
 
     function transfer(
-        bytes32 airnodeId,
-        address fromClientAddress,
-        address toClientAddress
+        address airnode,
+        address fromRequesterAddress,
+        address toRequesterAddress
     ) external;
 
     function burn(
-        bytes32 airnodeId,
-        address clientAddress,
+        address airnode,
+        address requesterAddress,
         address burnTarget
     ) external;
 }

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLock.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLock.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+interface IApi3TokenLock {
+    enum AdminStatus {
+        Unauthorized,
+        Admin
+    }
+
+    event SetMetaAdmin(address metaAdmin);
+
+    event SetAdminStatus(address indexed admin, AdminStatus status);
+
+    event SetApi3RequesterRrpAuthorizer(address api3RequesterRrpAuthorizer);
+
+    event SetApi3Token(address api3Token);
+
+    event SetMinimumLockingTime(uint256 minimumLockingTime);
+
+    event SetLockAmount(uint256 lockAmount);
+
+    event SetBlacklistStatus(
+        address indexed clientAddress,
+        bool status,
+        address indexed admin
+    );
+
+    event Lock(
+        bytes32 airnodeId,
+        address clientAddress,
+        address requester,
+        uint256 lockedAmount
+    );
+
+    event Unlock(
+        bytes32 airnodeId,
+        address clientAddress,
+        address requester,
+        uint256 lockedAmount
+    );
+
+    event Transfer(
+        bytes32 airnodeId,
+        address fromClientAddress,
+        address toClientAddress,
+        address requester,
+        uint256 amount,
+        uint256 expirationTime
+    );
+    event Burn(bytes32 airnodeId, address clientAddress, address requester);
+
+    event Withdraw(
+        bytes32 airnodeId,
+        address clientAddress,
+        address requester,
+        uint256 amount
+    );
+
+    function setMetaAdmin(address metaAdmin) external;
+
+    function setAdminStatus(address admin, AdminStatus status) external;
+
+    function setApi3RequesterRrpAuthorizer(address api3RequesterRrpAuthorizer)
+        external;
+
+    function setApi3Token(address api3Token) external;
+
+    function setMinimumLockingTime(uint256 minimumLockingTime) external;
+
+    function setLockAmount(uint256 lockAmount) external;
+
+    function setBlacklistStatus(address clientAddress, bool status) external;
+
+    function lock(bytes32 airnodeId, address clientAddress) external;
+
+    function unlock(bytes32 airnodeId, address clientAddress) external;
+
+    function withdraw(bytes32 airnodeId, address clientAddress) external;
+
+    function transfer(
+        bytes32 airnodeId,
+        address fromClientAddress,
+        address toClientAddress
+    ) external;
+
+    function burn(
+        bytes32 airnodeId,
+        address clientAddress,
+        address burnTarget
+    ) external;
+}

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLockExternal.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLockExternal.sol
@@ -35,8 +35,8 @@ interface IApi3TokenLockExternal {
     event Transfer(
         uint256 chainId,
         address airnode,
-        address fromClientAddress,
-        address toClientAddress,
+        address fromRequesterAddress,
+        address toRequesterAddress,
         address sponsor,
         uint256 amount,
         uint256 expirationTime
@@ -97,8 +97,8 @@ interface IApi3TokenLockExternal {
     function transfer(
         uint256 chainId,
         address airnode,
-        address fromClientAddress,
-        address toClientAddress
+        address fromRequesterAddress,
+        address toRequesterAddress
     ) external;
 
     function burn(

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLockExternal.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLockExternal.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+interface IApi3TokenLockExternal {
+    enum AdminStatus {
+        Unauthorized,
+        Admin
+    }
+
+    event SetMetaAdmin(address metaAdmin);
+
+    event SetAdminStatus(address indexed admin, AdminStatus status);
+
+    event SetApi3Token(address api3Token);
+
+    event SetMinimumLockingTime(uint256 minimumLockingTime);
+
+    event SetLockAmount(uint256 lockAmount);
+
+    event SetBlacklistStatus(
+        address indexed clientAddress,
+        bool status,
+        address indexed admin
+    );
+
+    event Lock(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress,
+        address requester,
+        uint256 lockedAmount
+    );
+
+    event Unlock(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress,
+        address requester,
+        uint256 lockedAmount
+    );
+
+    event Transfer(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address fromClientAddress,
+        address toClientAddress,
+        address requester,
+        uint256 amount,
+        uint256 expirationTime
+    );
+    event Burn(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress,
+        address requester
+    );
+
+    event Withdraw(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress,
+        address requester,
+        uint256 amount
+    );
+
+    event Authorize(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress,
+        uint256 expiration
+    );
+
+    function setMetaAdmin(address metaAdmin) external;
+
+    function setAdminStatus(address admin, AdminStatus status) external;
+
+    function setApi3Token(address api3Token) external;
+
+    function setMinimumLockingTime(uint256 minimumLockingTime) external;
+
+    function setLockAmount(uint256 lockAmount) external;
+
+    function setBlacklistStatus(address clientAddress, bool status) external;
+
+    function lock(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress
+    ) external;
+
+    function unlock(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress
+    ) external;
+
+    function withdraw(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress
+    ) external;
+
+    function transfer(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address fromClientAddress,
+        address toClientAddress
+    ) external;
+
+    function burn(
+        uint256 chainId,
+        bytes32 airnodeId,
+        address clientAddress,
+        address burnTarget
+    ) external;
+}

--- a/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLockExternal.sol
+++ b/packages/protocol/contracts/rrp/authorizers/interfaces/IApi3TokenLockExternal.sol
@@ -2,15 +2,6 @@
 pragma solidity 0.8.6;
 
 interface IApi3TokenLockExternal {
-    enum AdminStatus {
-        Unauthorized,
-        Admin
-    }
-
-    event SetMetaAdmin(address metaAdmin);
-
-    event SetAdminStatus(address indexed admin, AdminStatus status);
-
     event SetApi3Token(address api3Token);
 
     event SetMinimumLockingTime(uint256 minimumLockingTime);
@@ -18,61 +9,59 @@ interface IApi3TokenLockExternal {
     event SetLockAmount(uint256 lockAmount);
 
     event SetBlacklistStatus(
-        address indexed clientAddress,
+        uint256 chainId,
+        address airnode,
+        address indexed requesterAddress,
         bool status,
         address indexed admin
     );
 
     event Lock(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress,
-        address requester,
+        address airnode,
+        address requesterAddress,
+        address sponsor,
         uint256 lockedAmount
     );
 
     event Unlock(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress,
-        address requester,
+        address airnode,
+        address requesterAddress,
+        address sponsor,
         uint256 lockedAmount
     );
 
     event Transfer(
         uint256 chainId,
-        bytes32 airnodeId,
+        address airnode,
         address fromClientAddress,
         address toClientAddress,
-        address requester,
+        address sponsor,
         uint256 amount,
         uint256 expirationTime
     );
     event Burn(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress,
-        address requester
+        address airnode,
+        address requesterAddress,
+        address sponsor
     );
 
     event Withdraw(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress,
-        address requester,
+        address airnode,
+        address requesterAddress,
+        address sponsor,
         uint256 amount
     );
 
     event Authorize(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress,
+        address airnode,
+        address requesterAddress,
         uint256 expiration
     );
-
-    function setMetaAdmin(address metaAdmin) external;
-
-    function setAdminStatus(address admin, AdminStatus status) external;
 
     function setApi3Token(address api3Token) external;
 
@@ -80,37 +69,42 @@ interface IApi3TokenLockExternal {
 
     function setLockAmount(uint256 lockAmount) external;
 
-    function setBlacklistStatus(address clientAddress, bool status) external;
+    function setBlacklistStatus(
+        uint256 chainId,
+        address airnode,
+        address requesterAddress,
+        bool status
+    ) external;
 
     function lock(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress
+        address airnode,
+        address requesterAddress
     ) external;
 
     function unlock(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress
+        address airnode,
+        address requesterAddress
     ) external;
 
     function withdraw(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress
+        address airnode,
+        address requesterAddress
     ) external;
 
     function transfer(
         uint256 chainId,
-        bytes32 airnodeId,
+        address airnode,
         address fromClientAddress,
         address toClientAddress
     ) external;
 
     function burn(
         uint256 chainId,
-        bytes32 airnodeId,
-        address clientAddress,
+        address airnode,
+        address requesterAddress,
         address burnTarget
     ) external;
 }

--- a/packages/protocol/contracts/rrp/authorizers/mock/Api3Token.sol
+++ b/packages/protocol/contracts/rrp/authorizers/mock/Api3Token.sol
@@ -1,0 +1,110 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interfaces/IApi3Token.sol";
+
+/// @title API3 token contract
+/// @notice The API3 token contract is owned by the API3 DAO, which can grant
+/// minting privileges to addresses. Any account is allowed to burn their
+/// tokens, but this functionality is put behind a barrier that requires the
+/// account to make a call to remove.
+contract Api3Token is ERC20, Ownable, IApi3Token {
+    /// @dev If an address is authorized to mint tokens.
+    /// Token minting authorization is granted by the token contract owner
+    /// (i.e., the API3 DAO).
+    mapping(address => bool) private isMinter;
+    /// @dev If an address is authorized to burn tokens.
+    /// Token burning authorization is granted by the address itself, i.e.,
+    /// anyone can declare themselves a token burner.
+    mapping(address => bool) private isBurner;
+
+    /// @param contractOwner Address that will receive the ownership of the
+    /// token contract
+    /// @param mintingDestination Address that the tokens will be minted to
+    constructor(address contractOwner, address mintingDestination)
+        public
+        ERC20("API3", "API3")
+    {
+        transferOwnership(contractOwner);
+        // Initial supply is 100 million (100e6)
+        // We are using ether because the token has 18 decimals like ETH
+        _mint(mintingDestination, 100e6 ether);
+    }
+
+    /// @notice The OpenZeppelin renounceOwnership() implementation is
+    /// overriden to prevent ownership from being renounced accidentally.
+    function renounceOwnership() public override onlyOwner {
+        revert("Ownership cannot be renounced");
+    }
+
+    /// @notice Updates if an address is authorized to mint tokens
+    /// @param minterAddress Address whose minter authorization status will be
+    /// updated
+    /// @param minterStatus Updated minter authorization status
+    function updateMinterStatus(address minterAddress, bool minterStatus)
+        external
+        override
+        onlyOwner
+    {
+        require(
+            isMinter[minterAddress] != minterStatus,
+            "Input will not update state"
+        );
+        isMinter[minterAddress] = minterStatus;
+        emit MinterStatusUpdated(minterAddress, minterStatus);
+    }
+
+    /// @notice Updates if the caller is authorized to burn tokens
+    /// @param burnerStatus Updated minter authorization status
+    function updateBurnerStatus(bool burnerStatus) external override {
+        require(
+            isBurner[msg.sender] != burnerStatus,
+            "Input will not update state"
+        );
+        isBurner[msg.sender] = burnerStatus;
+        emit BurnerStatusUpdated(msg.sender, burnerStatus);
+    }
+
+    /// @notice Mints tokens
+    /// @param account Address that will receive the minted tokens
+    /// @param amount Amount that will be minted
+    function mint(address account, uint256 amount) external override {
+        require(isMinter[msg.sender], "Only minters are allowed to mint");
+        _mint(account, amount);
+    }
+
+    /// @notice Burns caller's tokens
+    /// @param amount Amount that will be burned
+    function burn(uint256 amount) external override {
+        require(isBurner[msg.sender], "Only burners are allowed to burn");
+        _burn(msg.sender, amount);
+    }
+
+    /// @notice Returns if an address is authorized to mint tokens
+    /// @param minterAddress Address whose minter authorization status will be
+    /// returned
+    /// @return minterStatus Minter authorization status
+    function getMinterStatus(address minterAddress)
+        external
+        view
+        override
+        returns (bool minterStatus)
+    {
+        minterStatus = isMinter[minterAddress];
+    }
+
+    /// @notice Returns if an address is authorized to burn tokens
+    /// @param burnerAddress Address whose burner authorization status will be
+    /// returned
+    /// @return burnerStatus Burner authorization status
+    function getBurnerStatus(address burnerAddress)
+        external
+        view
+        override
+        returns (bool burnerStatus)
+    {
+        burnerStatus = isBurner[burnerAddress];
+    }
+}

--- a/packages/protocol/contracts/rrp/authorizers/mock/Api3Token.sol
+++ b/packages/protocol/contracts/rrp/authorizers/mock/Api3Token.sol
@@ -24,7 +24,6 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
     /// token contract
     /// @param mintingDestination Address that the tokens will be minted to
     constructor(address contractOwner, address mintingDestination)
-        public
         ERC20("API3", "API3")
     {
         transferOwnership(contractOwner);
@@ -80,19 +79,6 @@ contract Api3Token is ERC20, Ownable, IApi3Token {
     function burn(uint256 amount) external override {
         require(isBurner[msg.sender], "Only burners are allowed to burn");
         _burn(msg.sender, amount);
-    }
-
-    /// @notice Returns if an address is authorized to mint tokens
-    /// @param minterAddress Address whose minter authorization status will be
-    /// returned
-    /// @return minterStatus Minter authorization status
-    function getMinterStatus(address minterAddress)
-        external
-        view
-        override
-        returns (bool minterStatus)
-    {
-        minterStatus = isMinter[minterAddress];
     }
 
     /// @notice Returns if an address is authorized to burn tokens

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/contracts": "^4.2.0",
     "@typechain/ethers-v5": "^6.0.5",
     "chai": "^4.2.0",
     "copyfiles": "^2.4.1",

--- a/packages/protocol/test/Api3TokenLock.sol.js
+++ b/packages/protocol/test/Api3TokenLock.sol.js
@@ -1,0 +1,702 @@
+/* globals context ethers */
+const { expect } = require('chai');
+const { timeTravel } = require('./utils');
+
+const AdminStatus = {
+  Unauthorized: 0,
+  Admin: 1,
+  SuperAdmin: 2,
+};
+
+let api3TokenLockFactory;
+const ONE_MINUTE_IN_SECONDS = 60;
+const LOCK_AMOUNT = 10;
+const adminnedId = ethers.constants.HashZero;
+
+const Errors = {
+  ClientBlacklisted: 'Client blacklisted',
+  ClientNotBlacklisted: 'Client not blacklisted',
+  FromClientBlacklisted: 'From Client blacklisted',
+  LockPeriodNotExpired: 'Locking period not expired',
+  ToClientBlacklisted: 'To Client blacklisted',
+  Unauthorized: 'Unauthorized',
+  ZeroAddress: 'Zero address',
+  ZeroAmount: 'Zero amount',
+};
+
+const airnodeId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+
+let deployer, metaAdmin, newMetaAdmin, admin, alice, bobClient, carolClient, unknown;
+
+describe('Api3TokenLock', async () => {
+  beforeEach(async () => {
+    [deployer, metaAdmin, newMetaAdmin, admin, alice, bobClient, carolClient, unknown] = await ethers.getSigners();
+
+    api3TokenLockFactory = await ethers.getContractFactory('Api3TokenLock', deployer);
+  });
+
+  describe('constructor', async () => {
+    context('successful deployment', async () => {
+      it('initialises correctly', async () => {
+        // when:
+        const api3TokenLock = await api3TokenLockFactory.deploy(metaAdmin.address, ONE_MINUTE_IN_SECONDS, LOCK_AMOUNT);
+        // then:
+
+        expect(await api3TokenLock.metaAdmin()).to.equal(metaAdmin.address);
+        expect(await api3TokenLock.minimumLockingTime()).to.equal(ONE_MINUTE_IN_SECONDS);
+        expect(await api3TokenLock.lockAmount()).to.equal(LOCK_AMOUNT);
+      });
+    });
+
+    context('Meta Admin is zero address', async () => {
+      it('reverts', async () => {
+        await expect(
+          api3TokenLockFactory.deploy(ethers.constants.AddressZero, ONE_MINUTE_IN_SECONDS, LOCK_AMOUNT)
+        ).to.revertedWith(Errors.ZeroAddress);
+      });
+    });
+
+    context('Lock Amount is zero', async () => {
+      it('reverts', async () => {
+        await expect(api3TokenLockFactory.deploy(metaAdmin.address, ONE_MINUTE_IN_SECONDS, 0)).to.revertedWith(
+          Errors.ZeroAmount
+        );
+      });
+    });
+  });
+
+  describe('post deployment', async () => {
+    let api3TokenLock;
+    let api3RequesterRrpAuthorizer;
+    let api3Token;
+
+    beforeEach(async () => {
+      // deploy Api3TokenLock
+      api3TokenLock = await api3TokenLockFactory.deploy(metaAdmin.address, ONE_MINUTE_IN_SECONDS, LOCK_AMOUNT);
+
+      const api3RequesterRrpAuthorizerFactory = await ethers.getContractFactory('Api3RequesterRrpAuthorizer', deployer);
+      // deploy Api3RequesterRrpAuthorizer
+      api3RequesterRrpAuthorizer = await api3RequesterRrpAuthorizerFactory.deploy(metaAdmin.address);
+
+      const api3TokenFactory = await ethers.getContractFactory('Api3Token', deployer);
+      // deploy Api3Token
+      api3Token = await api3TokenFactory.deploy(deployer.address, alice.address);
+
+      // set Api3TokenLock as admin
+      await api3RequesterRrpAuthorizer
+        .connect(metaAdmin)
+        .setRank(adminnedId, api3TokenLock.address, AdminStatus.SuperAdmin);
+    });
+
+    describe('setMetaAdmin', async () => {
+      context('caller is meta admin', async () => {
+        context('address to be set', async () => {
+          it('is set', async () => {
+            // when:
+            await api3TokenLock.connect(metaAdmin).setMetaAdmin(newMetaAdmin.address);
+
+            // then:
+            expect(await api3TokenLock.metaAdmin()).to.equal(newMetaAdmin.address);
+          });
+
+          it('emits event', async () => {
+            await expect(api3TokenLock.connect(metaAdmin).setMetaAdmin(newMetaAdmin.address))
+              .to.emit(api3TokenLock, 'SetMetaAdmin')
+              .withArgs(newMetaAdmin.address);
+          });
+        });
+
+        context('new meta admin is zero address', async () => {
+          it('reverts', async () => {
+            await expect(api3TokenLock.connect(metaAdmin).setMetaAdmin(ethers.constants.AddressZero)).to.revertedWith(
+              Errors.ZeroAddress
+            );
+          });
+        });
+      });
+
+      context('caller is not meta admin', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.connect(unknown).setMetaAdmin(newMetaAdmin.address)).to.revertedWith(
+            Errors.Unauthorized
+          );
+        });
+      });
+    });
+
+    describe('setAdminStatus', async () => {
+      context('caller is meta admin', async () => {
+        it('is set', async () => {
+          // when:
+          await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+          // then:
+          expect(await api3TokenLock.adminStatuses(admin.address)).to.equal(AdminStatus.Admin);
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin))
+            .to.emit(api3TokenLock, 'SetAdminStatus')
+            .withArgs(admin.address, AdminStatus.Admin);
+        });
+      });
+
+      context('caller is not meta admin', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.connect(unknown).setAdminStatus(admin.address, AdminStatus.Admin)).to.revertedWith(
+            Errors.Unauthorized
+          );
+        });
+      });
+    });
+
+    describe('setApi3RequesterRrpAuthorizer', async () => {
+      beforeEach(async () => {
+        await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+      });
+
+      context('caller is admin', async () => {
+        it('is set', async () => {
+          // when:
+          await api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address);
+          // then:
+          expect(await api3TokenLock.api3RequesterRrpAuthorizer()).to.equal(api3RequesterRrpAuthorizer.address);
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address))
+            .to.emit(api3TokenLock, 'SetApi3RequesterRrpAuthorizer')
+            .withArgs(api3RequesterRrpAuthorizer.address);
+        });
+
+        context('Api3RequesterRrpAuthorizer is zero address', async () => {
+          it('reverts', async () => {
+            await expect(
+              api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(ethers.constants.AddressZero)
+            ).to.revertedWith(Errors.ZeroAddress);
+          });
+        });
+      });
+
+      context('caller is not admin', async () => {
+        it('reverts', async () => {
+          await expect(
+            api3TokenLock.connect(unknown).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address)
+          ).to.revertedWith(Errors.Unauthorized);
+        });
+      });
+    });
+
+    describe('setApi3Token', async () => {
+      beforeEach(async () => {
+        await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+      });
+
+      context('caller is admin', async () => {
+        it('is set', async () => {
+          // when:
+          await api3TokenLock.connect(admin).setApi3Token(api3Token.address);
+          // then:
+          expect(await api3TokenLock.api3Token()).to.equal(api3Token.address);
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.connect(admin).setApi3Token(api3Token.address))
+            .to.emit(api3TokenLock, 'SetApi3Token')
+            .withArgs(api3Token.address);
+        });
+
+        context('Api3Token is zero address', async () => {
+          it('reverts', async () => {
+            await expect(api3TokenLock.connect(admin).setApi3Token(ethers.constants.AddressZero)).to.revertedWith(
+              Errors.ZeroAddress
+            );
+          });
+        });
+
+        context('Api3Token does not implement IApi3Token interface', async () => {
+          it('reverts', async () => {
+            await expect(api3TokenLock.connect(admin).setApi3Token(unknown.address)).to.reverted;
+          });
+        });
+      });
+
+      context('caller is not admin', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.connect(unknown).setApi3Token(api3Token.address)).to.revertedWith(
+            Errors.Unauthorized
+          );
+        });
+      });
+    });
+
+    describe('setMinimumLockingTime', async () => {
+      const NEW_MINIMUM_LOCKING_TIME = 2 * ONE_MINUTE_IN_SECONDS;
+
+      context('caller is admin', async () => {
+        it('is set', async () => {
+          // when:
+          await api3TokenLock.setMinimumLockingTime(NEW_MINIMUM_LOCKING_TIME);
+          // then:
+          expect(await api3TokenLock.minimumLockingTime()).to.equal(NEW_MINIMUM_LOCKING_TIME);
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.setMinimumLockingTime(NEW_MINIMUM_LOCKING_TIME))
+            .to.emit(api3TokenLock, 'SetMinimumLockingTime')
+            .withArgs(NEW_MINIMUM_LOCKING_TIME);
+        });
+      });
+
+      context('caller is not admin', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.connect(unknown).setMinimumLockingTime(NEW_MINIMUM_LOCKING_TIME)).to.revertedWith(
+            'caller is not the owner'
+          );
+        });
+      });
+    });
+
+    describe('setLockAmount', async () => {
+      const NEW_LOCK_AMOUNT = 2 * LOCK_AMOUNT;
+
+      context('caller is admin', async () => {
+        it('is set', async () => {
+          // when:
+          await api3TokenLock.setLockAmount(NEW_LOCK_AMOUNT);
+          // then:
+          expect(await api3TokenLock.lockAmount()).to.equal(NEW_LOCK_AMOUNT);
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.setLockAmount(NEW_LOCK_AMOUNT))
+            .to.emit(api3TokenLock, 'SetLockAmount')
+            .withArgs(NEW_LOCK_AMOUNT);
+        });
+
+        context('new lock amount is zero', async () => {
+          it('reverts', async () => {
+            await expect(api3TokenLock.setLockAmount(0)).to.revertedWith(Errors.ZeroAmount);
+          });
+        });
+      });
+
+      context('caller is not admin', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.connect(unknown).setLockAmount(NEW_LOCK_AMOUNT)).to.revertedWith(
+            'caller is not the owner'
+          );
+        });
+      });
+    });
+
+    describe('setBlacklistStatus', async () => {
+      context('caller is owner', async () => {
+        it('is set', async () => {
+          // when:
+          await api3TokenLock.setBlacklistStatus(bobClient.address, true);
+          // then:
+          expect(await api3TokenLock.clientAddressToBlacklistStatus(bobClient.address)).to.equal(true);
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.setBlacklistStatus(bobClient.address, true))
+            .to.emit(api3TokenLock, 'SetBlacklistStatus')
+            .withArgs(bobClient.address, true, deployer.address);
+        });
+      });
+      context('caller is not admin', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.connect(unknown).setBlacklistStatus(bobClient.address, true)).to.revertedWith(
+            'caller is not the owner'
+          );
+        });
+      });
+    });
+
+    describe('lock', async () => {
+      beforeEach(async () => {
+        // set admin
+        await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+
+        // set api3 authorizer
+        await api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address);
+
+        // set api3 token
+        await api3TokenLock.connect(admin).setApi3Token(api3Token.address);
+      });
+
+      context('caller is first time locking', async () => {
+        beforeEach(async () => {
+          // given:
+          await api3Token.connect(alice).approve(api3TokenLock.address, await api3TokenLock.lockAmount());
+        });
+
+        it('is set', async () => {
+          const beforeBalance = await api3Token.balanceOf(alice.address);
+          // when:
+          await api3TokenLock.connect(alice).lock(airnodeId, bobClient.address);
+          // then:
+          const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp;
+          const expectedUnlockTime = now + ONE_MINUTE_IN_SECONDS;
+          const afterBalance = await api3Token.balanceOf(alice.address);
+
+          expect(afterBalance).to.equal(beforeBalance.sub(LOCK_AMOUNT));
+
+          expect(await api3TokenLock.canUnlockAt(airnodeId, bobClient.address, alice.address)).to.equal(
+            expectedUnlockTime
+          );
+          expect(await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address)).to.equal(LOCK_AMOUNT);
+          expect(await api3TokenLock.tokenLocks(airnodeId, bobClient.address)).to.equal(1);
+
+          expect(
+            (await api3RequesterRrpAuthorizer.serviceIdToUserToWhitelistStatus(airnodeId, bobClient.address))
+              .expirationTimestamp
+          ).to.equal(ethers.BigNumber.from('0xffffffffffffffff'));
+        });
+
+        it('emits event', async () => {
+          // then:
+          await expect(api3TokenLock.connect(alice).lock(airnodeId, bobClient.address))
+            .to.emit(api3TokenLock, 'Lock')
+            .withArgs(airnodeId, bobClient.address, alice.address, LOCK_AMOUNT);
+        });
+      });
+
+      context('caller has already locked', async () => {
+        it('reverts', async () => {
+          // given:
+          await api3Token.connect(alice).approve(api3TokenLock.address, await api3TokenLock.lockAmount());
+          await api3TokenLock.connect(alice).lock(airnodeId, bobClient.address);
+          // then:
+          await expect(api3TokenLock.connect(alice).lock(airnodeId, bobClient.address)).to.revertedWith(
+            'Already locked'
+          );
+        });
+      });
+
+      context('client address is blacklisted', async () => {
+        it('reverts', async () => {
+          // given:
+          await api3TokenLock.setBlacklistStatus(bobClient.address, true);
+          // then:
+          await expect(api3TokenLock.connect(alice).lock(airnodeId, bobClient.address)).to.revertedWith(
+            Errors.ClientBlacklisted
+          );
+        });
+      });
+    });
+
+    describe('unlock', async () => {
+      beforeEach(async () => {
+        // set admin
+        await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+
+        // set api3 authorizer
+        await api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address);
+
+        // set api3 token
+        await api3TokenLock.connect(admin).setApi3Token(api3Token.address);
+
+        // approve Api3TokenLock:
+        await api3Token.connect(alice).approve(api3TokenLock.address, await api3TokenLock.lockAmount());
+        // Lock:
+        await api3TokenLock.connect(alice).lock(airnodeId, bobClient.address);
+      });
+
+      context('caller is unlocking successfully', async () => {
+        beforeEach(async () => {
+          timeTravel(ONE_MINUTE_IN_SECONDS + 1000);
+        });
+
+        it('is set', async () => {
+          const beforeBalance = await api3Token.balanceOf(alice.address);
+          // when:
+          await api3TokenLock.connect(alice).unlock(airnodeId, bobClient.address);
+          // then:
+          const afterBalance = await api3Token.balanceOf(alice.address);
+          expect(afterBalance).to.equal(beforeBalance.add(LOCK_AMOUNT));
+          expect(await api3TokenLock.canUnlockAt(airnodeId, bobClient.address, alice.address)).to.equal(0);
+          expect(await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address)).to.equal(0);
+          expect(await api3TokenLock.tokenLocks(airnodeId, bobClient.address)).to.equal(0);
+        });
+
+        it('emits event', async () => {
+          // then:
+          await expect(api3TokenLock.connect(alice).unlock(airnodeId, bobClient.address))
+            .to.emit(api3TokenLock, 'Unlock')
+            .withArgs(airnodeId, bobClient.address, alice.address, LOCK_AMOUNT);
+        });
+      });
+
+      context('caller period not expired', async () => {
+        it('reverts', async () => {
+          // then:
+          await expect(api3TokenLock.connect(alice).unlock(airnodeId, bobClient.address)).to.revertedWith(
+            Errors.LockPeriodNotExpired
+          );
+        });
+      });
+
+      context('already unlocked', async () => {
+        it('reverts', async () => {
+          // given:
+          timeTravel(ONE_MINUTE_IN_SECONDS + 1000);
+          await api3TokenLock.connect(alice).unlock(airnodeId, bobClient.address);
+          // then:
+          await expect(api3TokenLock.connect(alice).unlock(airnodeId, bobClient.address)).to.revertedWith(
+            'No amount locked'
+          );
+        });
+      });
+
+      context('client address is blacklisted', async () => {
+        it('reverts', async () => {
+          // given:
+          await api3TokenLock.setBlacklistStatus(bobClient.address, true);
+          timeTravel(ONE_MINUTE_IN_SECONDS + 1000);
+          // then:
+          await expect(api3TokenLock.connect(alice).unlock(airnodeId, bobClient.address)).to.revertedWith(
+            Errors.ClientBlacklisted
+          );
+        });
+      });
+    });
+
+    describe('withdraw', async () => {
+      const NEW_LOCK_AMOUNT = LOCK_AMOUNT / 2;
+      const expectedWithdrawnAmount = LOCK_AMOUNT - NEW_LOCK_AMOUNT;
+
+      beforeEach(async () => {
+        // set admin
+        await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+
+        // set api3 authorizer
+        await api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address);
+
+        // set api3 token
+        await api3TokenLock.connect(admin).setApi3Token(api3Token.address);
+
+        // approve Api3TokenLock:
+        await api3Token.connect(alice).approve(api3TokenLock.address, await api3TokenLock.lockAmount());
+        // Lock:
+        await api3TokenLock.connect(alice).lock(airnodeId, bobClient.address);
+      });
+
+      context('successful withdraws amount if it is set to a lower one', async () => {
+        beforeEach(async () => {
+          await api3TokenLock.setLockAmount(NEW_LOCK_AMOUNT);
+        });
+
+        it('withdraws', async () => {
+          const beforeBalance = await api3Token.balanceOf(alice.address);
+          // when:
+          await api3TokenLock.connect(alice).withdraw(airnodeId, bobClient.address);
+          // then:
+          const afterBalance = await api3Token.balanceOf(alice.address);
+          expect(afterBalance).to.equal(beforeBalance.add(expectedWithdrawnAmount));
+          expect(await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address)).to.equal(
+            NEW_LOCK_AMOUNT
+          );
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.connect(alice).withdraw(airnodeId, bobClient.address))
+            .to.emit(api3TokenLock, 'Withdraw')
+            .withArgs(airnodeId, bobClient.address, alice.address, expectedWithdrawnAmount);
+        });
+      });
+
+      context('client address is blacklisted', async () => {
+        beforeEach(async () => {
+          await api3TokenLock.setLockAmount(NEW_LOCK_AMOUNT);
+          await api3TokenLock.setBlacklistStatus(bobClient.address, true);
+        });
+
+        it('reverts', async () => {
+          // then:
+          await expect(api3TokenLock.connect(alice).withdraw(airnodeId, bobClient.address)).to.revertedWith(
+            Errors.ClientBlacklisted
+          );
+        });
+      });
+
+      context('locked amount is not reduced', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.connect(alice).withdraw(airnodeId, bobClient.address)).to.revertedWith(
+            'Insufficient amount'
+          );
+        });
+      });
+    });
+
+    describe('transfer', async () => {
+      beforeEach(async () => {
+        // set admin
+        await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+
+        // set api3 authorizer
+        await api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address);
+
+        // set api3 token
+        await api3TokenLock.connect(admin).setApi3Token(api3Token.address);
+
+        // approve Api3TokenLock:
+        await api3Token.connect(alice).approve(api3TokenLock.address, await api3TokenLock.lockAmount());
+
+        // Lock:
+        await api3TokenLock.connect(alice).lock(airnodeId, bobClient.address);
+      });
+
+      context('from one client to another', async () => {
+        it('is set', async () => {
+          const lockPeriod = await api3TokenLock.canUnlockAt(airnodeId, bobClient.address, alice.address);
+          const lockAmount = await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address);
+          const beforeBobWhitelistCount = await api3TokenLock.tokenLocks(airnodeId, bobClient.address);
+          const beforeCarolWhitelistCount = await api3TokenLock.tokenLocks(airnodeId, carolClient.address);
+
+          // when:
+          await api3TokenLock.connect(alice).transfer(airnodeId, bobClient.address, carolClient.address);
+          // then:
+          expect(await api3TokenLock.canUnlockAt(airnodeId, bobClient.address, alice.address)).to.equal(0);
+          expect(await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address)).to.equal(0);
+          expect(await api3TokenLock.tokenLocks(airnodeId, bobClient.address)).to.equal(beforeBobWhitelistCount - 1);
+          // and:
+          expect(await api3TokenLock.canUnlockAt(airnodeId, carolClient.address, alice.address)).to.equal(lockPeriod);
+          expect(await api3TokenLock.lockAmountAt(airnodeId, carolClient.address, alice.address)).to.equal(lockAmount);
+          expect(await api3TokenLock.tokenLocks(airnodeId, carolClient.address)).to.equal(
+            beforeCarolWhitelistCount + 1
+          );
+          // and:
+          expect(
+            (await api3RequesterRrpAuthorizer.serviceIdToUserToWhitelistStatus(airnodeId, bobClient.address))
+              .expirationTimestamp
+          ).to.equal(0);
+          expect(
+            (await api3RequesterRrpAuthorizer.serviceIdToUserToWhitelistStatus(airnodeId, carolClient.address))
+              .expirationTimestamp
+          ).to.equal(ethers.BigNumber.from('0xffffffffffffffff'));
+        });
+
+        it('emits event', async () => {
+          const lockPeriod = await api3TokenLock.canUnlockAt(airnodeId, bobClient.address, alice.address);
+          const lockAmount = await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address);
+          // then:
+          await expect(api3TokenLock.connect(alice).transfer(airnodeId, bobClient.address, carolClient.address))
+            .to.emit(api3TokenLock, 'Transfer')
+            .withArgs(airnodeId, bobClient.address, carolClient.address, alice.address, lockAmount, lockPeriod);
+        });
+      });
+
+      context('caller has not locked amounts', async () => {
+        it('reverts', async () => {
+          // then:
+          await expect(
+            api3TokenLock.connect(unknown).transfer(airnodeId, bobClient.address, carolClient.address)
+          ).to.revertedWith('locked amount must be != 0');
+        });
+      });
+
+      context('caller toClientAddress has existing locked amount', async () => {
+        it('reverts', async () => {
+          // given:
+          await api3Token.connect(alice).approve(api3TokenLock.address, await api3TokenLock.lockAmount());
+          await api3TokenLock.connect(alice).lock(airnodeId, carolClient.address);
+          // then:
+          await expect(
+            api3TokenLock.connect(alice).transfer(airnodeId, bobClient.address, carolClient.address)
+          ).to.revertedWith('locked amount must be 0');
+        });
+      });
+
+      context('fromClient address is blacklisted', async () => {
+        it('reverts', async () => {
+          // given:
+          await api3TokenLock.setBlacklistStatus(bobClient.address, true);
+          // then:
+          await expect(
+            api3TokenLock.connect(alice).transfer(airnodeId, bobClient.address, carolClient.address)
+          ).to.revertedWith(Errors.FromClientBlacklisted);
+        });
+      });
+
+      context('toClient address is blacklisted', async () => {
+        it('reverts', async () => {
+          // given:
+          await api3TokenLock.setBlacklistStatus(carolClient.address, true);
+          // then:
+          await expect(
+            api3TokenLock.connect(alice).transfer(airnodeId, bobClient.address, carolClient.address)
+          ).to.revertedWith(Errors.ToClientBlacklisted);
+        });
+      });
+    });
+
+    describe('burn', async () => {
+      beforeEach(async () => {
+        // set admin
+        await api3TokenLock.connect(metaAdmin).setAdminStatus(admin.address, AdminStatus.Admin);
+
+        // set api3 authorizer
+        await api3TokenLock.connect(admin).setApi3RequesterRrpAuthorizer(api3RequesterRrpAuthorizer.address);
+
+        // set api3 token
+        await api3TokenLock.connect(admin).setApi3Token(api3Token.address);
+
+        // approve Api3TokenLock:
+        await api3Token.connect(alice).approve(api3TokenLock.address, await api3TokenLock.lockAmount());
+
+        // Lock:
+        await api3TokenLock.connect(alice).lock(airnodeId, bobClient.address);
+      });
+
+      context('successful burn of blacklisted client', async () => {
+        beforeEach(async () => {
+          await api3TokenLock.setBlacklistStatus(bobClient.address, true);
+        });
+
+        it('burns tokens', async () => {
+          const beforeTotalSupply = await api3Token.totalSupply();
+          const beforeTokenLockBalance = await api3Token.balanceOf(api3TokenLock.address);
+          const lockAmount = await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address);
+          const beforeWhitelistCount = await api3TokenLock.tokenLocks(airnodeId, bobClient.address);
+
+          // when:
+          await api3TokenLock.burn(airnodeId, bobClient.address, alice.address);
+
+          // then:
+          expect(await api3TokenLock.canUnlockAt(airnodeId, bobClient.address, alice.address)).to.equal(0);
+          expect(await api3TokenLock.lockAmountAt(airnodeId, bobClient.address, alice.address)).to.equal(0);
+          // and:
+          expect(await api3Token.balanceOf(api3TokenLock.address)).to.equal(beforeTokenLockBalance.sub(lockAmount));
+          expect(await api3Token.totalSupply()).to.equal(beforeTotalSupply.sub(lockAmount));
+          expect(await api3TokenLock.tokenLocks(airnodeId, bobClient.address)).to.equal(beforeWhitelistCount.sub(1));
+        });
+
+        it('emits event', async () => {
+          await expect(api3TokenLock.burn(airnodeId, bobClient.address, alice.address))
+            .to.emit(api3TokenLock, 'Burn')
+            .withArgs(airnodeId, bobClient.address, alice.address);
+        });
+      });
+
+      context('burn target has zero locked amount', async () => {
+        it('reverts', async () => {
+          await expect(api3TokenLock.burn(airnodeId, bobClient.address, unknown.address)).to.revertedWith(
+            Errors.ZeroAmount
+          );
+        });
+      });
+
+      context('client address is not blacklisted', async () => {
+        it('reverts', async () => {
+          // given:
+          await api3TokenLock.setBlacklistStatus(bobClient.address, false);
+          // then:
+          await expect(api3TokenLock.burn(airnodeId, bobClient.address, alice.address)).to.revertedWith(
+            Errors.ClientNotBlacklisted
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/protocol/test/authorizers/Api3TokenLock.sol.js
+++ b/packages/protocol/test/authorizers/Api3TokenLock.sol.js
@@ -1,6 +1,6 @@
 /* globals context ethers */
 const { expect } = require('chai');
-const { timeTravel } = require('./utils');
+const { timeTravel } = require('../utils');
 
 const AdminStatus = {
   Unauthorized: 0,

--- a/packages/protocol/test/authorizers/Whitelister.sol.js
+++ b/packages/protocol/test/authorizers/Whitelister.sol.js
@@ -213,10 +213,10 @@ describe('userIsWhitelisted', function () {
   context('User not whitelisted past expiration', function () {
     context('Not past expiration', function () {
       it('returns true', async function () {
-        const timestampOneHourLater = Math.floor(Date.now() / 1000) + 3600;
+        const timestampOneDayLater = Math.floor(Date.now() / 1000) + 86400;
         await api3RequesterRrpAuthorizer
           .connect(roles.superAdmin)
-          .setWhitelistExpiration(adminnedId, roles.user.address, timestampOneHourLater);
+          .setWhitelistExpiration(adminnedId, roles.user.address, timestampOneDayLater);
         expect(await api3RequesterRrpAuthorizer.userIsWhitelisted(adminnedId, roles.user.address)).to.equal(true);
       });
     });

--- a/packages/protocol/test/utils.js
+++ b/packages/protocol/test/utils.js
@@ -1,4 +1,4 @@
-const ethers = require('ethers');
+const { ethers } = require('hardhat');
 
 function deriveWalletPathFromSponsorAddress(sponsorAddress) {
   const sponsorAddressBN = ethers.BigNumber.from(sponsorAddress);
@@ -11,6 +11,10 @@ function deriveWalletPathFromSponsorAddress(sponsorAddress) {
 }
 
 module.exports = {
+  timeTravel: async (_seconds) => {
+    await ethers.provider.send('evm_increaseTime', [_seconds]);
+    await ethers.provider.send('evm_mine');
+  },
   generateRandomAirnodeWallet: () => {
     const airnodeWallet = ethers.Wallet.createRandom();
     const airnodeHdNode = ethers.utils.HDNode.fromMnemonic(airnodeWallet.mnemonic.phrase);


### PR DESCRIPTION
![Api3TokenLock_specs_3](https://user-images.githubusercontent.com/31223740/127759778-97e8879a-d939-492c-8f55-73af4a654cff.jpg)

old reference image for better understanding(old and not completely accurate but helps to get an idea.)

This integrates the token lock contracts along with all their tests

Currently the token lock sets the whitelisting `expirationTimestamp` to `type(uint64).max` would setting `setWhitelistStatusPastExpiration` true be better instead?