### PR TITLE
Require Airnode signatures for fulfillments

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -3,9 +3,9 @@
 
 > The contracts that implement the Airnode protocols
 
-***This documents the Beta version of the protocol.
+***This documents the protocol for v0.1.
 We have also published and documented the pre-alpha version widely.
-The pre-alpha and the Beta versions are very different in implementation and the terminology they use is contradictory.
+Pre-alpha and v0.1 are very different in implementation and the terminology they use is contradictory.
 If you are referring to any outside source, make sure that it is not referring to the pre-alpha version, or at least interpret it accordingly.***
 
 ## Instructions
@@ -46,8 +46,9 @@ Currently, only RRP is implemented, and PSP is only designed at a conceptual lev
 Nevertheless, the package's directory structure is designed in anticipation of the PSP implementation.
 
 The protocols are extended in functionality through *authorizers*.
-An authorizer is an on-chain contract that can be called statically to check if a particular request should be responded to (e.g., if its requester is whitelisted).
+An authorizer is an on-chain contract that can be called statically to check if a particular request should be responded to, e.g., if its requester is whitelisted.
 While deploying an Airnode, the operator specifies the addresses of the authorizer contracts they want to use.
+(These contracts may live on a chain different than the protocol contract, e.g., an Airnode can be configured to refer to a mainnet authorizer for requests received from Rinkeby.)
 Then, whenever an Airnode receives a request, it will make a static call to its authorizers to determine if it should respond to the request.
 
 The contracts that use the Airnode protocol to make API calls are called *requesters*.
@@ -99,17 +100,13 @@ The contracts are implemented in a way that they are entirely trustless and perm
 
 In other words, the Airnode operators do not need to deploy any contracts in the regular user flow.
 This is preferred because deploying contracts causes a lot of UX friction and costs a lot of gas.
-Furthermore, the requester now has to verify that the individually-deployed contracts are not tampered with, which is not possible to do in a trustless way.
+Furthermore, the requester now has to verify that the individually-deployed contracts are not tampered with, which cannot peasibly be done in a trustless way.
 Implementing the protocol as a single, communal contract solves these problems.
 
-### Transactions that Airnode operators need to do explicitly are optional
+### No transactions needed for Airnode deployment
 
 In some cases, even needing to make a single transaction causes significant friction for onboarding Airnode operators (or looking at it from the other way, it would be extremely convenient to onboard Airnode operators if they never had to make any transactions).
 This is why the protocol is implemented in a way to avoid this.
-
-There is an optional transaction that the Airnode operator can make to announce their Airnode's extended public key (which the sponsor wallets can be derived from) on-chain.
-This information is not required for the protocol to be used, and the Airnode operator may announce this through off-chain channels, e.g., through a listing service, or in their docs.
-Therefore, the transaction to announce this parameter is optional.
 
 ### Requester sponsors all gas costs
 
@@ -121,7 +118,7 @@ Airnode protocols are implemented in a way that enables the requester to sponsor
 
 Airnodes are identified by the address of the default BIP 44 wallet (`m/44'/60'/0'/0/0`) derived from its seed.
 This means that if the Airnode uses the same seed on another chain (which they are expected to), the Airnode will have the same ID.
-In other words, the Airnode operator has to broadcast only a single ID as their own, this will be used universally across all chains.
+In other words, the Airnode operator has to broadcast only a single address as their own, this will be used universally across all chains.
 
 ### Be mindful of Ethereum provider interactions
 
@@ -149,10 +146,8 @@ Even though this decoding operation overhead will recur a lot, it is still negli
 The address of the default BIP 44 wallet (`m/44'/60'/0'/0/0`) derived from this seed is used to identify the Airnode.
 The Airnode (referring to the node application) polls `AirnodeRrp` for `MadeTemplateRequest` and `MadeFullRequest` events indexed by its own identifying address (and drops the ones that have matching `FulfilledRequest` and `FailedRequest` events).
 
-Note that the Airnode operator may not announce its extended public key (that belongs to the HDNode with the path `m/44'/60'/0'`) on-chain, in which case it would have to do it through off-chain channels.
-
 2. A developer decides to build a contract that makes requests to a specific Airnode (we will call this contract *requester*).
