### PR TITLE
Fixes protocol event names

### DIFF
--- a/packages/node/src/evm/contracts/airnodeRrp.test.ts
+++ b/packages/node/src/evm/contracts/airnodeRrp.test.ts
@@ -42,15 +42,15 @@ describe('AirnodeRrp', () => {
     expect(events).toEqual([
       'AirnodeParametersSet',
       'ClientEndorsementStatusSet',
-      'ClientFullRequestCreated',
-      'ClientRequestCreated',
-      'ClientRequestFailed',
-      'ClientRequestFulfilled',
+      'MadeFullRequest',
+      'MadeTemplateRequest',
+      'FailedRequest',
+      'FulfilledRequest',
       'RequesterCreated',
       'RequesterUpdated',
       'TemplateCreated',
-      'WithdrawalFulfilled',
-      'WithdrawalRequested',
+      'FulfilledWithdrawal',
+      'RequestedWithdrawal',
     ]);
   });
 
@@ -59,34 +59,34 @@ describe('AirnodeRrp', () => {
     expect.assertions(7);
 
     expect(Object.keys(airnodeRrpTopics).sort()).toEqual([
-      'ClientFullRequestCreated',
-      'ClientRequestCreated',
-      'ClientRequestFailed',
-      'ClientRequestFulfilled',
-      'WithdrawalFulfilled',
-      'WithdrawalRequested',
+      'MadeFullRequest',
+      'MadeTemplateRequest',
+      'FailedRequest',
+      'FulfilledRequest',
+      'FulfilledWithdrawal',
+      'RequestedWithdrawal',
     ]);
 
     // API calls
-    expect(airnodeRrpTopics.ClientRequestCreated).toEqual(
+    expect(airnodeRrpTopics.MadeTemplateRequest).toEqual(
       '0x8339fddbb81e588a9ed04dec82ee9ae6c7a185f44835adaaa2ace50ce3a14aaf'
     );
-    expect(airnodeRrpTopics.ClientFullRequestCreated).toEqual(
+    expect(airnodeRrpTopics.MadeFullRequest).toEqual(
       '0xe8ae99161b1547fd1c6ff3cb9660293fa4cd770fd52f72ff0362d64d8bccc08e'
     );
 
-    expect(airnodeRrpTopics.ClientRequestFulfilled).toEqual(
+    expect(airnodeRrpTopics.FulfilledRequest).toEqual(
       '0xcde46e28d8d3e348e5f5b4fcc511fe3b1f9b0f549cd8332f0da31802a6f2bf61'
     );
-    expect(airnodeRrpTopics.ClientRequestFailed).toEqual(
+    expect(airnodeRrpTopics.FailedRequest).toEqual(
       '0x1cfdd5ace64f15111ef8ed9df04364d0e9a9165cccf8386109347e54661ba3ad'
     );
 
     // Withdrawals
-    expect(airnodeRrpTopics.WithdrawalRequested).toEqual(
+    expect(airnodeRrpTopics.RequestedWithdrawal).toEqual(
       '0x3d0ebccb4fc9730699221da0180970852f595ed5c78781346149123cbbe9f1d3'
     );
-    expect(airnodeRrpTopics.WithdrawalFulfilled).toEqual(
+    expect(airnodeRrpTopics.FulfilledWithdrawal).toEqual(
       '0x9e7b58b29aa3b972bb0f457499d0dfd00bf23905b0c3358fb864e7120402aefa'
     );
   });

--- a/packages/node/src/evm/contracts/airnodeRrp.ts
+++ b/packages/node/src/evm/contracts/airnodeRrp.ts
@@ -2,30 +2,30 @@ import { ethers } from 'ethers';
 // TODO: refactor once https://github.com/ethereum-ts/TypeChain/pull/368 is merged and published
 import { AirnodeRrp, AirnodeRrpFactory, AirnodeRrpArtifact } from '@api3/protocol';
 
-const ClientRequestCreated = ethers.utils.id(
-  'ClientRequestCreated(bytes32,bytes32,uint256,uint256,address,bytes32,uint256,address,address,bytes4,bytes)'
+const MadeTemplateRequest = ethers.utils.id(
+  'MadeTemplateRequest(address,bytes32,uint256,uint256,address,bytes32,address,address,address,bytes4,bytes)'
 );
-const ClientFullRequestCreated = ethers.utils.id(
-  'ClientFullRequestCreated(bytes32,bytes32,uint256,uint256,address,bytes32,uint256,address,address,bytes4,bytes)'
+const MadeFullRequest = ethers.utils.id(
+  'MadeFullRequest(address,bytes32,uint256,uint256,address,bytes32,address,address,address,bytes4,bytes)'
 );
 
-const ClientRequestFulfilled = ethers.utils.id('ClientRequestFulfilled(bytes32,bytes32,uint256,bytes)');
-const ClientRequestFailed = ethers.utils.id('ClientRequestFailed(bytes32,bytes32)');
+const FulfilledRequest = ethers.utils.id('FulfilledRequest(address,bytes32,uint256,bytes)');
+const FailedRequest = ethers.utils.id('FailedRequest(address,bytes32)');
 
-const WithdrawalRequested = ethers.utils.id('WithdrawalRequested(bytes32,uint256,bytes32,address,address)');
-const WithdrawalFulfilled = ethers.utils.id('WithdrawalFulfilled(bytes32,uint256,bytes32,address,address,uint256)');
+const RequestedWithdrawal = ethers.utils.id('RequestedWithdrawal(address,address,bytes32,address)');
+const FulfilledWithdrawal = ethers.utils.id('FulfilledWithdrawal(address,address,bytes32,address,uint256)');
 
 const airnodeRrpTopics = {
   // API calls
-  ClientRequestCreated,
-  ClientFullRequestCreated,
+  MadeTemplateRequest,
+  MadeFullRequest,
 
-  ClientRequestFulfilled,
-  ClientRequestFailed,
+  FulfilledRequest,
+  FailedRequest,
 
   // Withdrawals
-  WithdrawalRequested,
-  WithdrawalFulfilled,
+  RequestedWithdrawal,
+  FulfilledWithdrawal,
 };
 
 export { AirnodeRrpFactory, AirnodeRrp, AirnodeRrpArtifact, airnodeRrpTopics };

--- a/packages/node/src/evm/handlers/fetch-pending-requests.test.ts
+++ b/packages/node/src/evm/handlers/fetch-pending-requests.test.ts
@@ -9,8 +9,8 @@ unfreezeImport(verification, 'verifyApiCallIds');
 
 describe('fetchPendingRequests', () => {
   it('maps and groups requests', async () => {
-    const fullRequest = fixtures.evm.logs.buildFullClientRequest();
-    const withdrawal = fixtures.evm.logs.buildWithdrawalRequest();
+    const fullRequest = fixtures.evm.logs.buildMadeFullRequest();
+    const withdrawal = fixtures.evm.logs.buildRequestedWithdrawal();
     const getLogsSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getLogs');
     getLogsSpy.mockResolvedValueOnce([fullRequest, withdrawal]);
     const state = fixtures.buildEVMProviderState();
@@ -69,7 +69,7 @@ describe('fetchPendingRequests', () => {
   });
 
   it('verifies API calls', async () => {
-    const fullRequest = fixtures.evm.logs.buildFullClientRequest();
+    const fullRequest = fixtures.evm.logs.buildMadeFullRequest();
     const getLogsSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getLogs');
     getLogsSpy.mockResolvedValueOnce([fullRequest]);
     const verificationSpy = jest.spyOn(verification, 'verifyApiCallIds');
@@ -79,8 +79,8 @@ describe('fetchPendingRequests', () => {
   });
 
   it('blocks API calls linked to withdrawals', async () => {
-    const fullRequest = fixtures.evm.logs.buildFullClientRequest();
-    const withdrawal = fixtures.evm.logs.buildFullClientRequest();
+    const fullRequest = fixtures.evm.logs.buildMadeFullRequest();
+    const withdrawal = fixtures.evm.logs.buildMadeFullRequest();
     const getLogsSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getLogs');
     getLogsSpy.mockResolvedValueOnce([fullRequest, withdrawal]);
     const blockingSpy = jest.spyOn(blocking, 'blockRequestsWithWithdrawals');

--- a/packages/node/src/evm/handlers/initialize-provider.test.ts
+++ b/packages/node/src/evm/handlers/initialize-provider.test.ts
@@ -24,9 +24,9 @@ describe('initializeProvider', () => {
       xpub: 'xpub661MyMwAqRbcGeCE1g3KTUVGZsFDE3jMNinRPGCQGQsAp1nwinB9Pi16ihKPJw7qtaaTFuBHbRPeSc6w3AcMjxiHkAPfyp1hqQRbthv4Ryx',
     });
 
-    const fullRequest = fixtures.evm.logs.buildFullClientRequest();
-    const regularRequest = fixtures.evm.logs.buildClientRequest();
-    const withdrawal = fixtures.evm.logs.buildWithdrawalRequest();
+    const fullRequest = fixtures.evm.logs.buildMadeFullRequest();
+    const regularRequest = fixtures.evm.logs.buildMadeTemplateRequest();
+    const withdrawal = fixtures.evm.logs.buildRequestedWithdrawal();
     const getLogsSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getLogs');
     getLogsSpy.mockResolvedValueOnce([fullRequest, regularRequest, withdrawal]);
 

--- a/packages/node/src/evm/requests/api-calls.test.ts
+++ b/packages/node/src/evm/requests/api-calls.test.ts
@@ -1,12 +1,12 @@
 import * as apiCalls from './api-calls';
 import { parseAirnodeRrpLog } from './event-logs';
-import { EVMRequestCreatedLog, RequestErrorCode, RequestStatus } from '../../types';
+import { EVMMadeRequestLog, RequestErrorCode, RequestStatus } from '../../types';
 import * as fixtures from '../../../test/fixtures';
 
 describe('initialize (ApiCall)', () => {
   it('builds a new ApiCall request', () => {
-    const event = fixtures.evm.logs.buildClientRequest();
-    const parsedLog = parseAirnodeRrpLog<'ClientRequestCreated'>(event);
+    const event = fixtures.evm.logs.buildMadeTemplateRequest();
+    const parsedLog = parseAirnodeRrpLog<'MadeTemplateRequest'>(event);
     const parsedLogWithMetadata = {
       parsedLog,
       blockNumber: 10716082,
@@ -41,8 +41,8 @@ describe('initialize (ApiCall)', () => {
   });
 
   it('sets the API call type', () => {
-    const event = fixtures.evm.logs.buildClientRequest();
-    const parsedLog = parseAirnodeRrpLog<'ClientRequestCreated'>(event);
+    const event = fixtures.evm.logs.buildMadeTemplateRequest();
+    const parsedLog = parseAirnodeRrpLog<'MadeTemplateRequest'>(event);
     const base = {
       parsedLog,
       blockNumber: 10716082,
@@ -65,11 +65,11 @@ describe('initialize (ApiCall)', () => {
 });
 
 describe('applyParameters', () => {
-  let mutableParsedLogWithMetadata: EVMRequestCreatedLog;
+  let mutableParsedLogWithMetadata: EVMMadeRequestLog;
 
   beforeEach(() => {
-    const event = fixtures.evm.logs.buildClientRequest();
-    const parsedLog = parseAirnodeRrpLog<'ClientRequestCreated'>(event);
+    const event = fixtures.evm.logs.buildMadeTemplateRequest();
+    const parsedLog = parseAirnodeRrpLog<'MadeTemplateRequest'>(event);
     mutableParsedLogWithMetadata = {
       parsedLog,
       blockNumber: 10716082,
@@ -163,8 +163,8 @@ describe('updateFulfilledRequests (ApiCall)', () => {
 
 describe('mapRequests (ApiCall)', () => {
   it('initializes, applies parameters and returns API call requests', () => {
-    const event = fixtures.evm.logs.buildClientRequest();
-    const parsedLog = parseAirnodeRrpLog<'ClientRequestCreated'>(event);
+    const event = fixtures.evm.logs.buildMadeTemplateRequest();
+    const parsedLog = parseAirnodeRrpLog<'MadeTemplateRequest'>(event);
     const parsedLogWithMetadata = {
       parsedLog,
       blockNumber: 10716082,
@@ -203,10 +203,10 @@ describe('mapRequests (ApiCall)', () => {
   });
 
   it('updates the status of fulfilled ApiCall requests', () => {
-    const requestEvent = fixtures.evm.logs.buildClientRequest();
-    const fulfillEvent = fixtures.evm.logs.buildClientRequestFulfilled();
-    const requestLog = parseAirnodeRrpLog<'ClientRequestCreated'>(requestEvent);
-    const fulfillLog = parseAirnodeRrpLog<'ClientRequestFulfilled'>(fulfillEvent);
+    const requestEvent = fixtures.evm.logs.buildMadeTemplateRequest();
+    const fulfillEvent = fixtures.evm.logs.buildTemplateFulfilledRequest();
+    const requestLog = parseAirnodeRrpLog<'MadeTemplateRequest'>(requestEvent);
+    const fulfillLog = parseAirnodeRrpLog<'FulfilledRequest'>(fulfillEvent);
 
     const requestLogWithMetadata = {
       parsedLog: requestLog,

--- a/packages/node/src/evm/requests/api-calls.ts
+++ b/packages/node/src/evm/requests/api-calls.ts
@@ -8,8 +8,8 @@ import {
   ApiCallType,
   ClientRequest,
   EVMEventLog,
-  EVMRequestCreatedLog,
-  EVMRequestFulfilledLog,
+  EVMMadeRequestLog,
+  EVMFulfilledRequestLog,
   LogsData,
   PendingLog,
   RequestErrorCode,
@@ -18,9 +18,9 @@ import {
 
 function getApiCallType(topic: string): ApiCallType {
   switch (topic) {
-    case airnodeRrpTopics.ClientRequestCreated:
+    case airnodeRrpTopics.MadeTemplateRequest:
       return 'regular';
-    case airnodeRrpTopics.ClientFullRequestCreated:
+    case airnodeRrpTopics.MadeFullRequest:
       return 'full';
     // This should never be reached
     default:
@@ -28,7 +28,7 @@ function getApiCallType(topic: string): ApiCallType {
   }
 }
 
-export function initialize(log: EVMRequestCreatedLog): ClientRequest<ApiCall> {
+export function initialize(log: EVMMadeRequestLog): ClientRequest<ApiCall> {
   const { parsedLog } = log;
 
   const request: ClientRequest<ApiCall> = {
@@ -115,10 +115,10 @@ export function updateFulfilledRequests(
 
 export function mapRequests(logsWithMetadata: EVMEventLog[]): LogsData<ClientRequest<ApiCall>[]> {
   // Separate the logs
-  const requestLogs = logsWithMetadata.filter((log) => events.isApiCallRequest(log)) as EVMRequestCreatedLog[];
+  const requestLogs = logsWithMetadata.filter((log) => events.isApiCallRequest(log)) as EVMMadeRequestLog[];
   const fulfillmentLogs = logsWithMetadata.filter((log) =>
     events.isApiCallFulfillment(log)
-  ) as EVMRequestFulfilledLog[];
+  ) as EVMFulfilledRequestLog[];
 
   // Cast raw logs to typed API request objects
   const apiCallRequests = requestLogs.map(initialize);

--- a/packages/node/src/evm/requests/event-logs.ts
+++ b/packages/node/src/evm/requests/event-logs.ts
@@ -7,10 +7,10 @@ import {
   EVMEventLog,
   AirnodeRrpFilters,
   AirnodeRrpLog,
-  EVMRequestCreatedLog,
-  EVMRequestFulfilledLog,
-  EVMWithdrawalFulfilledLog,
-  EVMWithdrawalRequestLog,
+  EVMMadeRequestLog,
+  EVMFulfilledRequestLog,
+  EVMFulfilledWithdrawalLog,
+  EVMRequestedWithdrawalLog,
   AirnodeLogDescription,
 } from '../../types';
 
@@ -24,8 +24,8 @@ interface FetchOptions {
 }
 
 interface GroupedLogs {
-  readonly apiCalls: (EVMRequestCreatedLog | EVMRequestFulfilledLog)[];
-  readonly withdrawals: (EVMWithdrawalFulfilledLog | EVMWithdrawalRequestLog)[];
+  readonly apiCalls: (EVMMadeRequestLog | EVMFulfilledRequestLog)[];
+  readonly withdrawals: (EVMFulfilledWithdrawalLog | EVMRequestedWithdrawalLog)[];
 }
 
 export function parseAirnodeRrpLog<T extends keyof AirnodeRrpFilters>(

--- a/packages/node/src/evm/requests/events.ts
+++ b/packages/node/src/evm/requests/events.ts
@@ -1,48 +1,42 @@
 import {
   EVMEventLog,
-  EVMRequestCreatedLog,
-  EVMRequestFulfilledLog,
-  EVMWithdrawalRequestLog,
-  EVMWithdrawalFulfilledLog,
-  EVMFullApiRequestCreatedLog,
-  EVMTemplateRequestCreatedLog,
+  EVMMadeRequestLog,
+  EVMFulfilledRequestLog,
+  EVMRequestedWithdrawalLog,
+  EVMFulfilledWithdrawalLog,
+  EVMMadeFullRequestLog,
+  EVMMadeTemplateRequestLog,
 } from '../../types';
 import { airnodeRrpTopics } from '../contracts';
 
-export const API_CALL_REQUEST_TOPICS = [
-  airnodeRrpTopics.ClientRequestCreated,
-  airnodeRrpTopics.ClientFullRequestCreated,
-];
+export const API_CALL_REQUEST_TOPICS = [airnodeRrpTopics.MadeTemplateRequest, airnodeRrpTopics.MadeFullRequest];
 
-export const API_CALL_FULFILLED_TOPICS = [
-  airnodeRrpTopics.ClientRequestFulfilled,
-  airnodeRrpTopics.ClientRequestFailed,
-];
+export const API_CALL_FULFILLED_TOPICS = [airnodeRrpTopics.MadeTemplateRequest, airnodeRrpTopics.FailedRequest];
 
-export const WITHDRAWAL_REQUEST_TOPICS = [airnodeRrpTopics.WithdrawalRequested];
+export const WITHDRAWAL_REQUEST_TOPICS = [airnodeRrpTopics.RequestedWithdrawal];
 
-export const WITHDRAWAL_FULFILLED_TOPICS = [airnodeRrpTopics.WithdrawalFulfilled];
+export const WITHDRAWAL_FULFILLED_TOPICS = [airnodeRrpTopics.FulfilledWithdrawal];
 
-export function isApiCallRequest(log: EVMEventLog): log is EVMRequestCreatedLog {
+export function isApiCallRequest(log: EVMEventLog): log is EVMMadeRequestLog {
   return API_CALL_REQUEST_TOPICS.includes(log.parsedLog.topic);
 }
 
-export function isTemplateApiRequest(log: EVMEventLog): log is EVMTemplateRequestCreatedLog {
-  return log.parsedLog.topic === airnodeRrpTopics.ClientRequestCreated;
+export function isTemplateApiRequest(log: EVMEventLog): log is EVMMadeTemplateRequestLog {
+  return log.parsedLog.topic === airnodeRrpTopics.MadeTemplateRequest;
 }
 
-export function isFullApiRequest(log: EVMEventLog): log is EVMFullApiRequestCreatedLog {
-  return log.parsedLog.topic === airnodeRrpTopics.ClientFullRequestCreated;
+export function isFullApiRequest(log: EVMEventLog): log is EVMMadeFullRequestLog {
+  return log.parsedLog.topic === airnodeRrpTopics.MadeFullRequest;
 }
 
-export function isApiCallFulfillment(log: EVMEventLog): log is EVMRequestFulfilledLog {
+export function isApiCallFulfillment(log: EVMEventLog): log is EVMFulfilledRequestLog {
   return API_CALL_FULFILLED_TOPICS.includes(log.parsedLog.topic);
 }
 
-export function isWithdrawalRequest(log: EVMEventLog): log is EVMWithdrawalRequestLog {
+export function isWithdrawalRequest(log: EVMEventLog): log is EVMRequestedWithdrawalLog {
   return WITHDRAWAL_REQUEST_TOPICS.includes(log.parsedLog.topic);
 }
 
-export function isWithdrawalFulfillment(log: EVMEventLog): log is EVMWithdrawalFulfilledLog {
+export function isWithdrawalFulfillment(log: EVMEventLog): log is EVMFulfilledWithdrawalLog {
   return WITHDRAWAL_FULFILLED_TOPICS.includes(log.parsedLog.topic);
 }

--- a/packages/node/src/evm/requests/withdrawals.test.ts
+++ b/packages/node/src/evm/requests/withdrawals.test.ts
@@ -5,8 +5,8 @@ import { RequestStatus } from '../../types';
 
 describe('initialize (Withdrawal)', () => {
   it('builds a withdrawal request', () => {
-    const event = fixtures.evm.logs.buildWithdrawalRequest();
-    const parsedLog = parseAirnodeRrpLog<'WithdrawalRequested'>(event);
+    const event = fixtures.evm.logs.buildRequestedWithdrawal();
+    const parsedLog = parseAirnodeRrpLog<'RequestedWithdrawal'>(event);
     const parseLogWithMetadata = {
       parsedLog,
       blockNumber: 10716082,
@@ -71,8 +71,8 @@ describe('updateFulfilledRequests (Withdrawal)', () => {
 
 describe('mapRequests (Withdrawal)', () => {
   it('initializes and returns withdrawal requests', () => {
-    const event = fixtures.evm.logs.buildWithdrawalRequest();
-    const parsedLog = parseAirnodeRrpLog<'WithdrawalRequested'>(event);
+    const event = fixtures.evm.logs.buildRequestedWithdrawal();
+    const parsedLog = parseAirnodeRrpLog<'RequestedWithdrawal'>(event);
     const parsedLogWithMetadata = {
       parsedLog,
       blockNumber: 10716082,
@@ -101,10 +101,10 @@ describe('mapRequests (Withdrawal)', () => {
   });
 
   it('updates the status of fulfilled withdrawal requests', () => {
-    const requestEvent = fixtures.evm.logs.buildWithdrawalRequest();
-    const fulfillEvent = fixtures.evm.logs.buildWithdrawalFulfilled();
-    const requestLog = parseAirnodeRrpLog<'WithdrawalRequested'>(requestEvent);
-    const fulfillLog = parseAirnodeRrpLog<'WithdrawalFulfilled'>(fulfillEvent);
+    const requestEvent = fixtures.evm.logs.buildRequestedWithdrawal();
+    const fulfillEvent = fixtures.evm.logs.buildFulfilledWithdrawal();
+    const requestLog = parseAirnodeRrpLog<'RequestedWithdrawal'>(requestEvent);
+    const fulfillLog = parseAirnodeRrpLog<'FulfilledWithdrawal'>(fulfillEvent);
 
     const requestLogWithMetadata = {
       parsedLog: requestLog,

--- a/packages/node/src/evm/requests/withdrawals.ts
+++ b/packages/node/src/evm/requests/withdrawals.ts
@@ -3,15 +3,15 @@ import * as logger from '../../logger';
 import {
   ClientRequest,
   EVMEventLog,
-  EVMWithdrawalFulfilledLog,
-  EVMWithdrawalRequestLog,
+  EVMFulfilledWithdrawalLog,
+  EVMRequestedWithdrawalLog,
   LogsData,
   RequestStatus,
   Withdrawal,
   PendingLog,
 } from '../../types';
 
-export function initialize(logWithMetadata: EVMWithdrawalRequestLog): ClientRequest<Withdrawal> {
+export function initialize(logWithMetadata: EVMRequestedWithdrawalLog): ClientRequest<Withdrawal> {
   const { parsedLog } = logWithMetadata;
 
   const request: ClientRequest<Withdrawal> = {
@@ -64,10 +64,10 @@ export function updateFulfilledRequests(
 
 export function mapRequests(logsWithMetadata: EVMEventLog[]): LogsData<ClientRequest<Withdrawal>[]> {
   // Separate the logs
-  const requestLogs = logsWithMetadata.filter((log) => events.isWithdrawalRequest(log)) as EVMWithdrawalRequestLog[];
+  const requestLogs = logsWithMetadata.filter((log) => events.isWithdrawalRequest(log)) as EVMRequestedWithdrawalLog[];
   const fulfillmentLogs = logsWithMetadata.filter((log) =>
     events.isWithdrawalFulfillment(log)
-  ) as EVMWithdrawalFulfilledLog[];
+  ) as EVMFulfilledWithdrawalLog[];
 
   // Cast raw logs to typed WithdrawalRequest objects
   const withdrawalRequests = requestLogs.map(initialize);

--- a/packages/node/src/handlers/start-coordinator.test.ts
+++ b/packages/node/src/handlers/start-coordinator.test.ts
@@ -42,7 +42,7 @@ describe('startCoordinator', () => {
       xpub: 'xpub661MyMwAqRbcGeCE1g3KTUVGZsFDE3jMNinRPGCQGQsAp1nwinB9Pi16ihKPJw7qtaaTFuBHbRPeSc6w3AcMjxiHkAPfyp1hqQRbthv4Ryx',
     });
 
-    const regularRequest = fixtures.evm.logs.buildClientRequest();
+    const regularRequest = fixtures.evm.logs.buildMadeTemplateRequest();
     const getLogsSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getLogs');
     getLogsSpy.mockResolvedValueOnce([regularRequest]);
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -226,46 +226,46 @@ type ExtractTypedEvent<T> = T extends TypedEventFilter<any, infer EventArgsObjec
 // NOTE: Picking only the events used by node code
 export type AirnodeRrpFilters = Pick<
   InstanceType<typeof AirnodeRrp>['filters'],
-  | 'ClientRequestCreated'
-  | 'ClientFullRequestCreated'
-  | 'ClientRequestFulfilled'
-  | 'ClientRequestFailed'
-  | 'WithdrawalRequested'
-  | 'WithdrawalFulfilled'
+  | 'MadeTemplateRequest'
+  | 'MadeFullRequest'
+  | 'FulfilledRequest'
+  | 'FailedRequest'
+  | 'RequestedWithdrawal'
+  | 'FulfilledWithdrawal'
 >;
 export type AirnodeRrpLog<T extends keyof AirnodeRrpFilters> = ExtractTypedEvent<ReturnType<AirnodeRrpFilters[T]>>;
 
 export type AirnodeLogDescription<T> = Omit<ethers.utils.LogDescription, 'args'> & { readonly args: T };
 
-export interface EVMFullApiRequestCreatedLog extends EVMEventLogMetadata {
-  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'ClientFullRequestCreated'>>;
+export interface EVMMadeFullRequestLog extends EVMEventLogMetadata {
+  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'MadeFullRequest'>>;
 }
 
-export interface EVMTemplateRequestCreatedLog extends EVMEventLogMetadata {
-  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'ClientRequestCreated'>>;
+export interface EVMMadeTemplateRequestLog extends EVMEventLogMetadata {
+  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'MadeTemplateRequest'>>;
 }
 
-export type EVMRequestCreatedLog = EVMTemplateRequestCreatedLog | EVMFullApiRequestCreatedLog;
+export type EVMMadeRequestLog = EVMMadeTemplateRequestLog | EVMMadeFullRequestLog;
 
-export interface EVMRequestFulfilledLog extends EVMEventLogMetadata {
+export interface EVMFulfilledRequestLog extends EVMEventLogMetadata {
   readonly parsedLog:
-    | AirnodeLogDescription<AirnodeRrpLog<'ClientRequestFulfilled'>>
-    | AirnodeLogDescription<AirnodeRrpLog<'ClientRequestFailed'>>;
+    | AirnodeLogDescription<AirnodeRrpLog<'FulfilledRequest'>>
+    | AirnodeLogDescription<AirnodeRrpLog<'FailedRequest'>>;
 }
 
-export interface EVMWithdrawalRequestLog extends EVMEventLogMetadata {
-  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'WithdrawalRequested'>>;
+export interface EVMRequestedWithdrawalLog extends EVMEventLogMetadata {
+  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'RequestedWithdrawal'>>;
 }
 
-export interface EVMWithdrawalFulfilledLog extends EVMEventLogMetadata {
-  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'WithdrawalFulfilled'>>;
+export interface EVMFulfilledWithdrawalLog extends EVMEventLogMetadata {
+  readonly parsedLog: AirnodeLogDescription<AirnodeRrpLog<'FulfilledWithdrawal'>>;
 }
 
 export type EVMEventLog =
-  | EVMRequestCreatedLog
-  | EVMRequestFulfilledLog
-  | EVMWithdrawalRequestLog
-  | EVMWithdrawalFulfilledLog;
+  | EVMMadeRequestLog
+  | EVMFulfilledRequestLog
+  | EVMRequestedWithdrawalLog
+  | EVMFulfilledWithdrawalLog;
 
 // ===========================================
 // Transactions

--- a/packages/node/test/e2e/client-fulfill.feature.ts
+++ b/packages/node/test/e2e/client-fulfill.feature.ts
@@ -3,7 +3,7 @@ import * as handlers from '../../src/workers/local-handlers';
 import * as fixtures from '../fixtures';
 import * as e2e from '../setup/e2e';
 
-it('should call fail function on AirnodeRrp contract and emit ClientRequestFailed if client contract fulfillment fails', async () => {
+it('should call fail function on AirnodeRrp contract and emit FailedRequest if client contract fulfillment fails', async () => {
   jest.setTimeout(45_000);
 
   const provider = e2e.buildProvider();
@@ -25,9 +25,9 @@ it('should call fail function on AirnodeRrp contract and emit ClientRequestFaile
 
   const preinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
 
-  const preinvokeRegularRequests = preinvokeLogs.filter((log) => log.name === 'ClientRequestCreated');
-  const preinvokeFullRequests = preinvokeLogs.filter((log) => log.name === 'ClientFullRequestCreated');
-  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'ClientRequestFulfilled');
+  const preinvokeRegularRequests = preinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
+  const preinvokeFullRequests = preinvokeLogs.filter((log) => log.name === 'MadeFullRequest');
+  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
 
   expect(preinvokeLogs.length).toEqual(7);
   expect(preinvokeRegularRequests.length).toEqual(1);
@@ -42,10 +42,10 @@ it('should call fail function on AirnodeRrp contract and emit ClientRequestFaile
 
   const postinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
 
-  const postinvokeRegularRequests = postinvokeLogs.filter((log) => log.name === 'ClientRequestCreated');
-  const postinvokeFullRequests = postinvokeLogs.filter((log) => log.name === 'ClientFullRequestCreated');
-  const postinvokeFulfillmentsFailed = postinvokeLogs.filter((log) => log.name === 'ClientRequestFailed');
-  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'ClientRequestFulfilled');
+  const postinvokeRegularRequests = postinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
+  const postinvokeFullRequests = postinvokeLogs.filter((log) => log.name === 'MadeFullRequest');
+  const postinvokeFulfillmentsFailed = postinvokeLogs.filter((log) => log.name === 'FailedRequest');
+  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
 
   expect(postinvokeLogs.length).toEqual(9);
   expect(postinvokeRegularRequests.length).toEqual(1);
@@ -60,7 +60,7 @@ it('should call fail function on AirnodeRrp contract and emit ClientRequestFaile
   });
 });
 
-it('should call fail function on AirnodeRrp contract and emit ClientRequestFailed if client contract fulfillment runs out of gas', async () => {
+it('should call fail function on AirnodeRrp contract and emit FailedRequest if client contract fulfillment runs out of gas', async () => {
   jest.setTimeout(45_000);
 
   const provider = e2e.buildProvider();
@@ -82,9 +82,9 @@ it('should call fail function on AirnodeRrp contract and emit ClientRequestFaile
 
   const preinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
 
-  const preinvokeRegularRequests = preinvokeLogs.filter((log) => log.name === 'ClientRequestCreated');
-  const preinvokeFullRequests = preinvokeLogs.filter((log) => log.name === 'ClientFullRequestCreated');
-  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'ClientRequestFulfilled');
+  const preinvokeRegularRequests = preinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
+  const preinvokeFullRequests = preinvokeLogs.filter((log) => log.name === 'MadeFullRequest');
+  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
 
   expect(preinvokeLogs.length).toEqual(7);
   expect(preinvokeRegularRequests.length).toEqual(1);
@@ -99,10 +99,10 @@ it('should call fail function on AirnodeRrp contract and emit ClientRequestFaile
 
   const postinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
 
-  const postinvokeRegularRequests = postinvokeLogs.filter((log) => log.name === 'ClientRequestCreated');
-  const postinvokeFullRequests = postinvokeLogs.filter((log) => log.name === 'ClientFullRequestCreated');
-  const postinvokeFulfillmentsFailed = postinvokeLogs.filter((log) => log.name === 'ClientRequestFailed');
-  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'ClientRequestFulfilled');
+  const postinvokeRegularRequests = postinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
+  const postinvokeFullRequests = postinvokeLogs.filter((log) => log.name === 'MadeFullRequest');
+  const postinvokeFulfillmentsFailed = postinvokeLogs.filter((log) => log.name === 'FailedRequest');
+  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
 
   expect(postinvokeLogs.length).toEqual(9);
   expect(postinvokeRegularRequests.length).toEqual(1);

--- a/packages/node/test/e2e/no-duplication.feature.ts
+++ b/packages/node/test/e2e/no-duplication.feature.ts
@@ -19,9 +19,9 @@ it('does not process requests twice', async () => {
 
   const preinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
 
-  const preinvokeRegularRequests = preinvokeLogs.filter((log) => log.name === 'ClientRequestCreated');
-  const preinvokeFullRequests = preinvokeLogs.filter((log) => log.name === 'ClientFullRequestCreated');
-  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'ClientRequestFulfilled');
+  const preinvokeRegularRequests = preinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
+  const preinvokeFullRequests = preinvokeLogs.filter((log) => log.name === 'MadeFullRequest');
+  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
 
   expect(preinvokeLogs.length).toEqual(7);
   expect(preinvokeRegularRequests.length).toEqual(1);
@@ -36,9 +36,9 @@ it('does not process requests twice', async () => {
 
   const postinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
 
-  const postinvokeRegularRequests = postinvokeLogs.filter((log) => log.name === 'ClientRequestCreated');
-  const postinvokeFullRequests = postinvokeLogs.filter((log) => log.name === 'ClientFullRequestCreated');
-  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'ClientRequestFulfilled');
+  const postinvokeRegularRequests = postinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
+  const postinvokeFullRequests = postinvokeLogs.filter((log) => log.name === 'MadeFullRequest');
+  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'MadeTemplateRequest');
 
   expect(postinvokeLogs.length).toEqual(9);
   expect(postinvokeRegularRequests.length).toEqual(1);

--- a/packages/node/test/e2e/request-status.feature.ts
+++ b/packages/node/test/e2e/request-status.feature.ts
@@ -48,7 +48,7 @@ it('sets the correct status code for both successful and failed requests', async
   const encodedValidParams = encode(validParameters);
   const validRequest = logs.find((log) => log.args.parameters === encodedValidParams);
   const validFulfillment = logs.find(
-    (log) => log.args.requestId === validRequest!.args.requestId && log.name === 'ClientRequestFulfilled'
+    (log) => log.args.requestId === validRequest!.args.requestId && log.name === 'MadeTemplateRequest'
   );
   // The API responds with 723.392028 which multipled by the _times parameter
   const validResponseValue = ethers.BigNumber.from(validFulfillment!.args.data).toString();
@@ -59,7 +59,7 @@ it('sets the correct status code for both successful and failed requests', async
   const encodedInvalidParams = encode(invalidParameters);
   const invalidRequest = logs.find((log) => log.args.parameters === encodedInvalidParams);
   const invalidFulfillment = logs.find(
-    (log) => log.args.requestId === invalidRequest!.args.requestId && log.name === 'ClientRequestFulfilled'
+    (log) => log.args.requestId === invalidRequest!.args.requestId && log.name === 'MadeTemplateRequest'
   );
   // There is no valid response data to return so this is empty
   const invalidResponseValue = ethers.BigNumber.from(invalidFulfillment!.args.data).toString();

--- a/packages/node/test/e2e/withdrawals.feature.ts
+++ b/packages/node/test/e2e/withdrawals.feature.ts
@@ -28,8 +28,8 @@ it('processes withdrawals only once', async () => {
 
   // Check that the relevant withdrawal events are present
   const preinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
-  const preinvokeWithdrawals = preinvokeLogs.filter((log) => log.name === 'WithdrawalRequested');
-  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'WithdrawalFulfilled');
+  const preinvokeWithdrawals = preinvokeLogs.filter((log) => log.name === 'RequestedWithdrawal');
+  const preinvokeFulfillments = preinvokeLogs.filter((log) => log.name === 'FulfilledWithdrawal');
 
   expect(preinvokeLogs.length).toEqual(6);
   expect(preinvokeWithdrawals.length).toEqual(1);
@@ -61,8 +61,8 @@ it('processes withdrawals only once', async () => {
 
   // Check that the relevant withdrawal events are present
   const postinvokeLogs = await e2e.fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
-  const postinvokeWithdrawals = postinvokeLogs.filter((log) => log.name === 'WithdrawalRequested');
-  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'WithdrawalFulfilled');
+  const postinvokeWithdrawals = postinvokeLogs.filter((log) => log.name === 'RequestedWithdrawal');
+  const postinvokeFulfillments = postinvokeLogs.filter((log) => log.name === 'FulfilledWithdrawal');
 
   expect(postinvokeLogs.length).toEqual(7);
   expect(postinvokeWithdrawals.length).toEqual(1);

--- a/packages/node/test/fixtures/evm/event-logs.ts
+++ b/packages/node/test/fixtures/evm/event-logs.ts
@@ -5,7 +5,7 @@ type Log = ethers.providers.Log;
 // =================================================================
 // Regular requests
 // =================================================================
-export function buildClientRequest(overrides?: Partial<Log>): Log {
+export function buildMadeTemplateRequest(overrides?: Partial<Log>): Log {
   return {
     blockNumber: 12,
     blockHash: '0x458042df79d347cb555aac9cd71f6e98fd920356d56af3a5ab46ab81c1838a31',
@@ -24,7 +24,7 @@ export function buildClientRequest(overrides?: Partial<Log>): Log {
   };
 }
 
-export function buildClientRequestFulfilled(overrides?: Partial<Log>): Log {
+export function buildTemplateFulfilledRequest(overrides?: Partial<Log>): Log {
   return {
     blockNumber: 20,
     blockHash: '0x42264bc78c914bbdc0b7e0acb8da1a2be12ba1dc8fcb75a49116784d43d93412',
@@ -46,7 +46,7 @@ export function buildClientRequestFulfilled(overrides?: Partial<Log>): Log {
 // =================================================================
 // Full requests
 // =================================================================
-export function buildFullClientRequest(overrides?: Partial<Log>): Log {
+export function buildMadeFullRequest(overrides?: Partial<Log>): Log {
   return {
     blockNumber: 16,
     blockHash: '0x9023292f59fe980a807f846db807e074d22b559065afba1af4948ae42239068c',
@@ -65,7 +65,7 @@ export function buildFullClientRequest(overrides?: Partial<Log>): Log {
   };
 }
 
-export function buildFullRequestFulfilled(overrides?: Partial<Log>): Log {
+export function buildFullFulfilledRequest(overrides?: Partial<Log>): Log {
   return {
     blockNumber: 21,
     blockHash: '0xc7b5393a877e8bd1cb3bc44e9dde29fbe2c3c2e9df022d1277ca4e97505a07f2',
@@ -87,7 +87,7 @@ export function buildFullRequestFulfilled(overrides?: Partial<Log>): Log {
 // =================================================================
 // Withdrawals
 // =================================================================
-export function buildWithdrawalRequest(overrides?: Partial<Log>): Log {
+export function buildRequestedWithdrawal(overrides?: Partial<Log>): Log {
   return {
     blockNumber: 18,
     blockHash: '0x6a1cc2c95d739003d023b5ed3174979fed0a26c5ec3b2eec21d4950120abaa90',
@@ -107,7 +107,7 @@ export function buildWithdrawalRequest(overrides?: Partial<Log>): Log {
   };
 }
 
-export function buildWithdrawalFulfilled(overrides?: Partial<Log>): Log {
+export function buildFulfilledWithdrawal(overrides?: Partial<Log>): Log {
   return {
     blockNumber: 22,
     blockHash: '0x10036d3cc8f54317033f529627280652129644ce01301a5856d82219bd4250be',


### PR DESCRIPTION
These changes will not guarantee that all tests and code related to protocol events will pass/work but they will get us one step closer to getting the node package to compile again and be able to run tests as well as start the app.

Changes in protocol event names:
- ClientFullRequestCreated -> MadeFullRequest
- ClientRequestCreated -> MadeTemplateRequest
- ClientRequestFailed -> FailedRequest
- ClientRequestFulfilled -> FulfilledRequest
- WithdrawalFulfilled -> FulfilledWithdrawal
- WithdrawalRequested -> RequestedWithdrawal