### PR TITLE
AN-300: Implement correct behavior for ois.[0].apiSpecifications.security field

### DIFF
--- a/packages/adapter/src/request-building/authentication.test.ts
+++ b/packages/adapter/src/request-building/authentication.test.ts
@@ -5,8 +5,14 @@ import * as authentication from './authentication';
 import * as fixtures from '../../test/fixtures';
 
 describe('building empty parameters', () => {
-  it('returns no parameters if credentials is empty', () => {
-    const options = fixtures.buildCacheRequestOptions({ apiCredentials: undefined });
+  it('returns no parameters if API security is empty', () => {
+    const ois = fixtures.buildOIS();
+    const apiSpecifications: ApiSpecification = {
+      ...ois.apiSpecifications,
+      security: {},
+    };
+    const invalidOIS = fixtures.buildOIS({ apiSpecifications });
+    const options = fixtures.buildCacheRequestOptions({ ois: invalidOIS });
     const res = authentication.buildParameters(options);
     expect(res).toEqual({
       headers: {},
@@ -26,6 +32,16 @@ describe('building empty parameters', () => {
     };
     const invalidOIS = fixtures.buildOIS({ apiSpecifications });
     const options = fixtures.buildCacheRequestOptions({ ois: invalidOIS });
+    const res = authentication.buildParameters(options);
+    expect(res).toEqual({
+      headers: {},
+      query: {},
+      cookies: {},
+    });
+  });
+
+  it('returns no parameters if API credentials is empty', () => {
+    const options = fixtures.buildCacheRequestOptions({ apiCredentials: undefined });
     const res = authentication.buildParameters(options);
     expect(res).toEqual({
       headers: {},

--- a/packages/adapter/test/fixtures/ois.ts
+++ b/packages/adapter/test/fixtures/ois.ts
@@ -44,6 +44,9 @@ export function buildOIS(overrides?: Partial<OIS>): OIS {
           },
         },
       },
+      security: {
+        myapiApiScheme: [],
+      },
     },
     endpoints: [
       {

--- a/packages/node/test/fixtures/config/ois.ts
+++ b/packages/node/test/fixtures/config/ois.ts
@@ -44,6 +44,9 @@ export function buildOIS(ois?: Partial<OIS>): OIS {
           },
         },
       },
+      security: {
+        myapiApiScheme: [],
+      },
     },
     endpoints: [
       {

--- a/packages/ois/src/types.ts
+++ b/packages/ois/src/types.ts
@@ -47,6 +47,7 @@ export interface ApiSpecification {
   components: ApiComponents;
   paths: { [key: string]: Path };
   servers: Server[];
+  security: { [key: string]: [] };
 }
 
 // ===========================================


### PR DESCRIPTION
New Implementation:
1. Iterate over `ois.apiSpecifications.security` 
2. and for each security scheme name we fetch the security scheme details from `ois.apiSpecifications.components.securitySchemes`
3. lastly for each security scheme we then fetch the credentials from `options.credentials`