-Using the `xpub` of the Airnode and the address of an Ethereum account they control, the developer derives the address of their sponsor wallet (see below for how this is done).
+Using the `xpub` of the Airnode (which is announced off-chain) and the address of an Ethereum account they control, the developer derives the address of their sponsor wallet (see below for how this is done).
 The developer funds this sponsor wallet, then calls `setSponsorshipStatus()` in `AirnodeRrp` with the address of their requester contract to sponsor it.
 This means the developer is now the *sponsor* of their requester contract, i.e., the requester contract can make Airnode requests that will be fulfilled by their sponsor wallet.
 
@@ -180,11 +175,17 @@ This is done because we cannot derive the sponsor wallet from `xpub` on-chain, s
 Assuming that the requester contract developer has done Step 3, one of the authorizers will have whitelisted the requester contract and will return `true`.
 
 7. The Airnode makes the API call specified by the request (with an `endpointId` and ABI-encoded `parameters`) and encodes the payload as specified by the request (these specifications are outside the scope of this package).
-Then, the Airnode calls `fulfill()` of `AirnodeRrp`, which forwards this call to the callback function in the destination address.
+The hash of the request ID and its response payload is signed by the private key of the address that identifies Airnode (to decisively prove that the holder of the Airnode private key returned the payload as the response to a specific request).
+Then, the Airnode calls `fulfill()` of `AirnodeRrp`, with the request ID, payload and the signature, which forwards the request ID and the payload to the callback function in the destination address.
 The callback function can be as flexible as needed, but note that the gas cost of execution will be undertaken by the sponsor wallet.
 
 If anything goes wrong during this flow, the Airnode calls the `fail()` function of `AirnodeRrp` with an error message that explains what went wrong.
+For example, if `fulfill()` is going to revert, the node calls back `fail()` and forwards the revert string as the error message for debugging purposes.
 However, there are some cases where this is not possible, e.g., the specified sponsor wallet does not match the sponsor address, in which case the request will not be responded to at all.
+
+Note that calling `fail()` does not require a signature from the Airnode address.
+This is because `sponsorWallet` is trusted with transmitting the signed payload to the chain with a proper transaction (e.g., with a large enough `gasLimit`), or reporting that it could not if that is the case (and sometimes the reason may be that the signing functionality is not available).
+The `sponsorWallet` failing requests that it should not or returning false error messages is not considered a security issue, as failed requests do not call back the fulfillment target.
 
 ## Sponsor wallet derivation
 
@@ -196,7 +197,8 @@ Then, we can divide these 160 bits into six 31 bit-long chunks and the derivatio
 m / 44' / 60' / 0' / 0 / sponsor && 0x7FFFFFFF / (sponsor >> 31) && 0x7FFFFFFF / (sponsor >> 62) && 0x7FFFFFFF / (sponsor >> 93) && 0x7FFFFFFF / (sponsor >> 124) && 0x7FFFFFFF / (sponsor >> 155) && 0x7FFFFFFF
 ```
 
-Anyone can use the `xpub` that the Airnode has announced (through on-chain or off-chain channels) and the sponsor's address to derive a sponsor wallet address for a specific Airnode–sponsor pair.
+Anyone can use the `xpub` that the Airnode has announced and the sponsor's address to derive a sponsor wallet address for a specific Airnode–sponsor pair.
+Before doing so, the user should first derive the address of the wallet derived with the path `0/0` and confirm that it is the Airnode address (to make sure that the `xpub` announced for the Airnode is correct).
 Since the `xpub` belongs to the HDNode with the path `m/44'/60'/0'`, the sponsor wallet address derivation from that will be done with the path `0/sponsor && 0x7FFFFFFF/...`, i.e., the `m/44'/60'/0'` at the beginning must be omitted.
 
 Note that the derivation path starts with `0/...`.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -100,7 +100,7 @@ The contracts are implemented in a way that they are entirely trustless and perm
 
 In other words, the Airnode operators do not need to deploy any contracts in the regular user flow.
 This is preferred because deploying contracts causes a lot of UX friction and costs a lot of gas.
-Furthermore, the requester now has to verify that the individually-deployed contracts are not tampered with, which cannot peasibly be done in a trustless way.
+Furthermore, the requester now has to verify that the individually-deployed contracts are not tampered with, which cannot feasibly be done in a trustless way.
 Implementing the protocol as a single, communal contract solves these problems.
 
 ### No transactions needed for Airnode deployment
@@ -147,7 +147,7 @@ The address of the default BIP 44 wallet (`m/44'/60'/0'/0/0`) derived from this 
 The Airnode (referring to the node application) polls `AirnodeRrp` for `MadeTemplateRequest` and `MadeFullRequest` events indexed by its own identifying address (and drops the ones that have matching `FulfilledRequest` and `FailedRequest` events).
 
 2. A developer decides to build a contract that makes requests to a specific Airnode (we will call this contract *requester*).
