### PR TITLE
AN-69: Verify sponsor wallets for withdrawal requests

### DIFF
--- a/packages/node/src/evm/handlers/initialize-provider.ts
+++ b/packages/node/src/evm/handlers/initialize-provider.ts
@@ -94,13 +94,13 @@ export async function initializeProvider(
   });
 
   // =================================================================
-  // STEP 5: Verify API calls
+  // STEP 5: Verify requests
   // =================================================================
-  const [verifyLogs, verifiedApiCalls] = verification.verifySponsorWallets(
+  const [verifyApiCallLogs, verifiedApiCalls] = verification.verifySponsorWallets(
     state4.requests.apiCalls,
     state4.masterHDNode
   );
-  logger.logPending(verifyLogs, baseLogOptions);
+  logger.logPending(verifyApiCallLogs, baseLogOptions);
 
   const [verifyTriggersLogs, verifiedApiCallsForTriggers] = verification.verifyTriggers(
     verifiedApiCalls,
@@ -109,8 +109,14 @@ export async function initializeProvider(
   );
   logger.logPending(verifyTriggersLogs, baseLogOptions);
 
+  const [verifyWithdrawalLogs, verifiedWithdrawals] = verification.verifySponsorWallets(
+    state4.requests.withdrawals,
+    state4.masterHDNode
+  );
+  logger.logPending(verifyWithdrawalLogs, baseLogOptions);
+
   const state5 = state.update(state4, {
-    requests: { ...state3.requests, apiCalls: verifiedApiCallsForTriggers },
+    requests: { ...state3.requests, apiCalls: verifiedApiCallsForTriggers, withdrawals: verifiedWithdrawals },
   });
 
   // =================================================================


### PR DESCRIPTION
It was really easy to apply this verification because [verifySponsorWallets](https://github.com/api3dao/airnode/blob/b7debcfcdad90e0d1c15fcd5becf7ec5f18f36ed/packages/node/src/evm/verification/request-verification.ts#L8) function was written in a way that supported any type of requests. Simply amazing!