### PR TITLE
AN-105: Removes destination address param when fulfilling withdrawal …

### DIFF
--- a/packages/node/src/evm/fulfillments/withdrawals.test.ts
+++ b/packages/node/src/evm/fulfillments/withdrawals.test.ts
@@ -54,7 +54,6 @@ describe('submitWithdrawal', () => {
       withdrawal.id,
       withdrawal.airnodeAddress,
       withdrawal.requesterIndex,
-      withdrawal.destinationAddress,
       {
         gasPrice,
         gasLimit: ethers.BigNumber.from(70_000),
@@ -226,7 +225,6 @@ describe('submitWithdrawal', () => {
       withdrawal.id,
       withdrawal.airnodeAddress,
       withdrawal.requesterIndex,
-      withdrawal.destinationAddress,
       {
         gasPrice,
         gasLimit: ethers.BigNumber.from(70_000),

--- a/packages/node/src/evm/handlers/fetch-pending-requests.test.ts
+++ b/packages/node/src/evm/handlers/fetch-pending-requests.test.ts
@@ -53,7 +53,6 @@ describe('fetchPendingRequests', () => {
         {
           airnodeAddress: '0x19255a4ec31e89cea54d1f125db7536e874ab4a96b4d4f6438668b6bb10a6adb',
           designatedWallet: '0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E',
-          destinationAddress: '0x6812efaf684AA899949212A2A6785305EC0F1474',
           id: '0xd9db6b416bbd9a87f4e693d66a0323eafde6591cae537727cd1f4e7ff0b53d5a',
           metadata: {
             blockNumber: 18,

--- a/packages/node/src/evm/handlers/process-transactions.test.ts
+++ b/packages/node/src/evm/handlers/process-transactions.test.ts
@@ -58,7 +58,6 @@ describe('processTransactions', () => {
       withdrawal.id,
       withdrawal.airnodeAddress,
       withdrawal.requesterIndex,
-      withdrawal.destinationAddress,
       {
         gasPrice,
         gasLimit: ethers.BigNumber.from(70_000),

--- a/packages/node/src/evm/requests/withdrawals.test.ts
+++ b/packages/node/src/evm/requests/withdrawals.test.ts
@@ -18,7 +18,6 @@ describe('initialize (Withdrawal)', () => {
     expect(res).toEqual({
       airnodeAddress: '0x19255a4ec31e89cea54d1f125db7536e874ab4a96b4d4f6438668b6bb10a6adb',
       designatedWallet: '0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E',
-      destinationAddress: '0x6812efaf684AA899949212A2A6785305EC0F1474',
       id: '0xd9db6b416bbd9a87f4e693d66a0323eafde6591cae537727cd1f4e7ff0b53d5a',
       metadata: {
         blockNumber: 10716082,
@@ -47,7 +46,6 @@ describe('updateFulfilledRequests (Withdrawal)', () => {
       {
         airnodeAddress: 'airnodeAddress',
         designatedWallet: 'designatedWallet',
-        destinationAddress: 'destinationAddress',
         id,
         metadata: {
           blockNumber: 10716082,
@@ -86,7 +84,6 @@ describe('mapRequests (Withdrawal)', () => {
       {
         airnodeAddress: '0x19255a4ec31e89cea54d1f125db7536e874ab4a96b4d4f6438668b6bb10a6adb',
         designatedWallet: '0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E',
-        destinationAddress: '0x6812efaf684AA899949212A2A6785305EC0F1474',
         id: '0xd9db6b416bbd9a87f4e693d66a0323eafde6591cae537727cd1f4e7ff0b53d5a',
         metadata: {
           blockNumber: 10716082,

--- a/packages/node/src/evm/requests/withdrawals.ts
+++ b/packages/node/src/evm/requests/withdrawals.ts
@@ -17,7 +17,6 @@ export function initialize(logWithMetadata: EVMRequestedWithdrawalLog): ClientRe
   const request: ClientRequest<Withdrawal> = {
     airnodeAddress: parsedLog.args.airnode,
     designatedWallet: parsedLog.args.designatedWallet,
-    destinationAddress: parsedLog.args.destination,
     id: parsedLog.args.withdrawalRequestId,
     metadata: {
       blockNumber: logWithMetadata.blockNumber,

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -87,7 +87,6 @@ export interface ApiCallTemplate {
 
 export interface Withdrawal {
   readonly airnodeAddress: string;
-  readonly destinationAddress: string;
   readonly requesterIndex: string;
 }
 

--- a/packages/node/test/e2e/withdrawals.feature.ts
+++ b/packages/node/test/e2e/withdrawals.feature.ts
@@ -10,7 +10,7 @@ it('processes withdrawals only once', async () => {
 
   const provider = e2e.buildProvider();
 
-  const requests = [fixtures.operation.buildWithdrawal({ requesterId: 'alice', destination: 'alice' })];
+  const requests = [fixtures.operation.buildWithdrawal({ requesterId: 'alice' })];
 
   const deployerIndex = e2e.getDeployerIndex(__filename);
   const deployConfig = fixtures.operation.buildDeployConfig({ deployerIndex, requests });

--- a/packages/node/test/fixtures/operation/requests.ts
+++ b/packages/node/test/fixtures/operation/requests.ts
@@ -40,7 +40,6 @@ export function buildWithdrawal(overrides?: Partial<Withdrawal>): Withdrawal {
     requesterId: 'alice',
     type: 'withdrawal',
     airnode: 'CurrencyConverterAirnode',
-    destination: 'alice',
     ...overrides,
   };
 }

--- a/packages/node/test/fixtures/requests/withdrawals.ts
+++ b/packages/node/test/fixtures/requests/withdrawals.ts
@@ -9,7 +9,6 @@ export function buildWithdrawal(params?: Partial<ClientRequest<Withdrawal>>): Cl
   return {
     airnodeAddress: 'airnodeAddress',
     designatedWallet: 'designatedWallet',
-    destinationAddress: 'destinationAddress',
     id: 'withdrawalId',
     metadata,
     requesterIndex: '1',


### PR DESCRIPTION
…requests

Fixes compilation errors due to protocol no longer taking the destination address as param for withdrawal requests. Now funds will be sent back to the sponsor. 

@andreogle I found this call to [fixtures.operation.buildWithdrawal()](https://github.com/api3dao/airnode/blob/ecd78ef7ff504a9ce6e5c52da0afa7eaf6b577f5/packages/node/test/e2e/withdrawals.feature.ts#L13) and I'm not sure why we didn't use fixtures.requests.buildWithdrawal() instead. It's also kind of weird to have this dependency on the operation package isn't it?