### PR TITLE
Parse API response to BigNumber

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -28,10 +28,12 @@
     "@api3/operation": "^0.1.0",
     "@api3/protocol": "^0.1.0",
     "@lifeomic/attempt": "^3.0.0",
+    "@types/json-bigint": "^1.0.1",
     "aws-sdk": "^2.753.0",
     "date-fns": "^2.16.1",
     "dotenv": "^10.0.0",
     "ethers": "^5.4.4",
+    "json-bigint": "^1.0.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/node/src/workers/cloud-platforms/aws.ts
+++ b/packages/node/src/workers/cloud-platforms/aws.ts
@@ -1,4 +1,5 @@
 import AWS from 'aws-sdk';
+import JSON from 'json-bigint';
 import { WorkerParameters, WorkerResponse } from '../../types';
 
 export function spawn(params: WorkerParameters): Promise<WorkerResponse> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,6 +2738,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/json-bigint@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/json-bigint/-/json-bigint-1.0.1.tgz#201062a6990119a8cc18023cfe1fed12fc2fc8a7"
+  integrity sha512-zpchZLNsNuzJHi6v64UBoFWAvQlPhch7XAi36FkH6tL1bbbmimIF+cS7vwkzY4u5RaSWMoflQfu+TshMPPw8uw==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -9925,6 +9930,13 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
+
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
 
 json-buffer@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description

Large numbers get destroyed because JavaScript only works on IEEE-754 float numbers.

While #93 did some changes to support large integers, there's more to be done because when the number reaches the _[adapter](/api3dao/airnode/tree/master/packages/adapter)_ the number has already been destroyed way before at the _[node](/api3dao/airnode/tree/master/packages/node)_.

As can be seen on the following transactions on ropsten, the rightmost 60 bits are always zero, and comparing with what the API did respond only the first 53 bits were correct and the rightmost 60 bits were not all zero.

[0x59112a449054cfdd7bc324c54df4eba26e296c84888c40d690c6fe7d388a4227](https://ropsten.etherscan.io/tx/0x59112a449054cfdd7bc324c54df4eba26e296c84888c40d690c6fe7d388a4227#eventlog)
[0x1a1ce21657b0ca34e0e11662dae5296034bde994a7159726ef32996d00348555](https://ropsten.etherscan.io/tx/0x1a1ce21657b0ca34e0e11662dae5296034bde994a7159726ef32996d00348555#eventlog)
[0x2dd15eaef0605720f8b0cbd3bb409cd18bb085469c177fcbe4d8f180a9605404](https://ropsten.etherscan.io/tx/0x2dd15eaef0605720f8b0cbd3bb409cd18bb085469c177fcbe4d8f180a9605404#eventlog)
[0x8bd5d221648bd50baa247926a41454af2c594c394501e75ee9cdf68013e9e63f](https://ropsten.etherscan.io/tx/0x8bd5d221648bd50baa247926a41454af2c594c394501e75ee9cdf68013e9e63f#eventlog)
[0x8f26294acab7d427dd857651b06ea2d96dd9b3ea316496a88f96beccc9151341](https://ropsten.etherscan.io/tx/0x8f26294acab7d427dd857651b06ea2d96dd9b3ea316496a88f96beccc9151341#eventlog)
[0x776aeef840e60f44edb70bb25cb394eb3591894b7ff2a5d524fd01ad12edabac](https://ropsten.etherscan.io/tx/0x776aeef840e60f44edb70bb25cb394eb3591894b7ff2a5d524fd01ad12edabac#eventlog)
[0x9143cbb5502f459d5e82a59887de9e8bc3fa087233c8d7d71a321a89908c9e9d](https://ropsten.etherscan.io/tx/0x9143cbb5502f459d5e82a59887de9e8bc3fa087233c8d7d71a321a89908c9e9d#eventlog)
[0xa8fea1369604f8918b491c8a2f3bcd78028060b37d1851442eecaa93537dc42c](https://ropsten.etherscan.io/tx/0xa8fea1369604f8918b491c8a2f3bcd78028060b37d1851442eecaa93537dc42c#eventlog)

The problem lies in this part of the code:

https://github.com/api3dao/airnode/blob/9577aeb7a8f6aea3ca2571eb923ce59acff16b8e/packages/node/src/workers/cloud-platforms/aws.ts#L22

`JSON.parse` will destroy any number too large for JS, you need a custom JSON parser that handles large numbers.

## Version

Commit 9577aeb7a8f6aea3ca2571eb923ce59acff16b8e

## Present Behaviour

Any number too larger for JS to handle gets broken.

## Expected Behaviour

The app should handle any integer that is 256 bits or less.

## Steps to reproduce

Add the tests that were included in this PR to the master branch and see it fail.