### PR TITLE
Fixes relay metadata parameters

### DIFF
--- a/packages/adapter/src/request-building/build-request.test.ts
+++ b/packages/adapter/src/request-building/build-request.test.ts
@@ -19,6 +19,46 @@ describe('buildingRequest', () => {
     });
   });
 
+  it('builds and returns the request with metadata', () => {
+    const options = fixtures.buildRequestOptions({
+      parameters: {
+        f: 'ETH',
+        amount: '1',
+        _airnode_airnode_id: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+        _airnode_client_address: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+        _airnode_designated_wallet: '0xB604c9f7de852F26DB90C04000820850112905b4',
+        _airnode_endpoint_id: '0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353',
+        _airnode_requester_index: '0x7a9a6F6B21AEE3b905AEeC757bbBcA39747Ca4Fa',
+        _airnode_request_id: '0xcf2816af81f9cc7c9879dc84ce29c00fe1e290bcb8d2e4b204be1eeb120811bf',
+        _airnode_chain_id: '31337',
+        _airnode_chain_type: 'evm',
+        _airnode_airnode_rrp: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+      },
+    });
+    const res = build.buildRequest(options);
+    expect(res).toEqual({
+      baseUrl: 'http://localhost:5000',
+      data: {
+        access_key: 'super-secret-key',
+        amount: '1',
+        from: 'ETH',
+        to: 'USD',
+        _airnode_airnode_id: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+        _airnode_client_address: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+        _airnode_designated_wallet: '0xB604c9f7de852F26DB90C04000820850112905b4',
+        _airnode_endpoint_id: '0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353',
+        _airnode_requester_index: '0x7a9a6F6B21AEE3b905AEeC757bbBcA39747Ca4Fa',
+        _airnode_request_id: '0xcf2816af81f9cc7c9879dc84ce29c00fe1e290bcb8d2e4b204be1eeb120811bf',
+        _airnode_chain_id: '31337',
+        _airnode_chain_type: 'evm',
+        _airnode_airnode_rrp: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+      },
+      headers: {},
+      method: 'get',
+      path: '/convert',
+    });
+  });
+
   it('throws an error if the endpoint cannot be found', () => {
     const ois = fixtures.buildOIS({ endpoints: [] });
     const options = fixtures.buildRequestOptions({ ois });

--- a/packages/adapter/src/request-building/build-request.test.ts
+++ b/packages/adapter/src/request-building/build-request.test.ts
@@ -24,6 +24,8 @@ describe('buildingRequest', () => {
       parameters: {
         f: 'ETH',
         amount: '1',
+      },
+      metadataParameters: {
         _airnode_airnode_id: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
         _airnode_client_address: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
         _airnode_designated_wallet: '0xB604c9f7de852F26DB90C04000820850112905b4',

--- a/packages/adapter/src/request-building/parameters.test.ts
+++ b/packages/adapter/src/request-building/parameters.test.ts
@@ -165,3 +165,43 @@ describe('user parameters', () => {
     });
   });
 });
+
+describe('relay metadata parameters', () => {
+  it('appends parameters to query', () => {
+    const options = fixtures.buildCacheRequestOptions({
+      parameters: {
+        f: 'ETH',
+        amount: '1',
+        _airnode_airnode_id: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+        _airnode_client_address: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+        _airnode_designated_wallet: '0xB604c9f7de852F26DB90C04000820850112905b4',
+        _airnode_endpoint_id: '0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353',
+        _airnode_requester_index: '0x7a9a6F6B21AEE3b905AEeC757bbBcA39747Ca4Fa',
+        _airnode_request_id: '0xcf2816af81f9cc7c9879dc84ce29c00fe1e290bcb8d2e4b204be1eeb120811bf',
+        _airnode_chain_id: '31337',
+        _airnode_chain_type: 'evm',
+        _airnode_airnode_rrp: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+      },
+    });
+    const res = parameters.buildParameters(options);
+    expect(res).toEqual({
+      paths: {},
+      query: {
+        access_key: 'super-secret-key',
+        amount: '1',
+        from: 'ETH',
+        to: 'USD',
+        _airnode_airnode_id: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+        _airnode_client_address: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+        _airnode_designated_wallet: '0xB604c9f7de852F26DB90C04000820850112905b4',
+        _airnode_endpoint_id: '0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353',
+        _airnode_requester_index: '0x7a9a6F6B21AEE3b905AEeC757bbBcA39747Ca4Fa',
+        _airnode_request_id: '0xcf2816af81f9cc7c9879dc84ce29c00fe1e290bcb8d2e4b204be1eeb120811bf',
+        _airnode_chain_id: '31337',
+        _airnode_chain_type: 'evm',
+        _airnode_airnode_rrp: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+      },
+      headers: {},
+    });
+  });
+});

--- a/packages/adapter/src/request-building/parameters.test.ts
+++ b/packages/adapter/src/request-building/parameters.test.ts
@@ -169,9 +169,7 @@ describe('user parameters', () => {
 describe('relay metadata parameters', () => {
   it('appends parameters to query', () => {
     const options = fixtures.buildCacheRequestOptions({
-      parameters: {
-        f: 'ETH',
-        amount: '1',
+      metadataParameters: {
         _airnode_airnode_id: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
         _airnode_client_address: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
         _airnode_designated_wallet: '0xB604c9f7de852F26DB90C04000820850112905b4',

--- a/packages/adapter/src/request-building/parameters.ts
+++ b/packages/adapter/src/request-building/parameters.ts
@@ -76,13 +76,13 @@ function buildUserParameters(options: CachedBuildRequestOptions): BuilderParamet
   }, initalParameters());
 }
 
-function buildRelayMetadataParameters(options: CachedBuildRequestOptions): BuilderParameters {
-  const { parameters } = options;
+function buildMetadataParameters(options: CachedBuildRequestOptions): BuilderParameters {
+  const { metadataParameters } = options;
 
-  const parameterKeys = Object.keys(parameters).filter((key) => key.startsWith('_airnode_'));
+  const parameterKeys = Object.keys(metadataParameters);
 
   return parameterKeys.reduce((acc, key) => {
-    return appendParameter(acc, 'query', key, parameters[key]);
+    return appendParameter(acc, 'query', key, metadataParameters[key]);
   }, initalParameters());
 }
 
@@ -90,7 +90,7 @@ export function buildParameters(options: CachedBuildRequestOptions): RequestPara
   const auth = authentication.buildParameters(options);
   const fixed = buildFixedParameters(options);
   const user = buildUserParameters(options);
-  const relayMetadata = buildRelayMetadataParameters(options);
+  const metadata = buildMetadataParameters(options);
 
   const cookie = cookies.buildHeader({ ...user.cookies, ...fixed.cookies, ...auth.cookies });
 
@@ -98,7 +98,7 @@ export function buildParameters(options: CachedBuildRequestOptions): RequestPara
   // overwrite fixed and authentication parameters
   return {
     paths: { ...user.paths, ...fixed.paths },
-    query: { ...user.query, ...fixed.query, ...auth.query, ...relayMetadata.query },
+    query: { ...user.query, ...fixed.query, ...auth.query, ...metadata.query },
     headers: { ...user.headers, ...fixed.headers, ...auth.headers, ...cookie },
   };
 }

--- a/packages/adapter/src/request-building/parameters.ts
+++ b/packages/adapter/src/request-building/parameters.ts
@@ -76,10 +76,21 @@ function buildUserParameters(options: CachedBuildRequestOptions): BuilderParamet
   }, initalParameters());
 }
 
+function buildRelayMetadataParameters(options: CachedBuildRequestOptions): BuilderParameters {
+  const { parameters } = options;
+
+  const parameterKeys = Object.keys(parameters).filter((key) => key.startsWith('_airnode_'));
+
+  return parameterKeys.reduce((acc, key) => {
+    return appendParameter(acc, 'query', key, parameters[key]);
+  }, initalParameters());
+}
+
 export function buildParameters(options: CachedBuildRequestOptions): RequestParameters {
   const auth = authentication.buildParameters(options);
   const fixed = buildFixedParameters(options);
   const user = buildUserParameters(options);
+  const relayMetadata = buildRelayMetadataParameters(options);
 
   const cookie = cookies.buildHeader({ ...user.cookies, ...fixed.cookies, ...auth.cookies });
 
@@ -87,7 +98,7 @@ export function buildParameters(options: CachedBuildRequestOptions): RequestPara
   // overwrite fixed and authentication parameters
   return {
     paths: { ...user.paths, ...fixed.paths },
-    query: { ...user.query, ...fixed.query, ...auth.query },
+    query: { ...user.query, ...fixed.query, ...auth.query, ...relayMetadata.query },
     headers: { ...user.headers, ...fixed.headers, ...auth.headers, ...cookie },
   };
 }

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -11,7 +11,8 @@ export interface ApiCredentials {
 export interface BuildRequestOptions {
   readonly ois: OIS;
   readonly endpointName: string;
-  readonly parameters: { readonly [key: string]: string };
+  readonly parameters: Parameters;
+  readonly metadataParameters: Parameters;
   readonly apiCredentials: ApiCredentials[];
 }
 

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -56,3 +56,15 @@ export interface ReservedParameters {
   readonly _type: ResponseType;
   readonly _relay_metadata?: string;
 }
+
+export interface RelayMetadataV1 {
+  readonly _airnode_airnode_id: string;
+  readonly _airnode_client_address: string;
+  readonly _airnode_designated_wallet: string;
+  readonly _airnode_endpoint_id: string;
+  readonly _airnode_requester_index: string;
+  readonly _airnode_request_id: string;
+  readonly _airnode_chain_id: string;
+  readonly _airnode_chain_type: string;
+  readonly _airnode_airnode_rrp: string;
+}

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -58,14 +58,17 @@ export interface ReservedParameters {
   readonly _relay_metadata?: string;
 }
 
-export interface RelayMetadataV1 {
-  readonly _airnode_airnode_id: string;
-  readonly _airnode_client_address: string;
-  readonly _airnode_designated_wallet: string;
-  readonly _airnode_endpoint_id: string;
-  readonly _airnode_requester_index: string;
-  readonly _airnode_request_id: string;
-  readonly _airnode_chain_id: string;
-  readonly _airnode_chain_type: string;
-  readonly _airnode_airnode_rrp: string;
-}
+export type MetadataParameterKeysV1 =
+  | '_airnode_airnode_id'
+  | '_airnode_client_address'
+  | '_airnode_designated_wallet'
+  | '_airnode_endpoint_id'
+  | '_airnode_requester_index'
+  | '_airnode_request_id'
+  | '_airnode_chain_id'
+  | '_airnode_chain_type'
+  | '_airnode_airnode_rrp';
+
+export type MetadataParametersV1 = {
+  readonly [key in MetadataParameterKeysV1]: string;
+};

--- a/packages/adapter/test/fixtures/options.ts
+++ b/packages/adapter/test/fixtures/options.ts
@@ -8,6 +8,7 @@ export function buildRequestOptions(overrides?: Partial<BuildRequestOptions>): B
     ois,
     endpointName: 'convertToUSD',
     parameters: { f: 'ETH', amount: '1' },
+    metadataParameters: {},
     apiCredentials: buildCredentials(),
     ...overrides,
   };

--- a/packages/node/src/handlers/call-api.test.ts
+++ b/packages/node/src/handlers/call-api.test.ts
@@ -30,6 +30,7 @@ describe('callApi', () => {
         endpointName: 'convertToUSD',
         ois: fixtures.buildOIS(),
         parameters: { from: 'ETH' },
+        metadataParameters: {},
         apiCredentials: [
           {
             securitySchemeName: 'My Security Scheme',
@@ -74,9 +75,7 @@ describe('callApi', () => {
         expect(spy).toHaveBeenCalledWith(
           {
             endpointName: 'convertToUSD',
-            ois,
-            parameters: {
-              from: 'ETH',
+            metadataParameters: {
               ...(expectMetadata && {
                 _airnode_airnode_id: aggregatedCall.airnodeId,
                 _airnode_client_address: aggregatedCall.clientAddress,
@@ -88,6 +87,10 @@ describe('callApi', () => {
                 _airnode_chain_type: config.chains[0].type,
                 _airnode_airnode_rrp: config.chains[0].contracts.AirnodeRrp,
               }),
+            },
+            ois,
+            parameters: {
+              from: 'ETH',
             },
             apiCredentials: [
               {

--- a/packages/node/src/handlers/call-api.ts
+++ b/packages/node/src/handlers/call-api.ts
@@ -15,7 +15,7 @@ function buildMetadataParameters(
 ): adapter.Parameters {
   switch (reservedParameters._relay_metadata?.toLowerCase()) {
     case 'v1': {
-      const metadataParametersV1: adapter.RelayMetadataV1 = {
+      const metadataParametersV1: adapter.MetadataParametersV1 = {
         _airnode_airnode_id: aggregatedApiCall.airnodeId,
         _airnode_client_address: aggregatedApiCall.clientAddress,
         _airnode_designated_wallet: aggregatedApiCall.designatedWallet,
@@ -26,7 +26,7 @@ function buildMetadataParameters(
         _airnode_chain_type: chain.type,
         _airnode_airnode_rrp: chain.contracts.AirnodeRrp,
       };
-      return { ...metadataParametersV1 };
+      return metadataParametersV1;
     }
     default:
       return {};

--- a/packages/node/src/handlers/call-api.ts
+++ b/packages/node/src/handlers/call-api.ts
@@ -23,9 +23,8 @@ function addMetadataParameters(
 ): ApiCallParameters {
   const parameters = aggregatedApiCall.parameters;
   switch (reservedParameters._relay_metadata?.toLowerCase()) {
-    case 'v1':
-      return {
-        ...parameters,
+    case 'v1': {
+      const relayMetadata: adapter.RelayMetadataV1 = {
         _airnode_airnode_id: aggregatedApiCall.airnodeId,
         _airnode_client_address: aggregatedApiCall.clientAddress,
         _airnode_designated_wallet: aggregatedApiCall.designatedWallet,
@@ -36,6 +35,11 @@ function addMetadataParameters(
         _airnode_chain_type: chain.type,
         _airnode_airnode_rrp: chain.contracts.AirnodeRrp,
       };
+      return {
+        ...parameters,
+        ...relayMetadata,
+      };
+    }
     default:
       return parameters;
   }


### PR DESCRIPTION
### Bug:
Relay metadata parameters are not included in http requests even after properly configuring the airnode

### Fix:
When implementing this feature I made the wrong assumption that adding the parameters to the reservedParameters list in [call-api.ts](https://github.com/api3dao/airnode/blob/1c94313f636da4c7f4e08baf6327fc24cb46c8df/packages/node/src/handlers/call-api.ts#L83) was enough and that they were going to be sent on http requests. This was not properly tested and the metadata parameters where ignored and never included.

 So I've created a new method on the adapters package to include them and tested both GET and POST requests using the operation package tools. Confirmed that the values reached the api by console logging the querystring when request was a GET and body when request was a POST.
 
Also added type checking for the V1 relay metadata parameters by adding a new interface to types.ts.

One thing I didn't like too much was extracting the relay metadata parameters by searching all keys that started with "_adapter_" on the parameters array. I would have prefer to use the new `RelayMetadataV1` interface instead of the string but I wasn't able to do it since interfaces do not exists on runtime. Another alternative was have those keys hardcoded in a string[] but I didn't like that duplication either.

**This fix also needs to be applied to pre-alpha since it's blocking Cam with an integration.**