### PR TITLE
Fix testing lambda deployment

### DIFF
--- a/packages/deployer/terraform/airnode/main.tf
+++ b/packages/deployer/terraform/airnode/main.tf
@@ -66,6 +66,7 @@ module "startCoordinator" {
 
 module "testApi" {
   source = "./modules/function"
+  count  = var.api_key == null ? 0 : 1
 
   name               = "${local.name_prefix}-testApi"
   handler            = "handlers/aws/index.testApi"
@@ -85,11 +86,11 @@ module "testApiGateway" {
   stage         = "v1"
   template_file = "./templates/apigateway.yaml.tpl"
   template_variables = {
-    proxy_lambda = module.testApi.lambda_arn
+    proxy_lambda = module.testApi[0].lambda_arn
     region       = var.aws_region
   }
   lambdas = [
-    module.testApi.lambda_arn
+    module.testApi[0].lambda_arn
   ]
   api_key = var.api_key
 }


### PR DESCRIPTION
As I was testing Airnode starter I realized that when I deploy Airnode without the HTTP gateway, the lambda that is called by the gateway is deployed anyway, even though nothing will ever call it. This fixes that.