### PR TITLE
AN-94: Replace requester with sponsor

### DIFF
--- a/packages/node/src/coordinator/calls/aggregation.test.ts
+++ b/packages/node/src/coordinator/calls/aggregation.test.ts
@@ -24,7 +24,7 @@ describe('aggregate (API calls)', () => {
     const res = aggregation.aggregate(fixtures.buildConfig(), apiCalls);
     expect(res).toEqual({
       apiCallId: {
-        requesterIndex: '3',
+        sponsorAddress: '3', //TODO: fix value
         airnodeAddress: 'airnodeAddress',
         clientAddress: 'clientAddress',
         sponsorWallet: 'sponsorWallet',
@@ -47,7 +47,7 @@ describe('aggregate (API calls)', () => {
     const res = aggregation.aggregate(fixtures.buildConfig(), apiCalls);
     expect(res).toEqual({
       apiCallId: {
-        requesterIndex: '3',
+        sponsorAddress: '3', //TODO: fix value
         airnodeAddress: 'airnodeAddress',
         clientAddress: 'clientAddress',
         sponsorWallet: 'sponsorWallet',

--- a/packages/node/src/coordinator/calls/aggregation.ts
+++ b/packages/node/src/coordinator/calls/aggregation.ts
@@ -6,7 +6,7 @@ function buildAggregatedCall(config: Config, request: ClientRequest<ApiCall>): A
 
   return {
     id: request.id,
-    requesterIndex: request.requesterIndex,
+    sponsorAddress: request.sponsorAddress,
     airnodeAddress: request.airnodeAddress!,
     clientAddress: request.clientAddress,
     sponsorWallet: request.sponsorWallet,

--- a/packages/node/src/evm/authorization/authorization-fetching.test.ts
+++ b/packages/node/src/evm/authorization/authorization-fetching.test.ts
@@ -57,7 +57,7 @@ describe('fetch (authorizations)', () => {
       '0xf5ad700af68118777f79fd1d1c8568f7377d4ae9e9ccce5970fe63bc7a1c1d6d',
       apiCalls.slice(0, 10).map((a) => a.id),
       apiCalls.slice(0, 10).map((a) => a.endpointId),
-      apiCalls.slice(0, 10).map((a) => a.requesterIndex),
+      apiCalls.slice(0, 10).map((a) => a.sponsorAddress),
       apiCalls.slice(0, 10).map((a) => a.sponsorWallet),
       apiCalls.slice(0, 10).map((a) => a.clientAddress),
     ];
@@ -65,7 +65,7 @@ describe('fetch (authorizations)', () => {
       '0xf5ad700af68118777f79fd1d1c8568f7377d4ae9e9ccce5970fe63bc7a1c1d6d',
       apiCalls.slice(10, 19).map((a) => a.id),
       apiCalls.slice(10, 19).map((a) => a.endpointId),
-      apiCalls.slice(10, 19).map((a) => a.requesterIndex),
+      apiCalls.slice(10, 19).map((a) => a.sponsorAddress),
       apiCalls.slice(10, 19).map((a) => a.sponsorWallet),
       apiCalls.slice(10, 19).map((a) => a.clientAddress),
     ];

--- a/packages/node/src/evm/authorization/authorization-fetching.ts
+++ b/packages/node/src/evm/authorization/authorization-fetching.ts
@@ -29,7 +29,7 @@ export async function fetchAuthorizationStatus(
       apiCall.id,
       // TODO: make sure endpointId is not null
       apiCall.endpointId!,
-      apiCall.requesterIndex,
+      apiCall.sponsorAddress,
       apiCall.clientAddress
     );
 
@@ -51,7 +51,7 @@ async function fetchAuthorizationStatuses(
   // Ordering must remain the same when mapping these two arrays
   const requestIds = apiCalls.map((a) => a.id);
   const endpointIds = apiCalls.map((a) => a.endpointId);
-  const requesterIndices = apiCalls.map((a) => a.requesterIndex);
+  const sponsorAddresses = apiCalls.map((a) => a.sponsorAddress);
   const clientAddresses = apiCalls.map((a) => a.clientAddress);
 
   const contractCall = () =>
@@ -61,7 +61,7 @@ async function fetchAuthorizationStatuses(
       requestIds,
       // TODO: make sure all endpointIds are non null
       endpointIds as string[],
-      requesterIndices,
+      sponsorAddresses,
       clientAddresses
     );
 

--- a/packages/node/src/evm/contracts/airnodeRrp.test.ts
+++ b/packages/node/src/evm/contracts/airnodeRrp.test.ts
@@ -12,7 +12,6 @@ describe('AirnodeRrp', () => {
       'checkAuthorizationStatus',
       'checkAuthorizationStatuses',
       'clientAddressToNoRequests',
-      'createRequester',
       'createTemplate',
       'fail',
       'fulfill',
@@ -23,12 +22,10 @@ describe('AirnodeRrp', () => {
       'makeRequest',
       'requestWithIdHasFailed',
       'requestWithdrawal',
-      'requesterIndexToAdmin',
       'requesterIndexToClientAddressToEndorsementStatus',
-      'requesterIndexToNextWithdrawalRequestIndex',
+      'sponsorToWithdrawalRequestCount',
       'setAirnodeToXpub',
       'setClientEndorsementStatus',
-      'setRequesterAdmin',
     ]);
   });
 
@@ -44,8 +41,6 @@ describe('AirnodeRrp', () => {
       'MadeTemplateRequest',
       'FailedRequest',
       'FulfilledRequest',
-      'RequesterCreated',
-      'RequesterUpdated',
       'TemplateCreated',
       'FulfilledWithdrawal',
       'RequestedWithdrawal',

--- a/packages/node/src/evm/fulfillments/index.test.ts
+++ b/packages/node/src/evm/fulfillments/index.test.ts
@@ -38,10 +38,10 @@ describe('submit', () => {
   it('submits transactions for multiple wallets and returns the transactions', async () => {
     const requests: GroupedRequests = {
       apiCalls: [
-        fixtures.requests.buildApiCall({ id: '0x1', nonce: 10, requesterIndex: '6' }),
-        fixtures.requests.buildApiCall({ id: '0x2', nonce: 11, requesterIndex: '7' }),
+        fixtures.requests.buildApiCall({ id: '0x1', nonce: 10, sponsorAddress: '6' }), //TODO: fix value
+        fixtures.requests.buildApiCall({ id: '0x2', nonce: 11, sponsorAddress: '7' }), //TODO: fix value
       ],
-      withdrawals: [fixtures.requests.buildWithdrawal({ id: '0x5', nonce: 3, requesterIndex: '8' })],
+      withdrawals: [fixtures.requests.buildWithdrawal({ id: '0x5', nonce: 3, sponsorAddress: '8' })],
     };
     const gasPrice = ethers.BigNumber.from(1000);
     const provider = new ethers.providers.JsonRpcProvider();

--- a/packages/node/src/evm/fulfillments/index.ts
+++ b/packages/node/src/evm/fulfillments/index.ts
@@ -26,14 +26,14 @@ export async function submit(state: ProviderState<EVMProviderState>) {
 
   const { AirnodeRrp } = state.contracts;
 
-  const requestsByRequesterIndex = grouping.groupRequestsByRequesterIndex(state.requests);
+  const requestsBySponsorAddress = grouping.groupRequestsBySponsorAddress(state.requests);
 
-  const requesterIndices = Object.keys(requestsByRequesterIndex);
+  const sponsorAddresses = Object.keys(requestsBySponsorAddress);
 
-  const promises = flatMap(requesterIndices, (index) => {
-    const requests = requestsByRequesterIndex[index];
-    const signingWallet = wallet.deriveSigningWalletFromIndex(state.masterHDNode, index);
-    const signer = signingWallet.connect(state.provider);
+  const promises = flatMap(sponsorAddresses, (sponsorAddress) => {
+    const requests = requestsBySponsorAddress[sponsorAddress];
+    const sponsorWallet = wallet.deriveSponsorWallet(state.masterHDNode, sponsorAddress);
+    const signer = sponsorWallet.connect(state.provider);
     const contract = AirnodeRrpFactory.connect(AirnodeRrp, signer);
 
     const txOptions: TransactionOptions = {

--- a/packages/node/src/evm/fulfillments/withdrawals.test.ts
+++ b/packages/node/src/evm/fulfillments/withdrawals.test.ts
@@ -44,7 +44,7 @@ describe('submitWithdrawal', () => {
       { level: 'DEBUG', message: `Withdrawal gas limit estimated at 70000 for Request:${withdrawal.id}` },
       {
         level: 'INFO',
-        message: `Submitting withdrawal wallet index:${withdrawal.requesterIndex} for Request:${withdrawal.id}...`,
+        message: `Submitting withdrawal sponsor address:${withdrawal.sponsorAddress} for Request:${withdrawal.id}...`,
       },
     ]);
     expect(err).toEqual(null);
@@ -53,7 +53,7 @@ describe('submitWithdrawal', () => {
     expect(fulfillWithdrawalMock).toHaveBeenCalledWith(
       withdrawal.id,
       withdrawal.airnodeAddress,
-      withdrawal.requesterIndex,
+      withdrawal.sponsorAddress,
       {
         gasPrice,
         gasLimit: ethers.BigNumber.from(70_000),
@@ -76,7 +76,7 @@ describe('submitWithdrawal', () => {
     expect(logs).toEqual([
       {
         level: 'DEBUG',
-        message: `Withdrawal wallet index:${withdrawal.requesterIndex} for Request:${withdrawal.id} not actioned as it has status:${withdrawal.status}`,
+        message: `Withdrawal sponsor address:${withdrawal.sponsorAddress} for Request:${withdrawal.id} not actioned as it has status:${withdrawal.status}`,
       },
     ]);
     expect(err).toEqual(null);
@@ -106,7 +106,7 @@ describe('submitWithdrawal', () => {
     expect(blockedRes[0]).toEqual([
       {
         level: 'INFO',
-        message: `Withdrawal wallet index:${blocked.requesterIndex} for Request:${blocked.id} not actioned as it has status:${blocked.status}`,
+        message: `Withdrawal sponsor address:${blocked.sponsorAddress} for Request:${blocked.id} not actioned as it has status:${blocked.status}`,
       },
     ]);
     expect(blockedRes[1]).toEqual(null);
@@ -114,7 +114,7 @@ describe('submitWithdrawal', () => {
     expect(erroredRes[0]).toEqual([
       {
         level: 'INFO',
-        message: `Withdrawal wallet index:${errored.requesterIndex} for Request:${errored.id} not actioned as it has status:${errored.status}`,
+        message: `Withdrawal sponsor address:${errored.sponsorAddress} for Request:${errored.id} not actioned as it has status:${errored.status}`,
       },
     ]);
     expect(erroredRes[1]).toEqual(null);
@@ -149,7 +149,7 @@ describe('submitWithdrawal', () => {
     expect(logs).toEqual([
       {
         level: 'ERROR',
-        message: `Withdrawal wallet index:${withdrawal.requesterIndex} for Request:${withdrawal.id} cannot be submitted as it does not have a nonce`,
+        message: `Withdrawal sponsor address:${withdrawal.sponsorAddress} for Request:${withdrawal.id} cannot be submitted as it does not have a nonce`,
       },
     ]);
     expect(err).toEqual(null);
@@ -167,7 +167,7 @@ describe('submitWithdrawal', () => {
     expect(logs).toEqual([
       {
         level: 'ERROR',
-        message: `Failed to fetch wallet index:${withdrawal.requesterIndex} balance for Request:${withdrawal.id}`,
+        message: `Failed to fetch sponsor address:${withdrawal.sponsorAddress} balance for Request:${withdrawal.id}`,
         error: new Error('Could not fetch balance'),
       },
     ]);
@@ -210,11 +210,11 @@ describe('submitWithdrawal', () => {
       { level: 'DEBUG', message: `Withdrawal gas limit estimated at 70000 for Request:${withdrawal.id}` },
       {
         level: 'INFO',
-        message: `Submitting withdrawal wallet index:${withdrawal.requesterIndex} for Request:${withdrawal.id}...`,
+        message: `Submitting withdrawal sponsor address:${withdrawal.sponsorAddress} for Request:${withdrawal.id}...`,
       },
       {
         level: 'ERROR',
-        message: `Error submitting wallet index:${withdrawal.requesterIndex} withdrawal for Request:${withdrawal.id}`,
+        message: `Error submitting sponsor address:${withdrawal.sponsorAddress} withdrawal for Request:${withdrawal.id}`,
         error: new Error('Could not submit withdrawal'),
       },
     ]);
@@ -224,7 +224,7 @@ describe('submitWithdrawal', () => {
     expect(fulfillWithdrawalMock).toHaveBeenCalledWith(
       withdrawal.id,
       withdrawal.airnodeAddress,
-      withdrawal.requesterIndex,
+      withdrawal.sponsorAddress,
       {
         gasPrice,
         gasLimit: ethers.BigNumber.from(70_000),

--- a/packages/node/src/evm/handlers/fetch-pending-requests.test.ts
+++ b/packages/node/src/evm/handlers/fetch-pending-requests.test.ts
@@ -43,7 +43,7 @@ describe('fetchPendingRequests', () => {
             to: 'USD',
           },
           requestCount: '1',
-          requesterIndex: '10',
+          sponsorAddress: '10', //TODO: fix value
           status: 'Pending',
           templateId: null,
           type: 'full',
@@ -60,7 +60,7 @@ describe('fetchPendingRequests', () => {
             ignoreBlockedRequestsAfterBlocks: 20,
             transactionHash: '0xac3aa3683548a631dd7561cfa32d4e003f43bfc061bb40adc9920c9c1d4d6a60',
           },
-          requesterIndex: '1',
+          sponsorAddress: '1', //TODO: fix value
           status: 'Pending',
         },
       ],

--- a/packages/node/src/evm/handlers/initialize-provider.test.ts
+++ b/packages/node/src/evm/handlers/initialize-provider.test.ts
@@ -61,7 +61,7 @@ describe('initializeProvider', () => {
           to: 'USD',
         },
         requestCount: '1',
-        requesterIndex: '10',
+        sponsorAddress: '10', //TODO: fix value
         status: 'Pending',
         templateId: null,
         type: 'full',
@@ -91,7 +91,7 @@ describe('initializeProvider', () => {
           to: 'USD',
         },
         requestCount: '1',
-        requesterIndex: '5',
+        sponsorAddress: '5', //TODO: fix value
         status: 'Pending',
         templateId: '0x41e0458b020642796b14db9bb790bcdebab805ec4b639232277f0e007b088796',
         type: 'regular',

--- a/packages/node/src/evm/handlers/initialize-provider.ts
+++ b/packages/node/src/evm/handlers/initialize-provider.ts
@@ -23,14 +23,14 @@ async function fetchAuthorizations(currentState: ProviderState<EVMProviderState>
 }
 
 async function fetchTransactionCounts(currentState: ProviderState<EVMProviderState>) {
-  const requesterIndices = requests.mapUniqueRequesterIndices(currentState.requests);
+  const sponsors = requests.mapUniqueSponsorAddresses(currentState.requests);
   const fetchOptions = {
     currentBlock: currentState.currentBlock!,
     masterHDNode: currentState.masterHDNode,
     provider: currentState.provider,
   };
   // This should not throw
-  const [logs, res] = await transactionCounts.fetchByRequesterIndex(requesterIndices, fetchOptions);
+  const [logs, res] = await transactionCounts.fetchBySponsor(sponsors, fetchOptions);
   return { id: 'transaction-counts', data: res, logs };
 }
 
@@ -130,10 +130,10 @@ export async function initializeProvider(
   const authRes = authAndTxResults.find((r) => r.id === 'authorizations')!;
   logger.logPending(authRes.logs, baseLogOptions);
 
-  const transactionCountsByRequesterIndex = txCountRes.data!;
+  const transactionCountsBySponsorAddress = txCountRes.data!;
   const authorizationsByRequestId = authRes.data!;
 
-  const state6 = state.update(state5, { transactionCountsByRequesterIndex });
+  const state6 = state.update(state5, { transactionCountsBySponsorAddress });
 
   // =================================================================
   // STEP 7: Apply authorization statuses to requests

--- a/packages/node/src/evm/handlers/process-transactions.test.ts
+++ b/packages/node/src/evm/handlers/process-transactions.test.ts
@@ -38,14 +38,17 @@ describe('processTransactions', () => {
       hash: '0xad33fe94de7294c6ab461325828276185dff6fed92c54b15ac039c6160d2bac3',
     });
 
-    const apiCall = fixtures.requests.buildSubmittableApiCall({ requesterIndex: '4' });
-    const withdrawal = fixtures.requests.buildWithdrawal({ requesterIndex: '5' });
+    const apiCall = fixtures.requests.buildSubmittableApiCall({ sponsorAddress: '4' }); //TODO: fix value
+    const withdrawal = fixtures.requests.buildWithdrawal({ sponsorAddress: '5' }); //TODO: fix value
     const requests: GroupedRequests = {
       apiCalls: [apiCall],
       withdrawals: [withdrawal],
     };
-    const transactionCountsByRequesterIndex = { 4: 79, 5: 212 };
-    const state = fixtures.buildEVMProviderState({ requests, transactionCountsByRequesterIndex });
+    const transactionCountsBySponsorAddress = { 4: 79, 5: 212 }; //TODO: fix value
+    const state = fixtures.buildEVMProviderState({
+      requests,
+      transactionCountsBySponsorAddress,
+    });
 
     const res = await processTransactions(state);
     expect(res.requests.apiCalls[0]).toEqual({ ...apiCall, nonce: 79 });
@@ -57,7 +60,7 @@ describe('processTransactions', () => {
     expect(fulfillWithdrawalMock).toHaveBeenCalledWith(
       withdrawal.id,
       withdrawal.airnodeAddress,
-      withdrawal.requesterIndex,
+      withdrawal.sponsorAddress,
       {
         gasPrice,
         gasLimit: ethers.BigNumber.from(70_000),
@@ -85,13 +88,16 @@ describe('processTransactions', () => {
     const gasPriceSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getGasPrice');
     gasPriceSpy.mockRejectedValue(new Error('Gas price cannot be fetched'));
 
-    const apiCall = fixtures.requests.buildSubmittableApiCall({ requesterIndex: '4' });
+    const apiCall = fixtures.requests.buildSubmittableApiCall({ sponsorAddress: '4' }); //TODO: fix value
     const requests: GroupedRequests = {
       apiCalls: [apiCall],
       withdrawals: [],
     };
-    const transactionCountsByRequesterIndex = { 4: 79 };
-    const state = fixtures.buildEVMProviderState({ requests, transactionCountsByRequesterIndex });
+    const transactionCountsBySponsorAddress = { 4: 79 }; //TODO: fix value
+    const state = fixtures.buildEVMProviderState({
+      requests,
+      transactionCountsBySponsorAddress,
+    });
 
     const res = await processTransactions(state);
     expect(res.requests.apiCalls[0]).toEqual({ ...apiCall, nonce: 79 });

--- a/packages/node/src/evm/requests/api-calls.ts
+++ b/packages/node/src/evm/requests/api-calls.ts
@@ -49,8 +49,8 @@ export function initialize(log: EVMMadeRequestLog): ClientRequest<ApiCall> {
     },
     // Parameters are decoded separately
     parameters: {},
-    requestCount: parsedLog.args.noRequests.toString(),
-    requesterIndex: parsedLog.args.requesterIndex?.toString(),
+    requestCount: parsedLog.args.requesterRequestCount.toString(),
+    sponsorAddress: parsedLog.args.sponsor,
     status: RequestStatus.Pending,
     templateId: events.isTemplateApiRequest(log) ? log.parsedLog.args.templateId : null,
     type: getApiCallType(parsedLog.topic),

--- a/packages/node/src/evm/requests/blocking.test.ts
+++ b/packages/node/src/evm/requests/blocking.test.ts
@@ -3,9 +3,9 @@ import * as fixtures from '../../../test/fixtures';
 import { GroupedRequests, RequestErrorCode, RequestStatus } from '../../types';
 
 describe('blockRequestsWithWithdrawals', () => {
-  it('blocks API calls with pending withdrawals from the same wallet index', () => {
-    const apiCall = fixtures.requests.buildApiCall({ requesterIndex: '123' });
-    const withdrawal = fixtures.requests.buildWithdrawal({ requesterIndex: '123' });
+  it('blocks API calls with pending withdrawals from the same sponsor', () => {
+    const apiCall = fixtures.requests.buildApiCall({ sponsorAddress: '123' }); //TODO: fix value
+    const withdrawal = fixtures.requests.buildWithdrawal({ sponsorAddress: '123' }); //TODO: fix value
     const requests: GroupedRequests = {
       apiCalls: [apiCall],
       withdrawals: [withdrawal],
@@ -22,8 +22,8 @@ describe('blockRequestsWithWithdrawals', () => {
   });
 
   it('does nothing if API call and withdrawal wallet indices do not match', () => {
-    const apiCall = fixtures.requests.buildApiCall({ requesterIndex: '123' });
-    const withdrawal = fixtures.requests.buildWithdrawal({ requesterIndex: '456' });
+    const apiCall = fixtures.requests.buildApiCall({ sponsorAddress: '123' }); //TODO: fix value
+    const withdrawal = fixtures.requests.buildWithdrawal({ sponsorAddress: '456' }); //TODO: fix value
     const requests: GroupedRequests = {
       apiCalls: [apiCall],
       withdrawals: [withdrawal],
@@ -39,13 +39,16 @@ describe('blockRequestsWithWithdrawals', () => {
   });
 
   it('does not block API calls linked to non-pending withdrawals', () => {
-    const requesterIndex = '123';
-    const apiCall = fixtures.requests.buildApiCall({ requesterIndex });
+    const sponsorAddress = '123'; //TODO: fix value
+    const apiCall = fixtures.requests.buildApiCall({ sponsorAddress });
     const statuses = Object.keys(RequestStatus).filter(
       (status) => RequestStatus[status as RequestStatus] !== RequestStatus.Pending
     );
     const withdrawals = statuses.map((status) => {
-      return fixtures.requests.buildWithdrawal({ status: RequestStatus[status as RequestStatus], requesterIndex });
+      return fixtures.requests.buildWithdrawal({
+        status: RequestStatus[status as RequestStatus],
+        sponsorAddress,
+      });
     });
     const requests: GroupedRequests = {
       apiCalls: [apiCall],

--- a/packages/node/src/evm/requests/blocking.ts
+++ b/packages/node/src/evm/requests/blocking.ts
@@ -19,12 +19,12 @@ export function blockRequestsWithWithdrawals(requests: GroupedRequests): LogsDat
   const pendingApiCalls = requests.apiCalls.filter((r) => r.status === RequestStatus.Pending);
   const pendingWithdrawals = requests.withdrawals.filter((r) => r.status === RequestStatus.Pending);
 
-  const withdrawalsByRequesterIndex = fromPairs(pendingWithdrawals.map((w) => [w.requesterIndex, w]));
+  const withdrawalsBySponsorAddress = fromPairs(pendingWithdrawals.map((w) => [w.sponsorAddress, w]));
 
   const initialState: ApiCallsWithLogs = { logs: [], apiCalls: [] };
 
   const { logs, apiCalls } = pendingApiCalls.reduce((acc, apiCall) => {
-    const pendingWithdrawal = withdrawalsByRequesterIndex[apiCall.requesterIndex!];
+    const pendingWithdrawal = withdrawalsBySponsorAddress[apiCall.sponsorAddress];
 
     if (pendingWithdrawal) {
       const warningLog = logger.pend(

--- a/packages/node/src/evm/requests/withdrawals.test.ts
+++ b/packages/node/src/evm/requests/withdrawals.test.ts
@@ -25,7 +25,7 @@ describe('initialize (Withdrawal)', () => {
         ignoreBlockedRequestsAfterBlocks: 20,
         transactionHash: '0x61c972d98485da38115a5730b6741ffc4f3e09ae5e1df39a7ff18a68777ab318',
       },
-      requesterIndex: '1',
+      sponsorAddress: '1', //TODO: fix value
       status: RequestStatus.Pending,
     });
   });
@@ -53,7 +53,7 @@ describe('updateFulfilledRequests (Withdrawal)', () => {
           ignoreBlockedRequestsAfterBlocks: 20,
           transactionHash: 'logTransactionHash',
         },
-        requesterIndex: '1',
+        sponsorAddress: '1', //TODO: fix value
         status: RequestStatus.Fulfilled,
       },
     ]);
@@ -91,7 +91,7 @@ describe('mapRequests (Withdrawal)', () => {
           ignoreBlockedRequestsAfterBlocks: 20,
           transactionHash: '0x61c972d98485da38115a5730b6741ffc4f3e09ae5e1df39a7ff18a68777ab318',
         },
-        requesterIndex: '1',
+        sponsorAddress: '1', //TODO: fix value
         status: RequestStatus.Pending,
       },
     ]);

--- a/packages/node/src/evm/requests/withdrawals.ts
+++ b/packages/node/src/evm/requests/withdrawals.ts
@@ -24,7 +24,7 @@ export function initialize(logWithMetadata: EVMRequestedWithdrawalLog): ClientRe
       ignoreBlockedRequestsAfterBlocks: logWithMetadata.ignoreBlockedRequestsAfterBlocks,
       transactionHash: logWithMetadata.transactionHash,
     },
-    requesterIndex: parsedLog.args.requesterIndex.toString(),
+    sponsorAddress: parsedLog.args.sponsor,
     status: RequestStatus.Pending,
   };
 

--- a/packages/node/src/evm/templates/template-application.test.ts
+++ b/packages/node/src/evm/templates/template-application.test.ts
@@ -36,7 +36,7 @@ describe('mergeApiCallsWithTemplates', () => {
     expect(res[0].fulfillAddress).toEqual('fulfillAddress');
     expect(res[0].fulfillFunctionId).toEqual('fulfillFunctionId');
     expect(res[0].sponsorWallet).toEqual('sponsorWallet');
-    expect(res[0].requesterIndex).toEqual('3');
+    expect(res[0].sponsorAddress).toEqual('3'); //TODO: fix value
   });
 
   it('merges template and API call parameters', () => {

--- a/packages/node/src/evm/transaction-counts.test.ts
+++ b/packages/node/src/evm/transaction-counts.test.ts
@@ -14,8 +14,8 @@ import { ethers } from 'ethers';
 import * as transactions from './transaction-counts';
 import * as wallet from './wallet';
 
-describe('fetchByRequesterIndex', () => {
-  it('calls getTransactionCount once for each unique requester index', async () => {
+describe('fetchBySponsor', () => {
+  it('calls getTransactionCount once for each unique sponsor', async () => {
     getTransactionCountMock.mockResolvedValueOnce(5);
     const options = {
       currentBlock: 10716084,
@@ -23,7 +23,7 @@ describe('fetchByRequesterIndex', () => {
       provider: new ethers.providers.JsonRpcProvider(),
     };
     const indices = ['1', '1'];
-    const [logs, res] = await transactions.fetchByRequesterIndex(indices, options);
+    const [logs, res] = await transactions.fetchBySponsor(indices, options);
     expect(logs).toEqual([]);
     expect(res).toEqual({ 1: 5 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(1);
@@ -39,7 +39,7 @@ describe('fetchByRequesterIndex', () => {
       provider: new ethers.providers.JsonRpcProvider(),
     };
     const indices = ['1', '2'];
-    const [logs, res] = await transactions.fetchByRequesterIndex(indices, options);
+    const [logs, res] = await transactions.fetchBySponsor(indices, options);
     expect(logs).toEqual([]);
     expect(res).toEqual({ 1: 45, 2: 123 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(2);
@@ -58,7 +58,7 @@ describe('fetchByRequesterIndex', () => {
       provider: new ethers.providers.JsonRpcProvider(),
     };
     const indices = ['1', '1'];
-    const [logs, res] = await transactions.fetchByRequesterIndex(indices, options);
+    const [logs, res] = await transactions.fetchBySponsor(indices, options);
     expect(logs).toEqual([]);
     expect(res).toEqual({ 1: 123 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(2);
@@ -77,7 +77,7 @@ describe('fetchByRequesterIndex', () => {
       provider: new ethers.providers.JsonRpcProvider(),
     };
     const indices = ['1', '1'];
-    const [logs, res] = await transactions.fetchByRequesterIndex(indices, options);
+    const [logs, res] = await transactions.fetchBySponsor(indices, options);
     expect(logs).toEqual([
       {
         level: 'ERROR',

--- a/packages/node/src/evm/transaction-counts.test.ts
+++ b/packages/node/src/evm/transaction-counts.test.ts
@@ -22,8 +22,8 @@ describe('fetchBySponsor', () => {
       masterHDNode: wallet.getMasterHDNode(),
       provider: new ethers.providers.JsonRpcProvider(),
     };
-    const indices = ['1', '1'];
-    const [logs, res] = await transactions.fetchBySponsor(indices, options);
+    const addresses = ['1', '1']; // TODO: fix value
+    const [logs, res] = await transactions.fetchBySponsor(addresses, options);
     expect(logs).toEqual([]);
     expect(res).toEqual({ 1: 5 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(1);
@@ -38,8 +38,8 @@ describe('fetchBySponsor', () => {
       masterHDNode: wallet.getMasterHDNode(),
       provider: new ethers.providers.JsonRpcProvider(),
     };
-    const indices = ['1', '2'];
-    const [logs, res] = await transactions.fetchBySponsor(indices, options);
+    const addresses = ['1', '2']; // TODO: fix value
+    const [logs, res] = await transactions.fetchBySponsor(addresses, options);
     expect(logs).toEqual([]);
     expect(res).toEqual({ 1: 45, 2: 123 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(2);
@@ -57,8 +57,8 @@ describe('fetchBySponsor', () => {
       masterHDNode: wallet.getMasterHDNode(),
       provider: new ethers.providers.JsonRpcProvider(),
     };
-    const indices = ['1', '1'];
-    const [logs, res] = await transactions.fetchBySponsor(indices, options);
+    const addresses = ['1', '1']; // TODO: fix value
+    const [logs, res] = await transactions.fetchBySponsor(addresses, options);
     expect(logs).toEqual([]);
     expect(res).toEqual({ 1: 123 });
     expect(getTransactionCountMock).toHaveBeenCalledTimes(2);
@@ -76,8 +76,8 @@ describe('fetchBySponsor', () => {
       masterHDNode: wallet.getMasterHDNode(),
       provider: new ethers.providers.JsonRpcProvider(),
     };
-    const indices = ['1', '1'];
-    const [logs, res] = await transactions.fetchBySponsor(indices, options);
+    const addresses = ['1', '1']; // TODO: fix value
+    const [logs, res] = await transactions.fetchBySponsor(addresses, options);
     expect(logs).toEqual([
       {
         level: 'ERROR',

--- a/packages/node/src/evm/verification/request-verification.test.ts
+++ b/packages/node/src/evm/verification/request-verification.test.ts
@@ -42,7 +42,7 @@ describe('verifySponsorWallets', () => {
   });
 
   it('ignores API calls where the sponsor wallet does not match the expected address', () => {
-    const apiCall = fixtures.requests.buildApiCall({ sponsorWallet: '0xinvalid', requesterIndex: '3' });
+    const apiCall = fixtures.requests.buildApiCall({ sponsorWallet: '0xinvalid', sponsorAddress: '3' }); //TODO: fix value
     const [logs, res] = verification.verifySponsorWallets([apiCall], masterHDNode);
     expect(logs).toEqual([
       {
@@ -61,7 +61,7 @@ describe('verifySponsorWallets', () => {
   it('does nothing if the sponsor wallet matches the expected wallet', () => {
     const apiCall = fixtures.requests.buildApiCall({
       sponsorWallet: '0x2EfDDdd9337999A00f36f28e58F036381B8b1125',
-      requesterIndex: '3',
+      sponsorAddress: '3', //TODO: fix value
     });
     const [logs, res] = verification.verifySponsorWallets([apiCall], masterHDNode);
     expect(logs).toEqual([

--- a/packages/node/src/evm/verification/request-verification.ts
+++ b/packages/node/src/evm/verification/request-verification.ts
@@ -16,7 +16,7 @@ export function verifySponsorWallets<T>(
       return [[log], request];
     }
 
-    const expectedSponsorWallet = wallet.deriveWalletAddressFromIndex(masterHDNode, request.requesterIndex);
+    const expectedSponsorWallet = wallet.deriveSponsorWalletAddress(masterHDNode, request.sponsorAddress);
     if (request.sponsorWallet !== expectedSponsorWallet) {
       const message = `Invalid sponsor wallet:${request.sponsorWallet} for Request:${request.id}. Expected:${expectedSponsorWallet}`;
       const log = logger.pend('ERROR', message);

--- a/packages/node/src/evm/wallet.test.ts
+++ b/packages/node/src/evm/wallet.test.ts
@@ -26,33 +26,23 @@ describe('getAirnodeAddressShort', () => {
   });
 });
 
-describe('deriveWalletAddressFromIndex', () => {
-  it('returns the wallet address for the given index', () => {
+describe('deriveSponsorWalletAddress', () => {
+  it('returns the wallet address for the given sponsor', () => {
     const masterHDNode = wallet.getMasterHDNode();
-    const adminWallet = wallet.deriveWalletAddressFromIndex(masterHDNode, '0');
-    const wallet1 = wallet.deriveWalletAddressFromIndex(masterHDNode, '1');
-    const wallet2 = wallet.deriveWalletAddressFromIndex(masterHDNode, '777');
+    const adminWallet = wallet.deriveSponsorWalletAddress(masterHDNode, '0'); //TODO: fix value
+    const wallet1 = wallet.deriveSponsorWalletAddress(masterHDNode, '1'); //TODO: fix value
+    const wallet2 = wallet.deriveSponsorWalletAddress(masterHDNode, '777'); //TODO: fix value
     expect(adminWallet).toEqual('0xF47dD64127f46ca44679647BC1B3c6B248bf79A0');
     expect(wallet1).toEqual('0x34e9A78D63c9ca2148C95e880c6B1F48AE7F121E');
     expect(wallet2).toEqual('0x5547c2B0420D120f1DE7767c9BE451705df5a4E5');
   });
 });
 
-describe('deriveSigningWalletFromIndex', () => {
-  it('returns the signer for the given index', () => {
+describe('deriveSponsorWallet', () => {
+  it('returns the wallet for the given sponsor', () => {
     const masterHDNode = wallet.getMasterHDNode();
-    const signingWallet = wallet.deriveSigningWalletFromIndex(masterHDNode, '0');
+    const signingWallet = wallet.deriveSponsorWallet(masterHDNode, '0'); //TODO: fix value
     expect(signingWallet._isSigner).toEqual(true);
     expect(signingWallet.address).toEqual('0xF47dD64127f46ca44679647BC1B3c6B248bf79A0');
-  });
-});
-
-describe('isAdminWalletIndex', () => {
-  it('returns true if the index is reserved by the admin', () => {
-    expect(wallet.isAdminWalletIndex('0')).toEqual(true);
-  });
-
-  it('returns false if the index is not reserved', () => {
-    expect(wallet.isAdminWalletIndex('1')).toEqual(false);
   });
 });

--- a/packages/node/src/evm/wallet.ts
+++ b/packages/node/src/evm/wallet.ts
@@ -1,16 +1,30 @@
 import { ethers } from 'ethers';
 import * as config from '../config';
 
-// 2^31-1 different wallets can be designated as below
-// m/0/0: masterWalletAddress
-// m/0/1: First reserved wallet path
-// m/0/2: Second reserved wallet path
-// ...
-// m/0/2^31-1 (each index is represented in 31-bits)
-// Although this can be extended as m/0/*/... it will not be needed.
-function getPathFromIndex(index: number | string) {
-  return `m/0/${index}`;
-}
+/**
+ * HD wallets allow us to create multiple accounts from a single mnemonic.
+ * Each sponsor creates a designated wallet for each provider to use
+ * in order for them to be able to respond to the requests their requesters make.
+ *
+ * By convention derivation paths start with a master index
+ * followed by child indexes that can be any integer up to 2^31.
+ *
+ * Since addresses can be represented as 160bits (20bytes) we can then
+ * split it in chunks of 31bits and create a path with the following pattern:
+ * m/0/1st31bits/2nd31bits/3rd31bits/4th31bits/5th31bits/6th31bits.
+ *
+ * @param sponsorAddress A string representing a 20bytes hex address
+ * @returns The path derived from the address
+ */
+export const deriveWalletPathFromSponsorAddress = (sponsorAddress: string): string => {
+  const sponsorAddressBN = ethers.BigNumber.from(ethers.utils.getAddress(sponsorAddress));
+  const paths = [];
+  for (let i = 0; i < 6; i++) {
+    const shiftedSponsorAddressBN = sponsorAddressBN.shr(31 * i);
+    paths.push(shiftedSponsorAddressBN.mask(31).toString());
+  }
+  return `m/0/${paths.join('/')}`;
+};
 
 export function getMasterHDNode(): ethers.utils.HDNode {
   const mnemonic = config.getMasterKeyMnemonic();
@@ -29,16 +43,12 @@ export function getAirnodeAddressShort(airnodeAddress: string): string {
   return airnodeAddress.substring(2, 9);
 }
 
-export function deriveWalletAddressFromIndex(masterHDNode: ethers.utils.HDNode, index: number | string): string {
-  const wallet = masterHDNode.derivePath(getPathFromIndex(index));
-  return wallet.address;
+export function deriveSponsorWalletAddress(masterHDNode: ethers.utils.HDNode, sponsorAddress: string): string {
+  const sponsorWalletHdNode = masterHDNode.derivePath(deriveWalletPathFromSponsorAddress(sponsorAddress));
+  return sponsorWalletHdNode.address;
 }
 
-export function deriveSigningWalletFromIndex(masterHDNode: ethers.utils.HDNode, index: number | string): ethers.Wallet {
-  const signerHDNode = masterHDNode.derivePath(getPathFromIndex(index));
-  return getWallet(signerHDNode.privateKey);
-}
-
-export function isAdminWalletIndex(index: string): boolean {
-  return index === '0';
+export function deriveSponsorWallet(masterHDNode: ethers.utils.HDNode, sponsorAddress: string): ethers.Wallet {
+  const sponsorWalletHdNode = masterHDNode.derivePath(deriveWalletPathFromSponsorAddress(sponsorAddress));
+  return getWallet(sponsorWalletHdNode.privateKey);
 }

--- a/packages/node/src/evm/wallet.ts
+++ b/packages/node/src/evm/wallet.ts
@@ -7,7 +7,7 @@ import * as config from '../config';
  * in order for them to be able to respond to the requests their requesters make.
  *
  * By convention derivation paths start with a master index
- * followed by child indexes that can be any integer up to 2^31.
+ * followed by child indices that can be any integer up to 2^31.
  *
  * Since addresses can be represented as 160bits (20bytes) we can then
  * split it in chunks of 31bits and create a path with the following pattern:

--- a/packages/node/src/handlers/call-api.test.ts
+++ b/packages/node/src/handlers/call-api.test.ts
@@ -82,7 +82,7 @@ describe('callApi', () => {
                 _airnode_client_address: aggregatedCall.clientAddress,
                 _airnode_sponsor_wallet: aggregatedCall.sponsorWallet,
                 _airnode_endpoint_id: aggregatedCall.endpointId,
-                _airnode_requester_index: aggregatedCall.requesterIndex,
+                _airnode_sponsor_address: aggregatedCall.sponsorAddress,
                 _airnode_request_id: aggregatedCall.id,
                 _airnode_chain_id: aggregatedCall.chainId,
                 _airnode_chain_type: config.chains[0].type,

--- a/packages/node/src/handlers/call-api.ts
+++ b/packages/node/src/handlers/call-api.ts
@@ -31,7 +31,7 @@ function addMetadataParameters(
         _airnode_client_address: aggregatedApiCall.clientAddress,
         _airnode_sponsor_wallet: aggregatedApiCall.sponsorWallet,
         _airnode_endpoint_id: aggregatedApiCall.endpointId,
-        _airnode_requester_index: aggregatedApiCall.requesterIndex,
+        _airnode_sponsor_address: aggregatedApiCall.sponsorAddress,
         _airnode_request_id: aggregatedApiCall.id,
         _airnode_chain_id: aggregatedApiCall.chainId,
         _airnode_chain_type: chain.type,

--- a/packages/node/src/providers/initialize.test.ts
+++ b/packages/node/src/providers/initialize.test.ts
@@ -96,7 +96,7 @@ describe('initializeProviders', () => {
           apiCalls: [],
           withdrawals: [],
         },
-        transactionCountsByRequesterIndex: {},
+        transactionCountsBySponsorAddress: {},
       },
       {
         contracts: {
@@ -128,7 +128,7 @@ describe('initializeProviders', () => {
           apiCalls: [],
           withdrawals: [],
         },
-        transactionCountsByRequesterIndex: {},
+        transactionCountsBySponsorAddress: {},
       },
     ]);
   });

--- a/packages/node/src/providers/state.test.ts
+++ b/packages/node/src/providers/state.test.ts
@@ -63,7 +63,7 @@ describe('create', () => {
         apiCalls: [],
         withdrawals: [],
       },
-      transactionCountsByRequesterIndex: {},
+      transactionCountsBySponsorAddress: {},
     });
   });
 
@@ -128,7 +128,7 @@ describe('create', () => {
         apiCalls: [],
         withdrawals: [],
       },
-      transactionCountsByRequesterIndex: {},
+      transactionCountsBySponsorAddress: {},
     });
   });
 });

--- a/packages/node/src/providers/state.ts
+++ b/packages/node/src/providers/state.ts
@@ -55,7 +55,7 @@ export function buildEVMState(
       apiCalls: [],
       withdrawals: [],
     },
-    transactionCountsByRequesterIndex: {},
+    transactionCountsBySponsorAddress: {},
   };
 }
 

--- a/packages/node/src/requests/grouping.test.ts
+++ b/packages/node/src/requests/grouping.test.ts
@@ -2,45 +2,45 @@ import * as grouping from './grouping';
 import * as fixtures from '../../test/fixtures';
 import { GroupedRequests } from '../types';
 
-describe('mapUniqueRequesterIndices', () => {
-  it('returns a unique list of requester indices', () => {
+describe('mapUniqueSponsors', () => {
+  it('returns a unique list of sponsors', () => {
     const apiCalls = [
-      fixtures.requests.buildApiCall({ requesterIndex: '8' }),
-      fixtures.requests.buildApiCall({ requesterIndex: '9' }),
-      fixtures.requests.buildApiCall({ requesterIndex: '9' }),
-      fixtures.requests.buildApiCall({ requesterIndex: '10' }),
+      fixtures.requests.buildApiCall({ sponsorAddress: '8' }), //TODO: fix value
+      fixtures.requests.buildApiCall({ sponsorAddress: '9' }), //TODO: fix value
+      fixtures.requests.buildApiCall({ sponsorAddress: '9' }), //TODO: fix value
+      fixtures.requests.buildApiCall({ sponsorAddress: '10' }), //TODO: fix value
     ];
     const withdrawals = [
-      fixtures.requests.buildWithdrawal({ requesterIndex: '9' }),
-      fixtures.requests.buildWithdrawal({ requesterIndex: '12' }),
+      fixtures.requests.buildWithdrawal({ sponsorAddress: '9' }), //TODO: fix value
+      fixtures.requests.buildWithdrawal({ sponsorAddress: '12' }), //TODO: fix value
     ];
     const requests: GroupedRequests = {
       apiCalls: apiCalls,
       withdrawals: withdrawals,
     };
-    const res = grouping.mapUniqueRequesterIndices(requests);
-    expect(res).toEqual(['8', '9', '10', '12']);
+    const res = grouping.mapUniqueSponsorAddresses(requests);
+    expect(res).toEqual(['8', '9', '10', '12']); //TODO: fix value
   });
 });
 
-describe('groupRequestsByRequesterIndex', () => {
-  it('groups all requests by wallet index', () => {
+describe('groupRequestsBySponsor', () => {
+  it('groups all requests by sponsor', () => {
     const apiCalls = [
-      fixtures.requests.buildApiCall({ requesterIndex: '8' }),
-      fixtures.requests.buildApiCall({ requesterIndex: '9' }),
-      fixtures.requests.buildApiCall({ requesterIndex: '9' }),
-      fixtures.requests.buildApiCall({ requesterIndex: '10' }),
+      fixtures.requests.buildApiCall({ sponsorAddress: '8' }), //TODO: fix value
+      fixtures.requests.buildApiCall({ sponsorAddress: '9' }), //TODO: fix value
+      fixtures.requests.buildApiCall({ sponsorAddress: '9' }), //TODO: fix value
+      fixtures.requests.buildApiCall({ sponsorAddress: '10' }), //TODO: fix value
     ];
     const withdrawals = [
-      fixtures.requests.buildWithdrawal({ requesterIndex: '9' }),
-      fixtures.requests.buildWithdrawal({ requesterIndex: '12' }),
+      fixtures.requests.buildWithdrawal({ sponsorAddress: '9' }), //TODO: fix value
+      fixtures.requests.buildWithdrawal({ sponsorAddress: '12' }), //TODO: fix value
     ];
     const requests: GroupedRequests = {
       apiCalls: apiCalls,
       withdrawals: withdrawals,
     };
 
-    const res = grouping.groupRequestsByRequesterIndex(requests);
+    const res = grouping.groupRequestsBySponsorAddress(requests);
     expect(res).toEqual({
       8: {
         apiCalls: [apiCalls[0]],

--- a/packages/node/src/requests/grouping.ts
+++ b/packages/node/src/requests/grouping.ts
@@ -2,32 +2,32 @@ import groupBy from 'lodash/groupBy';
 import uniq from 'lodash/uniq';
 import { GroupedRequests } from '../types';
 
-export interface RequestsByRequesterIndex {
-  readonly [requesterIndex: string]: GroupedRequests;
+export interface RequestsBySponsorAddress {
+  readonly [sponsorAddress: string]: GroupedRequests;
 }
 
-export function mapUniqueRequesterIndices(requests: GroupedRequests): string[] {
-  const apiCallIndices = requests.apiCalls.map((r) => r.requesterIndex!);
-  const withdrawalIndices = requests.withdrawals.map((r) => r.requesterIndex!);
-  return uniq([...apiCallIndices, ...withdrawalIndices]);
+export function mapUniqueSponsorAddresses(requests: GroupedRequests): string[] {
+  const apiCallSponsorAddresses = requests.apiCalls.map((r) => r.sponsorAddress!);
+  const withdrawalSponsorAddresses = requests.withdrawals.map((r) => r.sponsorAddress!);
+  return uniq([...apiCallSponsorAddresses, ...withdrawalSponsorAddresses]);
 }
 
-export function groupRequestsByRequesterIndex(requests: GroupedRequests): RequestsByRequesterIndex {
-  const apiCalls = requests.apiCalls.filter((a) => !!a.requesterIndex);
-  const withdrawals = requests.withdrawals.filter((w) => !!w.requesterIndex);
+export function groupRequestsBySponsorAddress(requests: GroupedRequests): RequestsBySponsorAddress {
+  const apiCalls = requests.apiCalls.filter((a) => !!a.sponsorAddress);
+  const withdrawals = requests.withdrawals.filter((w) => !!w.sponsorAddress);
 
-  const apiCallsByRequesterIndex = groupBy(apiCalls, 'requesterIndex');
-  const withdrawalsByRequesterIndex = groupBy(withdrawals, 'requesterIndex');
+  const apiCallsBySponsorAddress = groupBy(apiCalls, 'sponsorAddress');
+  const withdrawalsBySponsorAddress = groupBy(withdrawals, 'sponsorAddress');
 
-  const uniqueRequesterIndices = mapUniqueRequesterIndices(requests);
+  const uniqueSponsorAddresses = mapUniqueSponsorAddresses(requests);
 
-  const groupedRequests = uniqueRequesterIndices.reduce((acc, requesterIndex) => {
+  const groupedRequests = uniqueSponsorAddresses.reduce((acc, sponsorAddress) => {
     const requests = {
-      apiCalls: apiCallsByRequesterIndex[requesterIndex!] || [],
-      withdrawals: withdrawalsByRequesterIndex[requesterIndex!] || [],
+      apiCalls: apiCallsBySponsorAddress[sponsorAddress!] || [],
+      withdrawals: withdrawalsBySponsorAddress[sponsorAddress!] || [],
     };
 
-    return { ...acc, [requesterIndex!]: requests };
+    return { ...acc, [sponsorAddress]: requests };
   }, {});
 
   return groupedRequests;

--- a/packages/node/src/requests/nonces.test.ts
+++ b/packages/node/src/requests/nonces.test.ts
@@ -20,27 +20,30 @@ describe('assign', () => {
       id: '0x1',
       nonce: undefined,
       metadata: firstMeta,
-      requesterIndex: '5',
+      sponsorAddress: '5', //TODO: fix value
     });
     const second = fixtures.requests.buildApiCall({
       id: '0x2',
       nonce: undefined,
       metadata: secondMeta,
-      requesterIndex: '5',
+      sponsorAddress: '5', //TODO: fix value
     });
     const third = fixtures.requests.buildApiCall({
       id: '0x3',
       nonce: undefined,
       metadata: thirdMeta,
-      requesterIndex: '5',
+      sponsorAddress: '5', //TODO: fix value
     });
 
     const requests: GroupedRequests = {
       apiCalls: shuffle([third, second, first]),
       withdrawals: [],
     };
-    const transactionCountsByRequesterIndex = { 5: 3 };
-    const state = providerState.update(mutableInitialState, { requests, transactionCountsByRequesterIndex });
+    const transactionCountsBySponsorAddress = { 5: 3 }; //TODO: fix value
+    const state = providerState.update(mutableInitialState, {
+      requests,
+      transactionCountsBySponsorAddress,
+    });
     const res = nonces.assign(state);
     expect(res.apiCalls[0]).toEqual({ ...first, nonce: 3 });
     expect(res.apiCalls[1]).toEqual({ ...second, nonce: 4 });
@@ -56,44 +59,50 @@ describe('assign', () => {
       id: '0x1',
       nonce: undefined,
       metadata: firstMeta,
-      requesterIndex: '7',
+      sponsorAddress: '7', //TODO: fix value
     });
     const second = fixtures.requests.buildWithdrawal({
       id: '0x2',
       nonce: undefined,
       metadata: secondMeta,
-      requesterIndex: '7',
+      sponsorAddress: '7', //TODO: fix value
     });
     const third = fixtures.requests.buildWithdrawal({
       id: '0x3',
       nonce: undefined,
       metadata: thirdMeta,
-      requesterIndex: '7',
+      sponsorAddress: '7', //TODO: fix value
     });
 
     const requests: GroupedRequests = {
       apiCalls: [],
       withdrawals: shuffle([first, third, second]),
     };
-    const transactionCountsByRequesterIndex = { 7: 11 };
-    const state = providerState.update(mutableInitialState, { requests, transactionCountsByRequesterIndex });
+    const transactionCountsBySponsorAddress = { 7: 11 }; //TODO: fix value
+    const state = providerState.update(mutableInitialState, {
+      requests,
+      transactionCountsBySponsorAddress,
+    });
     const res = nonces.assign(state);
     expect(res.withdrawals[0]).toEqual({ ...first, nonce: 11 });
     expect(res.withdrawals[1]).toEqual({ ...second, nonce: 12 });
     expect(res.withdrawals[2]).toEqual({ ...third, nonce: 13 });
   });
 
-  it('does not share nonces between requesters', () => {
+  it('does not share nonces between sponsors', () => {
     const requests: GroupedRequests = {
       apiCalls: [
-        fixtures.requests.buildApiCall({ id: '0x1', requesterIndex: '7', nonce: undefined }),
-        fixtures.requests.buildApiCall({ id: '0x2', requesterIndex: '8', nonce: undefined }),
-        fixtures.requests.buildApiCall({ id: '0x3', requesterIndex: '9', nonce: undefined }),
+        fixtures.requests.buildApiCall({ id: '0x1', sponsorAddress: '7', nonce: undefined }), //TODO: fix value
+        fixtures.requests.buildApiCall({ id: '0x2', sponsorAddress: '8', nonce: undefined }), //TODO: fix value
+        fixtures.requests.buildApiCall({ id: '0x3', sponsorAddress: '9', nonce: undefined }), //TODO: fix value
       ],
       withdrawals: [],
     };
-    const transactionCountsByRequesterIndex = { 7: 11, 8: 11, 9: 7 };
-    const state = providerState.update(mutableInitialState, { requests, transactionCountsByRequesterIndex });
+    const transactionCountsBySponsorAddress = { 7: 11, 8: 11, 9: 7 }; //TODO: fix value
+    const state = providerState.update(mutableInitialState, {
+      requests,
+      transactionCountsBySponsorAddress,
+    });
     const res = nonces.assign(state);
     expect(res.apiCalls.find((a) => a.id === '0x1')!.nonce).toEqual(11);
     expect(res.apiCalls.find((a) => a.id === '0x2')!.nonce).toEqual(11);
@@ -111,30 +120,30 @@ describe('assign', () => {
       id: '0x1',
       nonce: undefined,
       metadata: firstMeta,
-      requesterIndex: '3',
+      sponsorAddress: '3', //TODO: fix value
     });
     const second = fixtures.requests.buildApiCall({
       id: '0x2',
       nonce: undefined,
       metadata: secondMeta,
       status: RequestStatus.Blocked,
-      requesterIndex: '3',
+      sponsorAddress: '3', //TODO: fix value
     });
     const third = fixtures.requests.buildApiCall({
       id: '0x3',
       nonce: undefined,
       metadata: thirdMeta,
-      requesterIndex: '3',
+      sponsorAddress: '3', //TODO: fix value
     });
 
     const requests: GroupedRequests = {
       apiCalls: shuffle([third, second, first]),
       withdrawals: [],
     };
-    const transactionCountsByRequesterIndex = { 3: 7 };
+    const transactionCountsBySponsorAddress = { 3: 7 }; //TODO: fix value
     const state = providerState.update(mutableInitialState, {
       requests,
-      transactionCountsByRequesterIndex,
+      transactionCountsBySponsorAddress,
     });
     const res = nonces.assign(state);
     expect(res.apiCalls[0]).toEqual({ ...first, nonce: 7 });
@@ -153,30 +162,30 @@ describe('assign', () => {
       id: '0x1',
       nonce: undefined,
       metadata: firstMeta,
-      requesterIndex: '3',
+      sponsorAddress: '3', //TODO: fix value
     });
     const second = fixtures.requests.buildApiCall({
       id: '0x2',
       nonce: undefined,
       metadata: secondMeta,
-      requesterIndex: '3',
+      sponsorAddress: '3', //TODO: fix value
       status: RequestStatus.Blocked,
     });
     const third = fixtures.requests.buildApiCall({
       id: '0x3',
       nonce: undefined,
       metadata: thirdMeta,
-      requesterIndex: '3',
+      sponsorAddress: '3', //TODO: fix value
     });
 
     const requests: GroupedRequests = {
       apiCalls: shuffle([third, second, first]),
       withdrawals: [],
     };
-    const transactionCountsByRequesterIndex = { 3: 7 };
+    const transactionCountsBySponsorAddress = { 3: 7 }; //TODO: fix value
     const state = providerState.update(mutableInitialState, {
       requests,
-      transactionCountsByRequesterIndex,
+      transactionCountsBySponsorAddress,
     });
     const res = nonces.assign(state);
     expect(res.apiCalls[0]).toEqual({ ...first, nonce: 7 });
@@ -193,21 +202,21 @@ describe('assign', () => {
       id: '0x1',
       nonce: undefined,
       metadata: firstMeta,
-      requesterIndex: '7',
+      sponsorAddress: '7', //TODO: fix value
       status: RequestStatus.Pending,
     });
     const second = fixtures.requests.buildWithdrawal({
       id: '0x2',
       nonce: undefined,
       metadata: secondMeta,
-      requesterIndex: '7',
+      sponsorAddress: '7', //TODO: fix value
       status: RequestStatus.Fulfilled,
     });
     const third = fixtures.requests.buildWithdrawal({
       id: '0x3',
       nonce: undefined,
       metadata: thirdMeta,
-      requesterIndex: '7',
+      sponsorAddress: '7', //TODO: fix value
       status: RequestStatus.Pending,
     });
 
@@ -215,8 +224,11 @@ describe('assign', () => {
       apiCalls: [],
       withdrawals: shuffle([first, third, second]),
     };
-    const transactionCountsByRequesterIndex = { 7: 11 };
-    const state = providerState.update(mutableInitialState, { requests, transactionCountsByRequesterIndex });
+    const transactionCountsBySponsorAddress = { 7: 11 }; //TODO: fix value
+    const state = providerState.update(mutableInitialState, {
+      requests,
+      transactionCountsBySponsorAddress,
+    });
     const res = nonces.assign(state);
     expect(res.withdrawals[0]).toEqual({ ...first, nonce: 11 });
     expect(res.withdrawals[1]).toEqual({ ...second, nonce: undefined });

--- a/packages/node/src/requests/nonces.ts
+++ b/packages/node/src/requests/nonces.ts
@@ -89,13 +89,13 @@ function assignWalletNonces(flatRequests: ClientRequest<AnyRequest>[], transacti
 }
 
 export function assign(state: ProviderState<EVMProviderState>): GroupedRequests {
-  const requestsByRequesterIndex = grouping.groupRequestsByRequesterIndex(state.requests);
+  const requestsBySponsorAddress = grouping.groupRequestsBySponsorAddress(state.requests);
 
-  const requesterIndices = Object.keys(requestsByRequesterIndex);
+  const sponsorAddresses = Object.keys(requestsBySponsorAddress);
 
-  return requesterIndices.reduce(
-    (acc: GroupedRequests, requesterIndex) => {
-      const requests = requestsByRequesterIndex[requesterIndex];
+  return sponsorAddresses.reduce(
+    (acc: GroupedRequests, sponsorAddress) => {
+      const requests = requestsBySponsorAddress[sponsorAddress];
 
       // Ensure requests are sorted for we assign nonces
       const sortedRequests = sorting.sortGroupedRequests(requests);
@@ -103,7 +103,7 @@ export function assign(state: ProviderState<EVMProviderState>): GroupedRequests 
       // Flatten all requests into a single array so that nonces can be assigned across types
       const flatRequests = flattenRequests(sortedRequests);
 
-      const transactionCount = state.transactionCountsByRequesterIndex[requesterIndex];
+      const transactionCount = state.transactionCountsBySponsorAddress[sponsorAddress];
 
       // Assign nonces to each request
       const flattenRequestsWithNonces = assignWalletNonces(flatRequests, transactionCount);

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -55,7 +55,7 @@ export type ClientRequest<T extends {}> = T & {
   readonly errorCode?: RequestErrorCode;
   readonly metadata: RequestMetadata;
   readonly nonce?: number;
-  readonly requesterIndex: string;
+  readonly sponsorAddress: string;
   readonly status: RequestStatus;
 };
 
@@ -87,7 +87,7 @@ export interface ApiCallTemplate {
 
 export interface Withdrawal {
   readonly airnodeAddress: string;
-  readonly requesterIndex: string;
+  readonly sponsorAddress: string;
 }
 
 export interface GroupedRequests {
@@ -112,7 +112,7 @@ export type ProviderState<T extends {}> = T & {
   readonly coordinatorId: string;
   readonly requests: GroupedRequests;
   readonly settings: ProviderSettings;
-  readonly transactionCountsByRequesterIndex: { readonly [requesterIndex: string]: number };
+  readonly transactionCountsBySponsorAddress: { readonly [sponsorAddress: string]: number };
 };
 
 export interface AggregatedApiCallsById {
@@ -171,7 +171,7 @@ export interface ApiCallResponse {
 
 export interface AggregatedApiCall {
   readonly id: string;
-  readonly requesterIndex: string;
+  readonly sponsorAddress: string;
   readonly airnodeAddress: string;
   readonly clientAddress: string;
   readonly sponsorWallet: string;

--- a/packages/node/test/e2e/withdrawals.feature.ts
+++ b/packages/node/test/e2e/withdrawals.feature.ts
@@ -10,7 +10,7 @@ it('processes withdrawals only once', async () => {
 
   const provider = e2e.buildProvider();
 
-  const requests = [fixtures.operation.buildWithdrawal({ requesterId: 'alice' })];
+  const requests = [fixtures.operation.buildWithdrawal({ sponsorId: 'alice' })];
 
   const deployerIndex = e2e.getDeployerIndex(__filename);
   const deployConfig = fixtures.operation.buildDeployConfig({ deployerIndex, requests });
@@ -35,11 +35,11 @@ it('processes withdrawals only once', async () => {
   expect(preinvokeWithdrawals.length).toEqual(1);
   expect(preinvokeFulfillments.length).toEqual(0);
 
-  const alice = deployment.requesters.find((r) => r.id === 'alice');
+  const alice = deployment.sponsors.find((s) => s.id === 'alice');
   const hdNode = wallet.getMasterHDNode();
-  const sponsorWalletAddress = wallet.deriveWalletAddressFromIndex(hdNode, alice!.requesterIndex);
+  const sponsorWalletAddress = wallet.deriveSponsorWalletAddress(hdNode, alice!.address);
 
-  // It's difficult to check exact balances because the requester has made transactions at this
+  // It's difficult to check exact balances because the sponsor has made transactions at this
   // point, so check current balance is > 1.99 ETH and < 2.01 ETH
   const preWithdrawalBalance = await provider.getBalance(alice!.address);
   expect(preWithdrawalBalance.gt(ethers.utils.parseEther('1.99'))).toEqual(true);

--- a/packages/node/test/fixtures/aggregated-api-call.ts
+++ b/packages/node/test/fixtures/aggregated-api-call.ts
@@ -2,7 +2,7 @@ import { AggregatedApiCall } from '../../src/types';
 
 export function buildAggregatedApiCall(params?: Partial<AggregatedApiCall>): AggregatedApiCall {
   return {
-    requesterIndex: '5',
+    sponsorAddress: '5', //TODO: fix value
     airnodeAddress: '0x19255a4ec31e89cea54d1f125db7536e874ab4a96b4d4f6438668b6bb10a6adb',
     clientAddress: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
     sponsorWallet: '0xD748Bc4212d8130879Ec4F24B950cAAb9EddfCB2',

--- a/packages/node/test/fixtures/operation/deploy-config.ts
+++ b/packages/node/test/fixtures/operation/deploy-config.ts
@@ -37,7 +37,7 @@ export function buildDeployConfig(config?: Partial<Config>): Config {
     clients: {
       MockAirnodeRrpClientFactory: { endorsers: ['bob'] },
     },
-    requesters: [
+    sponsors: [
       {
         id: 'alice',
         airnodes: {
@@ -53,8 +53,8 @@ export function buildDeployConfig(config?: Partial<Config>): Config {
     ],
     requests: [
       {
-        requesterId: 'bob',
-        type: 'regular',
+        sponsorId: 'bob',
+        type: 'template',
         airnode: 'CurrencyConverterAirnode',
         template: 'template-1',
         client: 'MockAirnodeRrpClientFactory',
@@ -62,7 +62,7 @@ export function buildDeployConfig(config?: Partial<Config>): Config {
         parameters: [{ type: 'bytes32', name: 'from', value: 'ETH' }],
       },
       {
-        requesterId: 'bob',
+        sponsorId: 'bob',
         type: 'full',
         airnode: 'CurrencyConverterAirnode',
         endpoint: 'convertToUSD',

--- a/packages/node/test/fixtures/operation/requests.ts
+++ b/packages/node/test/fixtures/operation/requests.ts
@@ -1,10 +1,10 @@
 import { ReservedParameterName } from '@api3/ois';
-import { FullRequest, RegularRequest, Withdrawal } from '@api3/operation';
+import { FullRequest, TemplateRequest, Request } from '@api3/operation';
 
-export function buildRegularRequest(overrides?: Partial<RegularRequest>): RegularRequest {
+export function buildRegularRequest(overrides?: Partial<TemplateRequest>): TemplateRequest {
   return {
-    requesterId: 'bob',
-    type: 'regular',
+    sponsorId: 'bob',
+    type: 'template',
     airnode: 'CurrencyConverterAirnode',
     template: 'template-1',
     client: 'MockAirnodeRrpClientFactory',
@@ -16,7 +16,7 @@ export function buildRegularRequest(overrides?: Partial<RegularRequest>): Regula
 
 export function buildFullRequest(overrides?: Partial<FullRequest>): FullRequest {
   return {
-    requesterId: 'bob',
+    sponsorId: 'bob',
     type: 'full',
     airnode: 'CurrencyConverterAirnode',
     endpoint: 'convertToUSD',
@@ -35,9 +35,9 @@ export function buildFullRequest(overrides?: Partial<FullRequest>): FullRequest 
   };
 }
 
-export function buildWithdrawal(overrides?: Partial<Withdrawal>): Withdrawal {
+export function buildWithdrawal(overrides?: Partial<Request>): Request {
   return {
-    requesterId: 'alice',
+    sponsorId: 'alice',
     type: 'withdrawal',
     airnode: 'CurrencyConverterAirnode',
     ...overrides,

--- a/packages/node/test/fixtures/requests/api-calls.ts
+++ b/packages/node/test/fixtures/requests/api-calls.ts
@@ -19,7 +19,7 @@ export function buildApiCall(params?: Partial<ClientRequest<ApiCall>>): ClientRe
     metadata,
     parameters: { from: 'ETH' },
     requestCount: '12',
-    requesterIndex: '3',
+    sponsorAddress: '3', //TODO: fix value
     status: RequestStatus.Pending,
     templateId: null,
     type: 'regular',

--- a/packages/node/test/fixtures/requests/withdrawals.ts
+++ b/packages/node/test/fixtures/requests/withdrawals.ts
@@ -11,7 +11,7 @@ export function buildWithdrawal(params?: Partial<ClientRequest<Withdrawal>>): Cl
     sponsorWallet: 'sponsorWallet',
     id: 'withdrawalId',
     metadata,
-    requesterIndex: '1',
+    sponsorAddress: '1', //TODO: fix value
     status: RequestStatus.Pending,
     ...params,
   };


### PR DESCRIPTION
3 compilation error down, 1 more to go 💪🏻 

* Used var name [`sponsorAddress`](https://github.com/api3dao/airnode/blob/96a4464270a388e2c37d32aea43bf2c1d471e4f6/packages/node/src/types.ts#L90) instead of just sponsor because I used the same pattern when renaming airnodeIdAddress to airnodeAddress. (I mention this because in AirnodeRrp.sol airnodeAddress is airnode and sponsorAddress is sponsor)
* Now [`Withdrawal`](https://github.com/api3dao/airnode/blob/96a4464270a388e2c37d32aea43bf2c1d471e4f6/packages/node/src/types.ts#L88) interface seems to share `airnodeAddress` with [`ApiCall`](https://github.com/api3dao/airnode/blob/96a4464270a388e2c37d32aea43bf2c1d471e4f6/packages/node/src/types.ts#L66) interface and `sponsorAddress` is already present in generic type [`ClientRequest<T>`](ClientRequest) so I was wondering if `Withdrawal` interface could be removed or merged. If so then I'll work on this on a separate branch.
* Replaced derivation path calculation function that splits the sponsor address into 31bits chunks.