-Using the `xpub` of the Airnode (which is announced off-chain) and the address of an Ethereum account they control, the developer derives the address of their sponsor wallet (see below for how this is done).
+Using the `xpub` (extended public key) of the Airnode (which is announced off-chain) and the address of an Ethereum account they control, the developer derives the address of their sponsor wallet (see below for how this is done).
 The developer funds this sponsor wallet, then calls `setSponsorshipStatus()` in `AirnodeRrp` with the address of their requester contract to sponsor it.
 This means the developer is now the *sponsor* of their requester contract, i.e., the requester contract can make Airnode requests that will be fulfilled by their sponsor wallet.
 

--- a/packages/protocol/contracts/rrp/AirnodeRrp.sol
+++ b/packages/protocol/contracts/rrp/AirnodeRrp.sol
@@ -156,6 +156,7 @@ contract AirnodeRrp is
                 fulfillFunctionId
             )
         );
+        requesterToRequestCountPlusOne[msg.sender]++;
         emit MadeTemplateRequest(
             airnode,
             requestId,
@@ -169,7 +170,6 @@ contract AirnodeRrp is
             fulfillFunctionId,
             parameters
         );
-        requesterToRequestCountPlusOne[msg.sender]++;
     }
 
     /// @notice Called by the requester to make a full request, which provides

