### PR TITLE
Add back `ois.[0].apiSpecifications.security` field

### DIFF
--- a/packages/examples/integrations/coingecko-testable/config.json
+++ b/packages/examples/integrations/coingecko-testable/config.json
@@ -88,7 +88,8 @@
         },
         "components": {
           "securitySchemes": {}
-        }
+        },
+        "security": {}
       },
       "endpoints": [
         {

--- a/packages/examples/integrations/coingecko/config.json
+++ b/packages/examples/integrations/coingecko/config.json
@@ -87,7 +87,8 @@
         },
         "components": {
           "securitySchemes": {}
-        }
+        },
+        "security": {}
       },
       "endpoints": [
         {

--- a/packages/node/config/config.json.example
+++ b/packages/node/config/config.json.example
@@ -84,6 +84,9 @@
               "name": "access_key"
             }
           }
+        },
+        "security": {
+          "Currency Converter Security Scheme": []
         }
       },
       "endpoints": [


### PR DESCRIPTION
Based on the [discussion](https://api3workspace.slack.com/archives/C02AYRX8D89/p1634728603061400).