### PR TITLE
AN-118: Replace call to AirnodeRrp.getTemplate() with AirnodeRrp.temp…

### DIFF
--- a/packages/node/src/evm/contracts/airnodeRrp.test.ts
+++ b/packages/node/src/evm/contracts/airnodeRrp.test.ts
@@ -11,21 +11,21 @@ describe('AirnodeRrp', () => {
       'airnodeToXpub',
       'checkAuthorizationStatus',
       'checkAuthorizationStatuses',
-      'requesterToRequestCountPlusOne',
       'createTemplate',
       'fail',
       'fulfill',
       'fulfillWithdrawal',
-      'getTemplate',
       'getTemplates',
       'makeFullRequest',
-      'makeRequest',
+      'makeTemplateRequest',
       'requestWithIdHasFailed',
       'requestWithdrawal',
-      'sponsorToWithdrawalRequestCount',
-      'sponsorToRequesterToSponsorshipStatus',
-      'setAirnodeToXpub',
+      'requesterToRequestCountPlusOne',
+      'setAirnodeXpub',
       'setSponsorshipStatus',
+      'sponsorToRequesterToSponsorshipStatus',
+      'sponsorToWithdrawalRequestCount',
+      'templates',
     ]);
   });
 
@@ -35,15 +35,15 @@ describe('AirnodeRrp', () => {
       .map((fn: any) => fn.name)
       .sort();
     expect(events).toEqual([
-      'AirnodeParametersSet',
-      'SetSponsorshipStatus',
-      'MadeFullRequest',
-      'MadeTemplateRequest',
+      'CreatedTemplate',
       'FailedRequest',
       'FulfilledRequest',
-      'TemplateCreated',
       'FulfilledWithdrawal',
+      'MadeFullRequest',
+      'MadeTemplateRequest',
       'RequestedWithdrawal',
+      'SetAirnodeXpub',
+      'SetSponsorshipStatus',
     ]);
   });
 
@@ -52,35 +52,35 @@ describe('AirnodeRrp', () => {
     expect.assertions(7);
 
     expect(Object.keys(airnodeRrpTopics).sort()).toEqual([
-      'MadeFullRequest',
-      'MadeTemplateRequest',
       'FailedRequest',
       'FulfilledRequest',
       'FulfilledWithdrawal',
+      'MadeFullRequest',
+      'MadeTemplateRequest',
       'RequestedWithdrawal',
     ]);
 
     // API calls
     expect(airnodeRrpTopics.MadeTemplateRequest).toEqual(
-      '0x8339fddbb81e588a9ed04dec82ee9ae6c7a185f44835adaaa2ace50ce3a14aaf'
+      '0xeb39930cdcbb560e6422558a2468b93a215af60063622e63cbb165eba14c3203'
     );
     expect(airnodeRrpTopics.MadeFullRequest).toEqual(
-      '0xe8ae99161b1547fd1c6ff3cb9660293fa4cd770fd52f72ff0362d64d8bccc08e'
+      '0x3a52c462346de2e9436a3868970892956828a11b9c43da1ed43740b12e1125ae'
     );
 
     expect(airnodeRrpTopics.FulfilledRequest).toEqual(
-      '0xcde46e28d8d3e348e5f5b4fcc511fe3b1f9b0f549cd8332f0da31802a6f2bf61'
+      '0xd1cc11d12363af4b6022e66d14b18ba1779ecd85a5b41891349d530fb6eee066'
     );
     expect(airnodeRrpTopics.FailedRequest).toEqual(
-      '0x1cfdd5ace64f15111ef8ed9df04364d0e9a9165cccf8386109347e54661ba3ad'
+      '0x8c087e42b178608800a2ea8b3d009bdbbf75e0d23426510c2edd447d4f8b8ebd'
     );
 
     // Withdrawals
     expect(airnodeRrpTopics.RequestedWithdrawal).toEqual(
-      '0x3d0ebccb4fc9730699221da0180970852f595ed5c78781346149123cbbe9f1d3'
+      '0xd48d52c7c6d0c940f3f8d07591e1800ef3a70daf79929a97ccd80b4494769fc7'
     );
     expect(airnodeRrpTopics.FulfilledWithdrawal).toEqual(
-      '0x9e7b58b29aa3b972bb0f457499d0dfd00bf23905b0c3358fb864e7120402aefa'
+      '0xadb4840bbd5f924665ae7e0e0c83de5c0fb40a98c9b57dba53a6c978127a622e'
     );
   });
 });

