### PR TITLE
Update deployer README - add AWS IAM setup video link

### DIFF
--- a/packages/deployer/README.md
+++ b/packages/deployer/README.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 * Install [Terraform v0.15.x](https://www.terraform.io/downloads.html) and make sure that the `terraform` binary is available in your `PATH`
-* Make sure your AWS credentials are stored in the [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where) or exported as [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set)
+* Make sure your AWS credentials are stored in the [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where) or exported as [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set). If you need help setting up an AWS IAM user you can follow [this video tutorial](https://www.youtube.com/watch?v=bT19B3IBWHE).
 
 ## Setup
 * Build all the Airnode packages


### PR DESCRIPTION
Part of #462

I know this isn't much of a change but I looked through the Airnode starter docs and it feels like pretty much the same thing to me.

Also, I don't think it's our place to suggest some IAM setup for the users. Even the example from the video is just one way to do it. I mean, yes, we're basically providing a service they can run on AWS but it's still their infrastructure. I'd say that if you want to run something on AWS you should know how users and permissions work anyway.

But I'm open to suggestions.