### PR TITLE
Force linking of unbuild binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint:eslint:fix": "eslint . --ext .js,.ts --fix",
     "lint:solhint": "solhint ./**/*.sol",
     "pack": "lerna run pack --stream",
-    "postinstall": "husky install",
+    "postinstall": "husky install && lerna link",
     "prettify": "prettier --write ./**/*.{js,sol,ts} --loglevel silent",
     "pretty-quick": "pretty-quick --staged --pattern \"**/*.*(js|sol|ts)\"",
     "publish": "lerna publish",


### PR DESCRIPTION
Links for binaries were not created due to the fact that before the TS build there is nothing to be linked. This will force the creation. Needed mainly for the new Airnode starter.