### PR TITLE
Add executable flag to CLIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "bootstrap": "yarn install && lerna bootstrap",
-    "build": "lerna run build --stream",
+    "build": "lerna run build --stream && ts-node scripts/make-cli-executable.ts",
     "build:adapter": "(cd packages/adapter && yarn run build)",
     "build:admin": "(cd packages/admin && yarn run build)",
     "build:airnode-abi": "(cd packages/airnode-abi && yarn run build)",

--- a/scripts/make-cli-executable.ts
+++ b/scripts/make-cli-executable.ts
@@ -1,0 +1,8 @@
+import { chmodSync } from 'fs';
+
+// See: https://github.com/microsoft/TypeScript/issues/37583
+const addExecuteRightsMode = '755'; // default is 664
+chmodSync('packages/admin/dist/bin/admin.js', addExecuteRightsMode);
+chmodSync('packages/deployer/dist/bin/deployer.js', addExecuteRightsMode);
+chmodSync('packages/validator/dist/bin/convertor.js', addExecuteRightsMode);
+chmodSync('packages/validator/dist/bin/validator.js', addExecuteRightsMode);


### PR DESCRIPTION
https://api3dao.atlassian.net/browse/AN-230

Cause of the issue: https://github.com/microsoft/TypeScript/issues/37583

I think we have only 4 CLI tools as of now - unfortunately we will have to think about this issue when adding new CLI tools.