--- a/packages/protocol/contracts/rrp/AirnodeRrp.sol
+++ b/packages/protocol/contracts/rrp/AirnodeRrp.sol
@@ -16,10 +16,6 @@ contract AirnodeRrp is
 {
     using ECDSA for bytes32;
 
-    /// @notice Called to get the extended public key of the Airnode
-    /// @dev The xpub belongs to the HDNode with the path m/44'/60'/0'
-    mapping(address => string) public override airnodeToXpub;
-
     /// @notice Called to get the sponsorship status for a sponsor–requester
     /// pair
     mapping(address => mapping(address => bool))
@@ -36,25 +32,6 @@ contract AirnodeRrp is
     /// also used to check if the fulfillment for the particular request is
     /// expected (i.e., if there are recorded fulfillment parameters)
     mapping(bytes32 => bytes32) private requestIdToFulfillmentParameters;
-
-    /// @notice Called by the Airnode operator to announce its extended public
-    /// key
-    /// @dev It is expected for the Airnode operator to call this function with
-    /// the respective Airnode's default BIP 44 wallet (m/44'/60'/0'/0/0), to
-    /// report the xpub belongs to the HDNode with the path m/44'/60'/0'. Then,
-    /// if the address of the default BIP 44 wallet derived from the extended
-    /// public key (with the remaining non-hardened path, 0/0) does not match
-    /// the respective Airnode address, the extended public key is invalid
-    /// (does not belong to the respective Airnode).
-    /// An Airnode operator can also announce their extended public key through
-    /// off-chain channels. Validation method remains the same.
-    /// The extended public key of an Airnode is used with a sponsor address to
-    /// derive the address of the respective sponsor wallet.
-    /// @param xpub Extended public key of the Airnode
-    function setAirnodeXpub(string calldata xpub) external override {
-        airnodeToXpub[msg.sender] = xpub;
-        emit SetAirnodeXpub(msg.sender, xpub);
-    }
 
     /// @notice Called by the sponsor to set the sponsorship status of a
     /// requester, i.e., allow or disallow a requester to make requests that

--- a/packages/protocol/contracts/rrp/AirnodeRrp.sol
+++ b/packages/protocol/contracts/rrp/AirnodeRrp.sol
@@ -93,9 +93,10 @@ contract AirnodeRrp is
         ];
         requestId = keccak256(
             abi.encodePacked(
-                requesterRequestCount,
                 block.chainid,
+                address(this),
                 msg.sender,
+                requesterRequestCount,
                 templateId,
                 sponsor,
                 sponsorWallet,
@@ -163,9 +164,10 @@ contract AirnodeRrp is
         ];
         requestId = keccak256(
             abi.encodePacked(
-                requesterRequestCount,
                 block.chainid,
+                address(this),
                 msg.sender,
+                requesterRequestCount,
                 airnode,
                 endpointId,
                 sponsor,

--- a/packages/protocol/contracts/rrp/interfaces/IAirnodeRrp.sol
+++ b/packages/protocol/contracts/rrp/interfaces/IAirnodeRrp.sol
@@ -81,9 +81,10 @@ interface IAirnodeRrp is IAuthorizationUtils, ITemplateUtils, IWithdrawalUtils {
     function fulfill(
         bytes32 requestId,
         address airnode,
-        bytes calldata data,
         address fulfillAddress,
-        bytes4 fulfillFunctionId
+        bytes4 fulfillFunctionId,
+        bytes calldata data,
+        bytes calldata signature
     ) external returns (bool callSuccess, bytes memory callData);
 
     function fail(

--- a/packages/protocol/contracts/rrp/interfaces/IAirnodeRrp.sol
+++ b/packages/protocol/contracts/rrp/interfaces/IAirnodeRrp.sol
@@ -6,8 +6,6 @@ import "./ITemplateUtils.sol";
 import "./IWithdrawalUtils.sol";
 
 interface IAirnodeRrp is IAuthorizationUtils, ITemplateUtils, IWithdrawalUtils {
-    event SetAirnodeXpub(address indexed airnode, string xpub);
-
     event SetSponsorshipStatus(
         address indexed sponsor,
         address indexed requester,
@@ -54,8 +52,6 @@ interface IAirnodeRrp is IAuthorizationUtils, ITemplateUtils, IWithdrawalUtils {
         string errorMessage
     );
 
-    function setAirnodeXpub(string calldata xpub) external;
-
     function setSponsorshipStatus(address requester, bool sponsorshipStatus)
         external;
 
@@ -94,11 +90,6 @@ interface IAirnodeRrp is IAuthorizationUtils, ITemplateUtils, IWithdrawalUtils {
         bytes4 fulfillFunctionId,
         string calldata errorMessage
     ) external;
-
-    function airnodeToXpub(address airnode)
-        external
-        view
-        returns (string memory xpub);
 
     function sponsorToRequesterToSponsorshipStatus(
         address sponsor,

--- a/packages/protocol/test/rrp/AirnodeRrp.sol.js
+++ b/packages/protocol/test/rrp/AirnodeRrp.sol.js
@@ -77,11 +77,23 @@ describe('makeTemplateRequest', function () {
           const requestTimeParameters = utils.generateRandomBytes();
           const expectedRequestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                requesterRequestCount,
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                requesterRequestCount,
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -211,8 +223,9 @@ describe('makeFullRequest', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -222,9 +235,10 @@ describe('makeFullRequest', function () {
                 'bytes',
               ],
               [
-                requesterRequestCount,
                 chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                requesterRequestCount,
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -365,11 +379,23 @@ describe('fulfill', function () {
                 );
               const requestId = hre.ethers.utils.keccak256(
                 hre.ethers.utils.solidityPack(
-                  ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                    'uint256',
+                    'address',
+                    'address',
+                    'uint256',
+                    'bytes32',
+                    'address',
+                    'address',
+                    'address',
+                    'bytes4',
+                    'bytes',
+                  ],
+                  [
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     templateId,
                     roles.sponsor.address,
                     sponsorWalletAddress,
@@ -466,11 +492,23 @@ describe('fulfill', function () {
                 );
               const requestId = hre.ethers.utils.keccak256(
                 hre.ethers.utils.solidityPack(
-                  ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                    'uint256',
+                    'address',
+                    'address',
+                    'uint256',
+                    'bytes32',
+                    'address',
+                    'address',
+                    'address',
+                    'bytes4',
+                    'bytes',
+                  ],
+                  [
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     templateId,
                     roles.sponsor.address,
                     sponsorWalletAddress,
@@ -566,11 +604,23 @@ describe('fulfill', function () {
                 );
               const requestId = hre.ethers.utils.keccak256(
                 hre.ethers.utils.solidityPack(
-                  ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(roles.randomPerson.address)).sub(1),
+                    'uint256',
+                    'address',
+                    'address',
+                    'uint256',
+                    'bytes32',
+                    'address',
+                    'address',
+                    'address',
+                    'bytes4',
+                    'bytes',
+                  ],
+                  [
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     roles.randomPerson.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(roles.randomPerson.address)).sub(1),
                     templateId,
                     roles.sponsor.address,
                     sponsorWalletAddress,
@@ -652,11 +702,23 @@ describe('fulfill', function () {
                 );
               const requestId = hre.ethers.utils.keccak256(
                 hre.ethers.utils.solidityPack(
-                  ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                    'uint256',
+                    'address',
+                    'address',
+                    'uint256',
+                    'bytes32',
+                    'address',
+                    'address',
+                    'address',
+                    'bytes4',
+                    'bytes',
+                  ],
+                  [
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     templateId,
                     roles.sponsor.address,
                     sponsorWalletAddress,
@@ -752,11 +814,23 @@ describe('fulfill', function () {
                 );
               const requestId = hre.ethers.utils.keccak256(
                 hre.ethers.utils.solidityPack(
-                  ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                    'uint256',
+                    'address',
+                    'address',
+                    'uint256',
+                    'bytes32',
+                    'address',
+                    'address',
+                    'address',
+                    'bytes4',
+                    'bytes',
+                  ],
+                  [
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     templateId,
                     roles.sponsor.address,
                     sponsorWalletAddress,
@@ -839,11 +913,23 @@ describe('fulfill', function () {
               );
             const requestId = hre.ethers.utils.keccak256(
               hre.ethers.utils.solidityPack(
-                ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
                 [
-                  (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                  'uint256',
+                  'address',
+                  'address',
+                  'uint256',
+                  'bytes32',
+                  'address',
+                  'address',
+                  'address',
+                  'bytes4',
+                  'bytes',
+                ],
+                [
                   (await hre.ethers.provider.getNetwork()).chainId,
+                  airnodeRrp.address,
                   rrpRequester.address,
+                  (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                   templateId,
                   roles.sponsor.address,
                   sponsorWalletAddress,
@@ -940,11 +1026,23 @@ describe('fulfill', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -1006,11 +1104,23 @@ describe('fulfill', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -1072,11 +1182,23 @@ describe('fulfill', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -1138,11 +1260,23 @@ describe('fulfill', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -1199,11 +1333,12 @@ describe('fulfill', function () {
           );
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpRequester.address,
+              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -1264,8 +1399,9 @@ describe('fulfill', function () {
                 hre.ethers.utils.solidityPack(
                   [
                     'uint256',
-                    'uint256',
                     'address',
+                    'address',
+                    'uint256',
                     'address',
                     'bytes32',
                     'address',
@@ -1275,9 +1411,10 @@ describe('fulfill', function () {
                     'bytes',
                   ],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     airnodeAddress,
                     endpointId,
                     roles.sponsor.address,
@@ -1372,8 +1509,9 @@ describe('fulfill', function () {
                 hre.ethers.utils.solidityPack(
                   [
                     'uint256',
-                    'uint256',
                     'address',
+                    'address',
+                    'uint256',
                     'address',
                     'bytes32',
                     'address',
@@ -1383,9 +1521,10 @@ describe('fulfill', function () {
                     'bytes',
                   ],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     airnodeAddress,
                     endpointId,
                     roles.sponsor.address,
@@ -1479,8 +1618,9 @@ describe('fulfill', function () {
                 hre.ethers.utils.solidityPack(
                   [
                     'uint256',
-                    'uint256',
                     'address',
+                    'address',
+                    'uint256',
                     'address',
                     'bytes32',
                     'address',
@@ -1490,9 +1630,10 @@ describe('fulfill', function () {
                     'bytes',
                   ],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(roles.randomPerson.address)).sub(1),
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     roles.randomPerson.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(roles.randomPerson.address)).sub(1),
                     airnodeAddress,
                     endpointId,
                     roles.sponsor.address,
@@ -1572,8 +1713,9 @@ describe('fulfill', function () {
                 hre.ethers.utils.solidityPack(
                   [
                     'uint256',
-                    'uint256',
                     'address',
+                    'address',
+                    'uint256',
                     'address',
                     'bytes32',
                     'address',
@@ -1583,9 +1725,10 @@ describe('fulfill', function () {
                     'bytes',
                   ],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     airnodeAddress,
                     endpointId,
                     roles.sponsor.address,
@@ -1679,8 +1822,9 @@ describe('fulfill', function () {
                 hre.ethers.utils.solidityPack(
                   [
                     'uint256',
-                    'uint256',
                     'address',
+                    'address',
+                    'uint256',
                     'address',
                     'bytes32',
                     'address',
@@ -1690,9 +1834,10 @@ describe('fulfill', function () {
                     'bytes',
                   ],
                   [
-                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     (await hre.ethers.provider.getNetwork()).chainId,
+                    airnodeRrp.address,
                     rrpRequester.address,
+                    (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                     airnodeAddress,
                     endpointId,
                     roles.sponsor.address,
@@ -1773,8 +1918,9 @@ describe('fulfill', function () {
               hre.ethers.utils.solidityPack(
                 [
                   'uint256',
-                  'uint256',
                   'address',
+                  'address',
+                  'uint256',
                   'address',
                   'bytes32',
                   'address',
@@ -1784,9 +1930,10 @@ describe('fulfill', function () {
                   'bytes',
                 ],
                 [
-                  (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                   (await hre.ethers.provider.getNetwork()).chainId,
+                  airnodeRrp.address,
                   rrpRequester.address,
+                  (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                   airnodeAddress,
                   endpointId,
                   roles.sponsor.address,
@@ -1881,8 +2028,9 @@ describe('fulfill', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -1892,9 +2040,10 @@ describe('fulfill', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -1954,8 +2103,9 @@ describe('fulfill', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -1965,9 +2115,10 @@ describe('fulfill', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -2027,8 +2178,9 @@ describe('fulfill', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -2038,9 +2190,10 @@ describe('fulfill', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -2100,8 +2253,9 @@ describe('fulfill', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -2111,9 +2265,10 @@ describe('fulfill', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -2166,11 +2321,24 @@ describe('fulfill', function () {
           );
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+              'uint256',
+              'address',
+              'address',
+              'uint256',
+              'address',
+              'bytes32',
+              'address',
+              'address',
+              'address',
+              'bytes4',
+              'bytes',
+            ],
+            [
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpRequester.address,
+              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
               airnodeAddress,
               endpointId,
               roles.sponsor.address,
@@ -2236,11 +2404,23 @@ describe('fail', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -2358,11 +2538,23 @@ describe('fail', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -2416,11 +2608,23 @@ describe('fail', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -2474,11 +2678,23 @@ describe('fail', function () {
             );
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -2526,11 +2742,12 @@ describe('fail', function () {
           );
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpRequester.address,
+              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -2583,8 +2800,9 @@ describe('fail', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -2594,9 +2812,10 @@ describe('fail', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -2707,8 +2926,9 @@ describe('fail', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -2718,9 +2938,10 @@ describe('fail', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -2772,8 +2993,9 @@ describe('fail', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -2783,9 +3005,10 @@ describe('fail', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -2837,8 +3060,9 @@ describe('fail', function () {
             hre.ethers.utils.solidityPack(
               [
                 'uint256',
-                'uint256',
                 'address',
+                'address',
+                'uint256',
                 'address',
                 'bytes32',
                 'address',
@@ -2848,9 +3072,10 @@ describe('fail', function () {
                 'bytes',
               ],
               [
-                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpRequester.address,
+                (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
                 airnodeAddress,
                 endpointId,
                 roles.sponsor.address,
@@ -2894,11 +3119,24 @@ describe('fail', function () {
           );
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
+              'uint256',
+              'address',
+              'address',
+              'uint256',
+              'address',
+              'bytes32',
+              'address',
+              'address',
+              'address',
+              'bytes4',
+              'bytes',
+            ],
+            [
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpRequester.address,
+              (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
               airnodeAddress,
               endpointId,
               roles.sponsor.address,

--- a/packages/protocol/test/rrp/AirnodeRrp.sol.js
+++ b/packages/protocol/test/rrp/AirnodeRrp.sol.js
@@ -32,19 +32,6 @@ beforeEach(async () => {
   });
 });
 
-describe('setAirnodeXpub', function () {
-  it('sets Airnode public key', async function () {
-    const initialPublicKey = await airnodeRrp.airnodeToXpub(airnodeAddress);
-    expect(initialPublicKey).to.equal('');
-    const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic).connect(hre.ethers.provider);
-    await expect(airnodeRrp.connect(airnodeWallet).setAirnodeXpub(airnodeXpub, { gasLimit: 500000 }))
-      .to.emit(airnodeRrp, 'SetAirnodeXpub')
-      .withArgs(airnodeAddress, airnodeXpub);
-    const setPublicKey = await airnodeRrp.airnodeToXpub(airnodeAddress);
-    expect(setPublicKey).to.equal(airnodeXpub);
-  });
-});
-
 describe('setSponsorshipStatus', function () {
   it('sets sponsorship status', async function () {
     expect(

--- a/packages/protocol/test/rrp/requesters/RrpBeaconServer.sol.js
+++ b/packages/protocol/test/rrp/requesters/RrpBeaconServer.sol.js
@@ -112,11 +112,12 @@ describe('requestBeaconUpdate', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -520,11 +521,12 @@ describe('readBeacon', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -582,11 +584,12 @@ describe('readBeacon', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -644,11 +647,12 @@ describe('readBeacon', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -706,11 +710,12 @@ describe('readBeacon', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -766,11 +771,12 @@ describe('readBeacon', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -824,11 +830,12 @@ describe('readBeacon', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -882,11 +889,12 @@ describe('readBeacon', function () {
         // Compute the expected request ID
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               rrpBeaconServer.address,
+              await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,
@@ -1076,11 +1084,23 @@ describe('fulfill', function () {
           // Compute the expected request ID
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpBeaconServer.address,
+                await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -1130,11 +1150,23 @@ describe('fulfill', function () {
           // Compute the expected request ID
           const requestId = hre.ethers.utils.keccak256(
             hre.ethers.utils.solidityPack(
-              ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
               [
-                await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
+                'uint256',
+                'address',
+                'address',
+                'uint256',
+                'bytes32',
+                'address',
+                'address',
+                'address',
+                'bytes4',
+                'bytes',
+              ],
+              [
                 (await hre.ethers.provider.getNetwork()).chainId,
+                airnodeRrp.address,
                 rrpBeaconServer.address,
+                await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
                 templateId,
                 roles.sponsor.address,
                 sponsorWalletAddress,
@@ -1237,11 +1269,12 @@ describe('fulfill', function () {
           );
         const requestId = hre.ethers.utils.keccak256(
           hre.ethers.utils.solidityPack(
-            ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+            ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
             [
-              (await airnodeRrp.requesterToRequestCountPlusOne(roles.randomPerson.address)).sub(1),
               (await hre.ethers.provider.getNetwork()).chainId,
+              airnodeRrp.address,
               roles.randomPerson.address,
+              (await airnodeRrp.requesterToRequestCountPlusOne(roles.randomPerson.address)).sub(1),
               templateId,
               roles.sponsor.address,
               sponsorWalletAddress,

--- a/packages/protocol/test/rrp/requesters/RrpRequester.sol.js
+++ b/packages/protocol/test/rrp/requesters/RrpRequester.sol.js
@@ -68,11 +68,12 @@ describe('onlyAirnodeRrp', function () {
         );
       const requestId = hre.ethers.utils.keccak256(
         hre.ethers.utils.solidityPack(
-          ['uint256', 'uint256', 'address', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+          ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
           [
-            (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
             (await hre.ethers.provider.getNetwork()).chainId,
+            airnodeRrp.address,
             rrpRequester.address,
+            (await airnodeRrp.requesterToRequestCountPlusOne(rrpRequester.address)).sub(1),
             templateId,
             roles.sponsor.address,
             sponsorWalletAddress,


### PR DESCRIPTION
- Require the Airnode wallet to sign the hash of `requestId` and `data`
- Reordered the `fulfill()` arguments
- Remove `xpub` announcement functionality (I was meaning to do this but this makes even more sense now, because in theory, multiple HD wallets with different seeds/xpubs can serve requests made to a single Airnode address as long as they have the Airnode sign the payload)
- Moved where the nonce is incremented in `makeTemplateRequest()`, not really important

I'm okay with waiting for https://github.com/api3dao/airnode/pull/577 to be merged before opening this PR, let me know if you think we should be doing something else