### PR TITLE
Bump contract dependencies

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -22,7 +22,7 @@
     {
       "files": "*.sol",
       "options": {
-        "compiler": "0.8.6",
+        "compiler": "0.8.9",
         "printWidth": 80,
         "tabWidth": 4,
         "useTabs": false,

--- a/packages/airnode-examples/contracts/AirnodeRrpForAirnodeStarter.sol
+++ b/packages/airnode-examples/contracts/AirnodeRrpForAirnodeStarter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 // We need to compile AirnodeRrp.sol and this is the easiest way to make hardhat do that
 import "@api3/airnode-protocol/contracts/rrp/AirnodeRrp.sol";

--- a/packages/airnode-examples/contracts/coingecko-testable/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko-testable/Requester.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequester.sol";
 

--- a/packages/airnode-examples/contracts/coingecko/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko/Requester.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequester.sol";
 

--- a/packages/airnode-examples/hardhat.config.ts
+++ b/packages/airnode-examples/hardhat.config.ts
@@ -22,7 +22,7 @@ if (integrationInfo) {
 const config: HardhatUserConfig = {
   defaultNetwork: integrationInfo?.network,
   networks,
-  solidity: '0.8.6',
+  solidity: '0.8.9',
 };
 
 export default config;

--- a/packages/airnode-protocol/archive/contracts/adminnable/Adminnable.sol
+++ b/packages/airnode-protocol/archive/contracts/adminnable/Adminnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./interfaces/IAdminnable.sol";
 

--- a/packages/airnode-protocol/archive/contracts/adminnable/SelfAdminnable.sol
+++ b/packages/airnode-protocol/archive/contracts/adminnable/SelfAdminnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./interfaces/ISelfAdminnable.sol";
 

--- a/packages/airnode-protocol/archive/contracts/adminnable/Whitelister.sol
+++ b/packages/airnode-protocol/archive/contracts/adminnable/Whitelister.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 /// @title Contract where users are whitelisted for specific services (could be
 /// Airnode endpoints, dAPIs, beacons, etc.) until an expiration time or

--- a/packages/airnode-protocol/archive/contracts/adminnable/interfaces/IAdminnable.sol
+++ b/packages/airnode-protocol/archive/contracts/adminnable/interfaces/IAdminnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IAdminnable {
     event TransferredMetaAdminStatus(address indexed metaAdmin);

--- a/packages/airnode-protocol/archive/contracts/adminnable/interfaces/ISelfAdminnable.sol
+++ b/packages/airnode-protocol/archive/contracts/adminnable/interfaces/ISelfAdminnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface ISelfAdminnable {
     event SetRank(

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/AirnodeRequesterRrpAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/AirnodeRequesterRrpAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../adminnable/SelfAdminnable.sol";
 import "./RequesterRrpAuthorizer.sol";

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/DaoRequesterRrpAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/DaoRequesterRrpAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../adminnable/Adminnable.sol";
 import "./RequesterRrpAuthorizer.sol";

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/RequesterRrpAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/RequesterRrpAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../adminnable/Whitelister.sol";
 import "./interfaces/IRequesterRrpAuthorizer.sol";

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/TokenLockRrpAuthorizerAdmin.sol_
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/TokenLockRrpAuthorizerAdmin.sol_
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../DaoRequesterRrpAuthorizer.sol";
 import "../interfaces/IApi3Token.sol";

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/TokenLockRrpAuthorizerAdminExternal.sol_
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/TokenLockRrpAuthorizerAdminExternal.sol_
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../interfaces/IApi3Token.sol";
 import "./interfaces/ITokenLockRrpAuthorizerAdminExternal.sol";

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/interfaces/ITokenLockRrpAuthorizerAdmin.sol_
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/interfaces/ITokenLockRrpAuthorizerAdmin.sol_
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface ITokenLockRrpAuthorizerAdmin {
     event SetMinimumLockingTime(uint256 minimumLockingTime);

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/interfaces/ITokenLockRrpAuthorizerAdminExternal.sol_
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/admin/interfaces/ITokenLockRrpAuthorizerAdminExternal.sol_
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface ITokenLockRrpAuthorizerAdminExternal {
     event SetMinimumLockingTime(uint256 minimumLockingTime);

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IAirnodeRequesterRrpAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IAirnodeRequesterRrpAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../../adminnable/interfaces/ISelfAdminnable.sol";
 import "./IRequesterRrpAuthorizer.sol";

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IAuthorizer {
     function isAuthorized(

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IDaoRequesterRrpAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IDaoRequesterRrpAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../../adminnable/interfaces/IAdminnable.sol";
 import "./IRequesterRrpAuthorizer.sol";

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IRequesterRrpAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IRequesterRrpAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./IRrpAuthorizer.sol";
 

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IRrpAuthorizer.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/interfaces/IRrpAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IRrpAuthorizer {
     // solhint-disable-next-line func-name-mixedcase

--- a/packages/airnode-protocol/archive/contracts/rrp/authorizers/mock/MockApi3Token.sol
+++ b/packages/airnode-protocol/archive/contracts/rrp/authorizers/mock/MockApi3Token.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/airnode-protocol/contracts/access-control-registry/AccessControlClient.sol
+++ b/packages/airnode-protocol/contracts/access-control-registry/AccessControlClient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./interfaces/IAccessControlClient.sol";
 

--- a/packages/airnode-protocol/contracts/access-control-registry/AccessControlManagerProxy.sol
+++ b/packages/airnode-protocol/contracts/access-control-registry/AccessControlManagerProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./AccessControlClient.sol";

--- a/packages/airnode-protocol/contracts/access-control-registry/AccessControlRegistry.sol
+++ b/packages/airnode-protocol/contracts/access-control-registry/AccessControlRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "./RoleDeriver.sol";

--- a/packages/airnode-protocol/contracts/access-control-registry/RoleDeriver.sol
+++ b/packages/airnode-protocol/contracts/access-control-registry/RoleDeriver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 /// @title Contract that implements the AccessControlRegistry role derivation
 /// logic

--- a/packages/airnode-protocol/contracts/access-control-registry/interfaces/IAccessControlClient.sol
+++ b/packages/airnode-protocol/contracts/access-control-registry/interfaces/IAccessControlClient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IAccessControlClient {
     function accessControlRegistry() external view returns (address);

--- a/packages/airnode-protocol/contracts/access-control-registry/interfaces/IAccessControlManagerProxy.sol
+++ b/packages/airnode-protocol/contracts/access-control-registry/interfaces/IAccessControlManagerProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./IAccessControlClient.sol";
 

--- a/packages/airnode-protocol/contracts/access-control-registry/interfaces/IAccessControlRegistry.sol
+++ b/packages/airnode-protocol/contracts/access-control-registry/interfaces/IAccessControlRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/IAccessControl.sol";
 

--- a/packages/airnode-protocol/contracts/authorizers/RequesterAuthorizer.sol
+++ b/packages/airnode-protocol/contracts/authorizers/RequesterAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../whitelist/Whitelist.sol";
 import "./interfaces/IRequesterAuthorizer.sol";

--- a/packages/airnode-protocol/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../whitelist/WhitelistRolesWithAirnode.sol";
 import "./RequesterAuthorizer.sol";

--- a/packages/airnode-protocol/contracts/authorizers/RequesterAuthorizerWithManager.sol
+++ b/packages/airnode-protocol/contracts/authorizers/RequesterAuthorizerWithManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../whitelist/WhitelistRolesWithManager.sol";
 import "./RequesterAuthorizer.sol";

--- a/packages/airnode-protocol/contracts/authorizers/interfaces/IAuthorizer.sol
+++ b/packages/airnode-protocol/contracts/authorizers/interfaces/IAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IAuthorizer {
     function isAuthorized(

--- a/packages/airnode-protocol/contracts/authorizers/interfaces/IRequesterAuthorizer.sol
+++ b/packages/airnode-protocol/contracts/authorizers/interfaces/IRequesterAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./IAuthorizer.sol";
 

--- a/packages/airnode-protocol/contracts/authorizers/interfaces/IRequesterAuthorizerWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/authorizers/interfaces/IRequesterAuthorizerWithAirnode.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../whitelist/interfaces/IWhitelistRolesWithAirnode.sol";
 import "./IRequesterAuthorizer.sol";

--- a/packages/airnode-protocol/contracts/authorizers/interfaces/IRequesterAuthorizerWithManager.sol
+++ b/packages/airnode-protocol/contracts/authorizers/interfaces/IRequesterAuthorizerWithManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../whitelist/interfaces/IWhitelistRolesWithManager.sol";
 import "./IRequesterAuthorizer.sol";

--- a/packages/airnode-protocol/contracts/authorizers/mock/MockAuthorizerAlwaysFalse.sol
+++ b/packages/airnode-protocol/contracts/authorizers/mock/MockAuthorizerAlwaysFalse.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../interfaces/IAuthorizer.sol";
 

--- a/packages/airnode-protocol/contracts/authorizers/mock/MockAuthorizerAlwaysTrue.sol
+++ b/packages/airnode-protocol/contracts/authorizers/mock/MockAuthorizerAlwaysTrue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../interfaces/IAuthorizer.sol";
 

--- a/packages/airnode-protocol/contracts/rrp/AirnodeRrp.sol
+++ b/packages/airnode-protocol/contracts/rrp/AirnodeRrp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "./AuthorizationUtils.sol";

--- a/packages/airnode-protocol/contracts/rrp/AuthorizationUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/AuthorizationUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./interfaces/IAuthorizationUtils.sol";
 import "../authorizers/interfaces/IAuthorizer.sol";

--- a/packages/airnode-protocol/contracts/rrp/TemplateUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/TemplateUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./interfaces/ITemplateUtils.sol";
 

--- a/packages/airnode-protocol/contracts/rrp/WithdrawalUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/WithdrawalUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./interfaces/IWithdrawalUtils.sol";
 

--- a/packages/airnode-protocol/contracts/rrp/interfaces/IAirnodeRrp.sol
+++ b/packages/airnode-protocol/contracts/rrp/interfaces/IAirnodeRrp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./IAuthorizationUtils.sol";
 import "./ITemplateUtils.sol";

--- a/packages/airnode-protocol/contracts/rrp/interfaces/IAuthorizationUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/interfaces/IAuthorizationUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IAuthorizationUtils {
     function checkAuthorizationStatus(

--- a/packages/airnode-protocol/contracts/rrp/interfaces/ITemplateUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/interfaces/ITemplateUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface ITemplateUtils {
     event CreatedTemplate(

--- a/packages/airnode-protocol/contracts/rrp/interfaces/IWithdrawalUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/interfaces/IWithdrawalUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IWithdrawalUtils {
     event RequestedWithdrawal(

--- a/packages/airnode-protocol/contracts/rrp/requesters/RrpBeaconServer.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/RrpBeaconServer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../../whitelist/Whitelist.sol";
 import "../../whitelist/WhitelistRolesWithManager.sol";

--- a/packages/airnode-protocol/contracts/rrp/requesters/RrpRequester.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/RrpRequester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../interfaces/IAirnodeRrp.sol";
 

--- a/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IRrpBeaconServer.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IRrpBeaconServer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IRrpBeaconServer {
     event ExtendedWhitelistExpiration(

--- a/packages/airnode-protocol/contracts/rrp/requesters/mock/MockRrpRequester.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/mock/MockRrpRequester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../RrpRequester.sol";
 

--- a/packages/airnode-protocol/contracts/whitelist/Whitelist.sol
+++ b/packages/airnode-protocol/contracts/whitelist/Whitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 /// @title Contract that implements temporary and permanent whitelists for
 /// multiple services identified with a hash

--- a/packages/airnode-protocol/contracts/whitelist/WhitelistRoles.sol
+++ b/packages/airnode-protocol/contracts/whitelist/WhitelistRoles.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "../access-control-registry/RoleDeriver.sol";
 import "../access-control-registry/AccessControlClient.sol";

--- a/packages/airnode-protocol/contracts/whitelist/WhitelistRolesWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/whitelist/WhitelistRolesWithAirnode.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./WhitelistRoles.sol";
 import "./interfaces/IWhitelistRolesWithAirnode.sol";

--- a/packages/airnode-protocol/contracts/whitelist/WhitelistRolesWithManager.sol
+++ b/packages/airnode-protocol/contracts/whitelist/WhitelistRolesWithManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./WhitelistRoles.sol";
 import "./interfaces/IWhitelistRolesWithManager.sol";

--- a/packages/airnode-protocol/contracts/whitelist/interfaces/IWhitelistRoles.sol
+++ b/packages/airnode-protocol/contracts/whitelist/interfaces/IWhitelistRoles.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 interface IWhitelistRoles {
     function adminRoleDescription() external view returns (string memory);

--- a/packages/airnode-protocol/contracts/whitelist/interfaces/IWhitelistRolesWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/whitelist/interfaces/IWhitelistRolesWithAirnode.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./IWhitelistRoles.sol";
 

--- a/packages/airnode-protocol/contracts/whitelist/interfaces/IWhitelistRolesWithManager.sol
+++ b/packages/airnode-protocol/contracts/whitelist/interfaces/IWhitelistRolesWithManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.9;
 
 import "./IWhitelistRoles.sol";
 

--- a/packages/airnode-protocol/hardhat.config.js
+++ b/packages/airnode-protocol/hardhat.config.js
@@ -45,6 +45,6 @@ module.exports = {
     tests: process.env.EXTENDED_TEST ? './extended-test' : './test',
   },
   solidity: {
-    version: '0.8.6',
+    version: '0.8.9',
   },
 };

--- a/packages/airnode-protocol/package.json
+++ b/packages/airnode-protocol/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "^4.2.0",
+    "@openzeppelin/contracts": "^4.3.2",
     "@typechain/ethers-v5": "^7.1.0",
     "chai": "^4.3.4",
     "copyfiles": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2557,10 +2557,10 @@
     "@opencensus/core" "^0.0.8"
     uuid "^3.2.1"
 
-"@openzeppelin/contracts@^4.2.0":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.1.tgz#c01f791ce6c9d3989ac1a643267501dbe336b9e3"
-  integrity sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw==
+"@openzeppelin/contracts@^4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
+  integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
 
 "@pm2/agent@~1.0.8":
   version "1.0.8"


### PR DESCRIPTION
I figured it would be a good idea to bump the OpenZeppelin contracts package version after Ashar pointed out that AccessControl.sol, but that seems to have happened in 4.4.0 which is not released yet. So this PR shouldn't really change anything.