### PR TITLE
AN-130: Skip authorization checks if authorizers is empty array

### DIFF
--- a/packages/node/__dev__/config.json.example
+++ b/packages/node/__dev__/config.json.example
@@ -2,9 +2,7 @@
   {
     "chains": [
       {
-        "authorizers": [
-          "0x0000000000000000000000000000000000000000"
-        ],
+        "authorizers": [],
         "contracts": {
           "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
         },

--- a/packages/node/src/evm/authorization/authorization-fetching.test.ts
+++ b/packages/node/src/evm/authorization/authorization-fetching.test.ts
@@ -19,7 +19,7 @@ describe('fetch (authorizations)', () => {
 
   beforeEach(() => {
     mutableFetchOptions = {
-      authorizers: ['0x0000000000000000000000000000000000000000'],
+      authorizers: ['0x711c93B32c0D28a5d18feD87434cce11C3e5699B', '0x9E0e23766b0ed0C492804872c5164E9187fB56f5'],
       airnodeAddress: '0xf5ad700af68118777f79fd1d1c8568f7377d4ae9e9ccce5970fe63bc7a1c1d6d',
       airnodeRrpAddress: '0xD5659F26A72A8D718d1955C42B3AE418edB001e0',
       provider: new ethers.providers.JsonRpcProvider(),
@@ -31,6 +31,22 @@ describe('fetch (authorizations)', () => {
     const [logs, res] = await authorization.fetch(apiCalls, mutableFetchOptions);
     expect(logs).toEqual([]);
     expect(res).toEqual({});
+  });
+
+  it('returns true for all pending requests if authorizers array is empty', async () => {
+    const apiCalls = Array.from(Array(19).keys()).map((n) => {
+      return fixtures.requests.buildApiCall({
+        id: `${n}`,
+        endpointId: `endpointId-${n}`,
+        requesterAddress: `requesterAddress-${n}`,
+        sponsorAddress: 'sponsorAddress',
+      });
+    });
+    const [logs, res] = await authorization.fetch(apiCalls, { ...mutableFetchOptions, authorizers: [] });
+    expect(logs).toEqual([]);
+    expect(Object.keys(res).length).toEqual(19);
+    expect(res['0']).toEqual(true);
+    expect(res['18']).toEqual(true);
   });
 
   it('calls the contract with groups of 10', async () => {
@@ -55,7 +71,7 @@ describe('fetch (authorizations)', () => {
     expect(checkAuthorizationStatusesMock).toHaveBeenCalledTimes(2);
 
     const call1Args = [
-      ['0x0000000000000000000000000000000000000000'],
+      ['0x711c93B32c0D28a5d18feD87434cce11C3e5699B', '0x9E0e23766b0ed0C492804872c5164E9187fB56f5'],
       '0xf5ad700af68118777f79fd1d1c8568f7377d4ae9e9ccce5970fe63bc7a1c1d6d',
       apiCalls.slice(0, 10).map((a) => a.id),
       apiCalls.slice(0, 10).map((a) => a.endpointId),
@@ -63,7 +79,7 @@ describe('fetch (authorizations)', () => {
       apiCalls.slice(0, 10).map((a) => a.requesterAddress),
     ];
     const call2Args = [
-      ['0x0000000000000000000000000000000000000000'],
+      ['0x711c93B32c0D28a5d18feD87434cce11C3e5699B', '0x9E0e23766b0ed0C492804872c5164E9187fB56f5'],
       '0xf5ad700af68118777f79fd1d1c8568f7377d4ae9e9ccce5970fe63bc7a1c1d6d',
       apiCalls.slice(10, 19).map((a) => a.id),
       apiCalls.slice(10, 19).map((a) => a.endpointId),

--- a/packages/node/src/evm/authorization/authorization-fetching.ts
+++ b/packages/node/src/evm/authorization/authorization-fetching.ts
@@ -109,6 +109,14 @@ export async function fetch(
     return [[], {}];
   }
 
+  // If there are no authorizer contracts then endpoint is public
+  if (isEmpty(fetchOptions.authorizers)) {
+    const authorizationByRequestIds = pendingApiCalls.map((pendingApiCall) => ({
+      [pendingApiCall.id]: true,
+    }));
+    return [[], Object.assign({}, ...authorizationByRequestIds) as AuthorizationByRequestId];
+  }
+
   // Request groups of 10 at a time
   const groupedPairs = chunk(pendingApiCalls, CONVENIENCE_BATCH_SIZE);
 

--- a/packages/node/src/evm/fulfillments/api-calls.ts
+++ b/packages/node/src/evm/fulfillments/api-calls.ts
@@ -46,7 +46,7 @@ async function testFulfill(
     `Attempting to fulfill API call with status code:${statusCode.toString()} for Request:${request.id}...`
   );
 
-  const operation = () =>
+  const operation = (): Promise<StaticResponse> =>
     airnodeRrp.callStatic.fulfill(
       request.id,
       // TODO: make sure airnodeAddress is not null
@@ -81,7 +81,7 @@ async function submitFulfill(
     `Submitting API call fulfillment with status code:${statusCode.toString()} for Request:${request.id}...`
   );
 
-  const tx = () =>
+  const tx = (): Promise<ethers.Transaction> =>
     airnodeRrp.fulfill(
       request.id,
       // TODO: make sure airnodeAddress is not null
@@ -105,7 +105,7 @@ async function submitFulfill(
     );
     return [[noticeLog, errorLog], err, null];
   }
-  return [[noticeLog], null, res as ethers.Transaction];
+  return [[noticeLog], null, res];
 }
 
 async function testAndSubmitFulfill(
@@ -155,7 +155,7 @@ async function submitFail(
 ): Promise<LogsErrorData<SubmitResponse>> {
   const noticeLog = logger.pend('INFO', `Submitting API call fail for Request:${request.id}...`);
 
-  const tx = () =>
+  const tx = (): Promise<ethers.Transaction> =>
     // TODO: make sure airnodeAddress is not null
     airnodeRrp.fail(request.id, request.airnodeAddress!, request.fulfillAddress, request.fulfillFunctionId, {
       gasLimit: GAS_LIMIT,
@@ -167,7 +167,7 @@ async function submitFail(
     const errorLog = logger.pend('ERROR', `Error submitting API call fail transaction for Request:${request.id}`, err);
     return [[noticeLog, errorLog], err, null];
   }
-  return [[noticeLog], null, res as ethers.Transaction];
+  return [[noticeLog], null, res];
 }
 
 // =================================================================

--- a/packages/node/test/fixtures/config/config.ts
+++ b/packages/node/test/fixtures/config/config.ts
@@ -22,7 +22,7 @@ export function buildConfig(overrides?: Partial<Config>): Config {
   return {
     chains: [
       {
-        authorizers: ['0x0000000000000000000000000000000000000000'],
+        authorizers: [],
         contracts: {
           AirnodeRrp: '0x197F3826040dF832481f835652c290aC7c41f073',
         },

--- a/packages/node/test/fixtures/operation/deploy-config.ts
+++ b/packages/node/test/fixtures/operation/deploy-config.ts
@@ -10,7 +10,7 @@ export function buildDeployConfig(config?: Partial<Config>): Config {
         // We need to create a new mnemonic each time otherwise E2E tests
         // will share the same Airnode wallet
         mnemonic: ethers.Wallet.createRandom().mnemonic.phrase,
-        authorizers: ['public'],
+        authorizers: [],
         endpoints: {
           convertToUSD: {
             oisTitle: 'Currency Converter API',
@@ -31,9 +31,7 @@ export function buildDeployConfig(config?: Partial<Config>): Config {
         },
       },
     },
-    authorizers: {
-      public: '0x0000000000000000000000000000000000000000',
-    },
+    authorizers: {},
     requesters: {
       MockRrpRequesterFactory: { sponsors: ['bob'] },
     },

--- a/packages/node/test/fixtures/provider-states/evm.ts
+++ b/packages/node/test/fixtures/provider-states/evm.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'ethers';
 import { buildEVMState } from '../../../src/providers/state';
 import { buildConfig } from '../config';
 import { ChainConfig, EnvironmentConfig, EVMProviderState, ProviderState } from '../../../src/types';
@@ -12,7 +11,7 @@ export function buildEVMProviderState(
   const chainProviderName = 'Ganache test';
   const chainProviderEnvName = 'CP_EVM_1337_GANACHE_TEST';
   const chainConfig: ChainConfig = {
-    authorizers: [ethers.constants.AddressZero],
+    authorizers: [],
     contracts: {
       AirnodeRrp: '0x197F3826040dF832481f835652c290aC7c41f073',
     },

--- a/packages/node/test/setup/e2e/utils.ts
+++ b/packages/node/test/setup/e2e/utils.ts
@@ -13,7 +13,7 @@ export function buildChainConfig(contracts: Contracts): ChainConfig {
     contracts: {
       AirnodeRrp: contracts.AirnodeRrp,
     },
-    authorizers: [ethers.constants.AddressZero],
+    authorizers: [],
     id: '31337',
     type: 'evm',
     providerNames: ['EVM local'],

--- a/packages/operation/README.md
+++ b/packages/operation/README.md
@@ -203,7 +203,7 @@ The withdrawn funds should be sent back to the address of the sponsor.
   "airnodes": {
     "CurrencyConverterAirnode": {
       "mnemonic": "achieve climb couple wait accident symbol spy blouse reduce foil echo label",
-      "authorizers": ["public"],
+      "authorizers": [],
       "endpoints": {
         "convertToUSD": {
           "oisTitle": "Currency Converter API"
@@ -223,9 +223,7 @@ The withdrawn funds should be sent back to the address of the sponsor.
       }
     }
   },
-  "authorizers": {
-    "public": "0x0000000000000000000000000000000000000000"
-  },
+  "authorizers": {},
   "requesters": {
     "MockRrpRequesterFactory": { "sponsors": ["bob"] }
   },

--- a/packages/operation/src/config/evm-dev-config.json
+++ b/packages/operation/src/config/evm-dev-config.json
@@ -3,7 +3,7 @@
   "airnodes": {
     "CurrencyConverterAirnode": {
       "mnemonic": "achieve climb couple wait accident symbol spy blouse reduce foil echo label",
-      "authorizers": ["public"],
+      "authorizers": [],
       "endpoints": {
         "convertToUSD": {
           "oisTitle": "Currency Converter API"
@@ -23,9 +23,7 @@
       }
     }
   },
-  "authorizers": {
-    "public": "0x0000000000000000000000000000000000000000"
-  },
+  "authorizers": {},
   "requesters": {
     "MockRrpRequesterFactory": { "sponsors": ["bob"] }
   },

--- a/packages/operation/src/evm/deploy/deployment.ts
+++ b/packages/operation/src/evm/deploy/deployment.ts
@@ -28,7 +28,5 @@ export async function deployAuthorizers(state: State): Promise<State> {
     await authorizer.deployed();
     authorizersByName[authorizerName] = authorizer.address;
   }
-  // Special authorizer addresses
-  authorizersByName.public = ethers.constants.AddressZero;
   return { ...state, authorizersByName };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,6 +1913,11 @@
     "@opencensus/core" "^0.0.8"
     uuid "^3.2.1"
 
+"@openzeppelin/contracts@^4.2.0":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.1.tgz#c01f791ce6c9d3989ac1a643267501dbe336b9e3"
+  integrity sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw==
+
 "@pm2/agent@~1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@pm2/agent/-/agent-1.0.8.tgz#cd15d84dbfc95427e6fccce72bc165b79f1d8579"


### PR DESCRIPTION
Fix: 
Skips calling AirnodeRrp.checkAuthorizationStatuses when authorizers array is empty and returns true for all pending requests.

Operation package commands should be back to working condition.

@Siegrift Please checkout the branch and run the e2e locally. For some weird reason requester-fulfill.feature tests started to pass automagically. 

We can also work on a separate branch for fixing e2e since this is actually for fixing public authorizers.