### PR TITLE
Return testing gateway URL

### DIFF
--- a/packages/deployer/src/cli/commands.ts
+++ b/packages/deployer/src/cli/commands.ts
@@ -60,8 +60,9 @@ export async function deploy(
   await checkAirnodeParameters(config, airnodeId, masterWalletAddress);
 
   const airnodeIdShort = shortenAirnodeId(airnodeId);
+  let output = {};
   try {
-    await deployAirnode(
+    output = await deployAirnode(
       airnodeIdShort,
       config.nodeSettings.stage,
       config.nodeSettings.cloudProvider,
@@ -81,6 +82,7 @@ export async function deploy(
     config: { chains: config.chains, nodeSettings: config.nodeSettings },
     masterWalletAddress,
     xpub: deriveXpub(secrets.MASTER_KEY_MNEMONIC),
+    ...output,
   };
 
   logger.debug('Deleting a temporary secrets.json file');

--- a/packages/deployer/terraform/airnode/main.tf
+++ b/packages/deployer/terraform/airnode/main.tf
@@ -11,6 +11,9 @@ module "initializeProvider" {
   timeout            = 20
   configuration_file = var.configuration_file
   secrets_file       = var.secrets_file
+  environment_variables = {
+    TESTING_GATEWAY_URL = var.api_key == null ? null : "${module.testApiGateway[0].api_url}/test"
+  }
 }
 
 module "callApi" {
@@ -22,6 +25,9 @@ module "callApi" {
   timeout            = 30
   configuration_file = var.configuration_file
   secrets_file       = var.secrets_file
+  environment_variables = {
+    TESTING_GATEWAY_URL = var.api_key == null ? null : "${module.testApiGateway[0].api_url}/test"
+  }
 }
 
 module "processProviderRequests" {
@@ -33,6 +39,9 @@ module "processProviderRequests" {
   timeout            = 10
   configuration_file = var.configuration_file
   secrets_file       = var.secrets_file
+  environment_variables = {
+    TESTING_GATEWAY_URL = var.api_key == null ? null : "${module.testApiGateway[0].api_url}/test"
+  }
 }
 
 module "startCoordinator" {
@@ -44,6 +53,9 @@ module "startCoordinator" {
   timeout            = 60
   configuration_file = var.configuration_file
   secrets_file       = var.secrets_file
+  environment_variables = {
+    TESTING_GATEWAY_URL = var.api_key == null ? null : "${module.testApiGateway[0].api_url}/test"
+  }
 
   invoke_targets                 = [module.initializeProvider.lambda_arn, module.callApi.lambda_arn, module.processProviderRequests.lambda_arn]
   schedule_interval              = 1
@@ -63,7 +75,6 @@ module "testApi" {
   secrets_file       = var.secrets_file
 
   invoke_targets = [module.callApi.lambda_arn]
-  depends_on     = [module.callApi]
 }
 
 module "testApiGateway" {

--- a/packages/deployer/terraform/airnode/modules/apigateway/outputs.tf
+++ b/packages/deployer/terraform/airnode/modules/apigateway/outputs.tf
@@ -1,0 +1,3 @@
+output "api_url" {
+  value = aws_api_gateway_stage.stage.invoke_url
+}

--- a/packages/deployer/terraform/airnode/modules/function/main.tf
+++ b/packages/deployer/terraform/airnode/modules/function/main.tf
@@ -55,7 +55,7 @@ resource "aws_lambda_function" "lambda" {
   ]
 
   environment {
-    variables = fileexists(var.secrets_file) ? jsondecode(file(var.secrets_file)) : {}
+    variables = merge(var.environment_variables, fileexists(var.secrets_file) ? jsondecode(file(var.secrets_file)) : {})
   }
 }
 

--- a/packages/deployer/terraform/airnode/modules/function/variables.tf
+++ b/packages/deployer/terraform/airnode/modules/function/variables.tf
@@ -46,3 +46,9 @@ variable "configuration_file" {
 variable "secrets_file" {
   description = "Airnode secrets file"
 }
+
+variable "environment_variables" {
+  description = "Additional Lambda environment variables"
+  type        = map(any)
+  default     = {}
+}

--- a/packages/deployer/terraform/airnode/outputs.tf
+++ b/packages/deployer/terraform/airnode/outputs.tf
@@ -1,0 +1,3 @@
+output "testing_gateway_url" {
+  value = var.api_key == null ? null : "${module.testApiGateway[0].api_url}/test"
+}

--- a/packages/node/src/reporting/heartbeat.ts
+++ b/packages/node/src/reporting/heartbeat.ts
@@ -18,6 +18,8 @@ export async function reportHeartbeat(state: CoordinatorState): Promise<PendingL
     return [log];
   }
 
+  const testingGatewayUrl = getEnvValue('TESTING_GATEWAY_URL');
+
   // TODO: add statistics here
   const payload = {};
 
@@ -27,6 +29,7 @@ export async function reportHeartbeat(state: CoordinatorState): Promise<PendingL
     data: {
       api_key: apiKey,
       deployment_id: heartbeatId,
+      ...(testingGatewayUrl ? {} : { testing_gateway_url: testingGatewayUrl }),
       payload,
     },
     timeout: 5_000,


### PR DESCRIPTION
Not entirely sure that writing the URL to `receipt.json` is ok but we don't really have any other choice how to let user know what the testing URL is.