### PR TITLE
Add lerna caching to CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.17.1'
+      - name: restore lerna
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install Dependencies
         run: yarn run bootstrap
       - name: Prepare config


### PR DESCRIPTION
The CI `yarn run bootstrap` step is taking ~60-90s each CI run. When the `yarn.lock` files aren’t modified in a PR, we can restore cached dependencies to avoid the install portion of this step and save the vast majority of that time. [Source](https://github.com/actions/cache/blob/main/examples.md#node---lerna).  

The restore key is based on key: `${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}` where `**` indicates any `yarn.lock` file in the repository. Consequently if any `yarn.lock` file changes there will be a cache miss and the install will run anew. 

Tested on my fork to restore the cache when there aren't `yarn.lock` changes, which speeds up this step quite a bit (10s restore + 4s `yarn run bootstrap`). Also tested to confirm a fresh install after a `yarn.lock` change.