### PR TITLE
Remove withdrawal destination

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -211,5 +211,5 @@ The zero here is allocated for RRP, and the other branches will be used to deriv
 ## Withdrawal from the sponsor wallet
 
 Requesters may not want to use up all the ETH deposited in their sponsor wallet.
-Then, they can use `WithdrawalUtils` to request a withdrawal from the Airnode, which sends the entire balance of the sponsor wallet to the specified address.
+Then, they can use `WithdrawalUtils` to request a withdrawal from the Airnode, which sends the entire balance of the sponsor wallet to the sponsor address.
 Unlike template and full requests, there are no parameters that the Ethereum provider can tamper with, which is why withdrawal requests/fulfillments do not make similar hash checks.

--- a/packages/protocol/contracts/rrp/interfaces/IWithdrawalUtils.sol
+++ b/packages/protocol/contracts/rrp/interfaces/IWithdrawalUtils.sol
@@ -6,8 +6,7 @@ interface IWithdrawalUtils {
         address indexed airnode,
         address indexed sponsor,
         bytes32 indexed withdrawalRequestId,
-        address sponsorWallet,
-        address destination
+        address sponsorWallet
     );
 
     event FulfilledWithdrawal(
@@ -15,21 +14,15 @@ interface IWithdrawalUtils {
         address indexed sponsor,
         bytes32 indexed withdrawalRequestId,
         address sponsorWallet,
-        address destination,
         uint256 amount
     );
 
-    function requestWithdrawal(
-        address airnode,
-        address sponsorWallet,
-        address destination
-    ) external;
+    function requestWithdrawal(address airnode, address sponsorWallet) external;
 
     function fulfillWithdrawal(
         bytes32 withdrawalRequestId,
         address airnode,
-        address sponsor,
-        address destination
+        address sponsor
     ) external payable;
 
     function sponsorToWithdrawalRequestCount(address sponsor)


### PR DESCRIPTION
AirnodeRrp caller will no longer be able to set a destination and funds from sponsored wallet will be sent to the sponsor (account that created the withdrawal request prior to airnode fulfilling it with sponsored wallet)