--- a/packages/node/src/evm/templates/template-fetching.test.ts
+++ b/packages/node/src/evm/templates/template-fetching.test.ts
@@ -1,7 +1,7 @@
 import { mockEthers } from '../../../test/mock-utils';
-const getTemplateMock = jest.fn();
+const templatesMock = jest.fn();
 const getTemplatesMock = jest.fn();
-mockEthers({ airnodeRrpMocks: { getTemplate: getTemplateMock, getTemplates: getTemplatesMock } });
+mockEthers({ airnodeRrpMocks: { templates: templatesMock, getTemplates: getTemplatesMock } });
 
 import { ethers } from 'ethers';
 import * as templates from './template-fetching';
@@ -20,15 +20,15 @@ describe('fetch (templates)', () => {
 
   it('fetches templates in groups of 10', async () => {
     const firstRawTemplates = {
+      airnodes: Array.from(Array(10).keys()).map((n) => `airnode-${n}`),
       endpointIds: Array.from(Array(10).keys()).map((n) => `endpointId-${n}`),
       parameters: Array.from(Array(10).keys()).map(() => '0x6874656d706c6174656576616c7565'),
-      airnodes: Array.from(Array(10).keys()).map((n) => `airnode-${n}`),
     };
 
     const secondRawTemplates = {
+      airnodes: Array.from(Array(9).keys()).map((n) => `airnode-${n + 10}`),
       endpointIds: Array.from(Array(9).keys()).map((n) => `endpointId-${n + 10}`),
       parameters: Array.from(Array(9).keys()).map(() => '0x6874656d706c6174656576616c7565'),
-      airnodes: Array.from(Array(9).keys()).map((n) => `airnode-${n + 10}`),
     };
 
     getTemplatesMock.mockResolvedValueOnce(firstRawTemplates);
@@ -56,9 +56,9 @@ describe('fetch (templates)', () => {
 
   it('returns all template attributes', async () => {
     const rawTemplates = {
+      airnodes: ['airnode-0'],
       endpointIds: ['endpointId-0'],
       parameters: ['0x6874656d706c6174656576616c7565'],
-      airnodes: ['airnode-0'],
     };
     getTemplatesMock.mockResolvedValueOnce(rawTemplates);
 
@@ -67,9 +67,9 @@ describe('fetch (templates)', () => {
     expect(logs).toEqual([]);
     expect(res).toEqual({
       'templateId-0': {
-        airnode: 'airnode-0',
-        encodedParameters: '0x6874656d706c6174656576616c7565',
+        airnodeAddress: 'airnode-0',
         endpointId: 'endpointId-0',
+        encodedParameters: '0x6874656d706c6174656576616c7565',
         id: 'templateId-0',
       },
     });
@@ -77,9 +77,9 @@ describe('fetch (templates)', () => {
 
   it('filters out duplicate template IDs', async () => {
     const rawTemplates = {
+      airnodes: ['airnode-0'],
       endpointIds: ['endpointId-0'],
       parameters: ['0x6874656d706c6174656576616c7565'],
-      airnodes: ['airnode-0'],
     };
     getTemplatesMock.mockResolvedValueOnce(rawTemplates);
 
@@ -89,9 +89,9 @@ describe('fetch (templates)', () => {
     expect(logs).toEqual([]);
     expect(res).toEqual({
       'templateId-0': {
-        airnode: 'airnode-0',
-        encodedParameters: '0x6874656d706c6174656576616c7565',
+        airnodeAddress: 'airnode-0',
         endpointId: 'endpointId-0',
+        encodedParameters: '0x6874656d706c6174656576616c7565',
         id: 'templateId-0',
       },
     });
@@ -110,9 +110,9 @@ describe('fetch (templates)', () => {
 
   it('retries once on failure', async () => {
     const rawTemplates = {
+      airnodes: ['airnode-0'],
       endpointIds: ['endpointId-0'],
       parameters: ['0x6874656d706c6174656576616c7565'],
-      airnodes: ['airnode-0'],
     };
     getTemplatesMock.mockRejectedValueOnce(new Error('Server says no'));
     getTemplatesMock.mockResolvedValueOnce(rawTemplates);
@@ -122,9 +122,9 @@ describe('fetch (templates)', () => {
     expect(logs).toEqual([]);
     expect(res).toEqual({
       'templateId-0': {
-        airnode: 'airnode-0',
-        encodedParameters: '0x6874656d706c6174656576616c7565',
+        airnodeAddress: 'airnode-0',
         endpointId: 'endpointId-0',
+        encodedParameters: '0x6874656d706c6174656576616c7565',
         id: 'templateId-0',
       },
     });
@@ -140,7 +140,7 @@ describe('fetch (templates)', () => {
       endpointId: 'endpointId-0',
       parameters: '0x6874656d706c6174656576616c7565',
     };
-    getTemplateMock.mockResolvedValueOnce(rawTemplate);
+    templatesMock.mockResolvedValueOnce(rawTemplate);
 
     const apiCall = fixtures.requests.buildApiCall({ templateId: 'templateId-0' });
     const [logs, res] = await templates.fetch([apiCall], mutableFetchOptions);
@@ -150,14 +150,14 @@ describe('fetch (templates)', () => {
     ]);
     expect(res).toEqual({
       'templateId-0': {
-        airnode: 'airnode-0',
-        encodedParameters: '0x6874656d706c6174656576616c7565',
+        airnodeAddress: 'airnode-0',
         endpointId: 'endpointId-0',
+        encodedParameters: '0x6874656d706c6174656576616c7565',
         id: 'templateId-0',
       },
     });
     expect(getTemplatesMock).toHaveBeenCalledTimes(2);
-    expect(getTemplateMock).toHaveBeenCalledTimes(1);
+    expect(templatesMock).toHaveBeenCalledTimes(1);
   });
 
   it('retries individual template calls once', async () => {
@@ -169,8 +169,8 @@ describe('fetch (templates)', () => {
       endpointId: 'endpointId-0',
       parameters: '0x6874656d706c6174656576616c7565',
     };
-    getTemplateMock.mockRejectedValueOnce(new Error('Server says no'));
-    getTemplateMock.mockResolvedValueOnce(rawTemplate);
+    templatesMock.mockRejectedValueOnce(new Error('Server says no'));
+    templatesMock.mockResolvedValueOnce(rawTemplate);
 
     const apiCall = fixtures.requests.buildApiCall({ templateId: 'templateId-0' });
     const [logs, res] = await templates.fetch([apiCall], mutableFetchOptions);
@@ -180,22 +180,22 @@ describe('fetch (templates)', () => {
     ]);
     expect(res).toEqual({
       'templateId-0': {
-        airnode: 'airnode-0',
-        encodedParameters: '0x6874656d706c6174656576616c7565',
+        airnodeAddress: 'airnode-0',
         endpointId: 'endpointId-0',
+        encodedParameters: '0x6874656d706c6174656576616c7565',
         id: 'templateId-0',
       },
     });
     expect(getTemplatesMock).toHaveBeenCalledTimes(2);
-    expect(getTemplateMock).toHaveBeenCalledTimes(2);
+    expect(templatesMock).toHaveBeenCalledTimes(2);
   });
 
   it('returns nothing after all template calls are exhausted', async () => {
     getTemplatesMock.mockRejectedValueOnce(new Error('Server says no'));
     getTemplatesMock.mockRejectedValueOnce(new Error('Server says no'));
 
-    getTemplateMock.mockRejectedValueOnce(new Error('Still no'));
-    getTemplateMock.mockRejectedValueOnce(new Error('Still no'));
+    templatesMock.mockRejectedValueOnce(new Error('Still no'));
+    templatesMock.mockRejectedValueOnce(new Error('Still no'));
 
     const apiCall = fixtures.requests.buildApiCall({ templateId: 'templateId-0' });
     const [logs, res] = await templates.fetch([apiCall], mutableFetchOptions);
@@ -209,7 +209,7 @@ describe('fetch (templates)', () => {
     ]);
     expect(res).toEqual({});
     expect(getTemplatesMock).toHaveBeenCalledTimes(2);
-    expect(getTemplateMock).toHaveBeenCalledTimes(2);
+    expect(templatesMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -226,18 +226,18 @@ describe('fetchTemplate', () => {
       endpointId: 'endpointId-0',
       parameters: '0x6874656d706c6174656576616c7565',
     };
-    getTemplateMock.mockResolvedValueOnce(rawTemplate);
+    templatesMock.mockResolvedValueOnce(rawTemplate);
 
     const templateId = 'templateId';
     const [logs, res] = await templates.fetchTemplate(mutableAirnodeRrp, templateId);
     expect(logs).toEqual([{ level: 'INFO', message: `Fetched API call template:${templateId}` }]);
     expect(res).toEqual({
-      airnode: 'airnode-0',
-      encodedParameters: '0x6874656d706c6174656576616c7565',
+      airnodeAddress: 'airnode-0',
       endpointId: 'endpointId-0',
+      encodedParameters: '0x6874656d706c6174656576616c7565',
       id: templateId,
     });
-    expect(getTemplateMock).toHaveBeenCalledTimes(1);
+    expect(templatesMock).toHaveBeenCalledTimes(1);
   });
 
   it('retries individual template calls once', async () => {
@@ -246,24 +246,24 @@ describe('fetchTemplate', () => {
       endpointId: 'endpointId-0',
       parameters: '0x6874656d706c6174656576616c7565',
     };
-    getTemplateMock.mockRejectedValueOnce(new Error('Server says no'));
-    getTemplateMock.mockResolvedValueOnce(rawTemplate);
+    templatesMock.mockRejectedValueOnce(new Error('Server says no'));
+    templatesMock.mockResolvedValueOnce(rawTemplate);
 
     const templateId = 'templateId';
     const [logs, res] = await templates.fetchTemplate(mutableAirnodeRrp, templateId);
     expect(logs).toEqual([{ level: 'INFO', message: `Fetched API call template:${templateId}` }]);
     expect(res).toEqual({
-      airnode: 'airnode-0',
-      encodedParameters: '0x6874656d706c6174656576616c7565',
+      airnodeAddress: 'airnode-0',
       endpointId: 'endpointId-0',
+      encodedParameters: '0x6874656d706c6174656576616c7565',
       id: templateId,
     });
-    expect(getTemplateMock).toHaveBeenCalledTimes(2);
+    expect(templatesMock).toHaveBeenCalledTimes(2);
   });
 
   it('returns nothing after all individual template calls are exhausted', async () => {
-    getTemplateMock.mockRejectedValueOnce(new Error('Server says no'));
-    getTemplateMock.mockRejectedValueOnce(new Error('Server says no'));
+    templatesMock.mockRejectedValueOnce(new Error('Server says no'));
+    templatesMock.mockRejectedValueOnce(new Error('Server says no'));
 
     const templateId = 'templateId';
     const [logs, res] = await templates.fetchTemplate(mutableAirnodeRrp, templateId);
@@ -275,6 +275,6 @@ describe('fetchTemplate', () => {
       },
     ]);
     expect(res).toEqual(null);
-    expect(getTemplateMock).toHaveBeenCalledTimes(2);
+    expect(templatesMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/node/src/evm/wallet.ts
+++ b/packages/node/src/evm/wallet.ts
@@ -19,6 +19,7 @@ import * as config from '../config';
 export const deriveWalletPathFromSponsorAddress = (sponsorAddress: string): string => {
   const sponsorAddressBN = ethers.BigNumber.from(ethers.utils.getAddress(sponsorAddress));
   const paths = [];
+  // eslint-disable-next-line functional/no-let, functional/no-loop-statement
   for (let i = 0; i < 6; i++) {
     const shiftedSponsorAddressBN = sponsorAddressBN.shr(31 * i);
     paths.push(shiftedSponsorAddressBN.mask(31).toString());

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -80,8 +80,8 @@ export interface ApiCall {
 
 export interface ApiCallTemplate {
   readonly airnodeAddress: string;
-  readonly encodedParameters: string;
   readonly endpointId: string;
+  readonly encodedParameters: string;
   readonly id: string;
 }
 


### PR DESCRIPTION
…lates()

* Replaced calls to `getTemplate()` with `template()`
* Disabled linting errors in `wallet.ts`
* Started fixing tests now that code compiles again 🍾 