### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "node": "^14.17.1"
   },
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/api3dao/airnode"
+  },
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
It's a good practice to include the URL of the repo: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository