### PR TITLE
Remove `ois.[0].apiSpecifications.security` field from example configs

### DIFF
--- a/packages/examples/integrations/coingecko-testable/config.json
+++ b/packages/examples/integrations/coingecko-testable/config.json
@@ -88,8 +88,7 @@
         },
         "components": {
           "securitySchemes": {}
-        },
-        "security": {}
+        }
       },
       "endpoints": [
         {

--- a/packages/examples/integrations/coingecko/config.json
+++ b/packages/examples/integrations/coingecko/config.json
@@ -87,8 +87,7 @@
         },
         "components": {
           "securitySchemes": {}
-        },
-        "security": {}
+        }
       },
       "endpoints": [
         {


### PR DESCRIPTION
Field `ois.[0].apiSpecifications.security` should no longer be present in the `config.json`.