### PR TITLE
AN-208: Fix node e2e tests in beta-protocol-revision after merging be…

### DIFF
--- a/packages/node/test/e2e/requester-fulfill.feature.ts
+++ b/packages/node/test/e2e/requester-fulfill.feature.ts
@@ -43,29 +43,15 @@ it('should call fail function on AirnodeRrp contract and emit FailedRequest if r
     operation.buildFullRequest(),
   ]);
 
+  const preInvokeExpectedLogs = ['MadeTemplateRequest', 'MadeFullRequest'];
   const preInvokelogNames = await fetchAllLogNames(provider, deployment.contracts.AirnodeRrp);
-  expect(preInvokelogNames).toEqual([
-    'SetSponsorshipStatus', // RrpRequester constructor
-    'SetAirnodeXpub',
-    'SetSponsorshipStatus',
-    'CreatedTemplate',
-    'MadeTemplateRequest',
-    'MadeFullRequest',
-  ]);
+  expect(preInvokelogNames).toEqual(expect.arrayContaining(preInvokeExpectedLogs));
 
   await startCoordinator();
 
+  const postInvokeExpectedLogs = [...preInvokeExpectedLogs, 'FailedRequest', 'FulfilledRequest'];
   const postInvokeLogs = await fetchAllLogs(provider, deployment.contracts.AirnodeRrp);
-  expect(postInvokeLogs.map(({ name }) => name)).toEqual([
-    'SetSponsorshipStatus', // RrpRequester constructor
-    'SetAirnodeXpub',
-    'SetSponsorshipStatus',
-    'CreatedTemplate',
-    'MadeTemplateRequest',
-    'MadeFullRequest',
-    'FailedRequest',
-    'FulfilledRequest',
-  ]);
+  expect(postInvokeLogs.map(({ name }) => name)).toEqual(expect.arrayContaining(postInvokeExpectedLogs));
 
   const failedRequest = filterLogsByName(postInvokeLogs, 'FailedRequest')[0];
   const templateRequest = filterLogsByName(postInvokeLogs, 'MadeTemplateRequest')[0];


### PR DESCRIPTION
…ta-protocol changes

Some node e2e tests are expecting a fixed set of events to be emitted and since the protocol is now emitting an extra `SetSponsorshiptStatus` event then they break. I refactored those tests to only expect only on the relevant events for the specific test.