### PR TITLE
PSP draft v4

### DIFF
--- a/packages/airnode-protocol/contracts/psp/AirnodePsp.sol
+++ b/packages/airnode-protocol/contracts/psp/AirnodePsp.sol
@@ -9,6 +9,7 @@ contract AirnodePsp {
 
     struct Subscription {
         bytes32 templateId;
+        address sponsor;
         address conditionAddress;
         bytes4 conditionFunctionId;
         address fulfillAddress;
@@ -26,6 +27,7 @@ contract AirnodePsp {
 
     function createSubscription(
         bytes32 templateId,
+        address sponsor,
         address conditionAddress,
         bytes4 conditionFunctionId,
         address fulfillAddress,
@@ -35,6 +37,7 @@ contract AirnodePsp {
         subscriptionId = keccak256(
             abi.encode(
                 templateId,
+                sponsor,
                 conditionAddress,
                 conditionFunctionId,
                 fulfillAddress,
@@ -44,6 +47,7 @@ contract AirnodePsp {
         );
         subscriptions[subscriptionId] = Subscription({
             templateId: templateId,
+            sponsor: sponsor,
             conditionAddress: conditionAddress,
             conditionFunctionId: conditionFunctionId,
             fulfillAddress: fulfillAddress,

--- a/packages/airnode-protocol/contracts/psp/AirnodePsp.sol
+++ b/packages/airnode-protocol/contracts/psp/AirnodePsp.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "../rrp/interfaces/IAirnodeRrp.sol";
+
+contract AirnodePsp {
+    using ECDSA for bytes32;
+
+    struct Subscription {
+        bytes32 templateId;
+        address conditionAddress;
+        bytes4 conditionFunctionId;
+        address fulfillAddress;
+        bytes4 fulfillFunctionId;
+        bytes parameters;
+    }
+
+    IAirnodeRrp public airnodeRrp;
+
+    mapping(bytes32 => Subscription) public subscriptions;
+
+    constructor(address airnodeRrp_) {
+        airnodeRrp = IAirnodeRrp(airnodeRrp_);
+    }
+
+    function createSubscription(
+        bytes32 templateId,
+        address conditionAddress,
+        bytes4 conditionFunctionId,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata parameters
+    ) external returns (bytes32 subscriptionId) {
+        subscriptionId = keccak256(
+            abi.encode(
+                templateId,
+                conditionAddress,
+                conditionFunctionId,
+                fulfillAddress,
+                fulfillFunctionId,
+                parameters
+            )
+        );
+        subscriptions[subscriptionId] = Subscription({
+            templateId: templateId,
+            conditionAddress: conditionAddress,
+            conditionFunctionId: conditionFunctionId,
+            fulfillAddress: fulfillAddress,
+            fulfillFunctionId: fulfillFunctionId,
+            parameters: parameters
+        });
+    }
+
+    function fulfill(
+        bytes32 subscriptionId,
+        bytes calldata data,
+        bytes calldata signature
+    ) external returns (bool callSuccess, bytes memory callData) {
+        Subscription storage subscription = subscriptions[subscriptionId];
+        (address airnode, , ) = airnodeRrp.templates(subscription.templateId);
+        require(
+            (
+                keccak256(abi.encodePacked(subscriptionId, data))
+                    .toEthSignedMessageHash()
+            ).recover(signature) == airnode,
+            "Invalid signature"
+        );
+        (callSuccess, callData) = subscription.fulfillAddress.call( // solhint-disable-line avoid-low-level-calls
+            abi.encodeWithSelector(
+                subscription.fulfillFunctionId,
+                subscriptionId,
+                data
+            )
+        );
+    }
+}

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
@@ -9,7 +9,6 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
     struct Slot {
         bytes32 subscriptionId;
         address setter;
-        address sponsor;
         uint64 expirationTimestamp;
     }
 
@@ -40,7 +39,6 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
         address airnode,
         uint256 slotIndex,
         bytes32 subscriptionId,
-        address sponsor,
         uint64 expirationTimestamp
     ) external {
         require(
@@ -49,7 +47,6 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
         );
         require(airnode != address(0), "Zero Airnode address");
         require(subscriptionId != bytes32(0), "Zero subscription ID");
-        require(sponsor != address(0), "Zero sponsor address");
         require(
             expirationTimestamp > block.timestamp,
             "Expiration is in the past"
@@ -58,7 +55,6 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
         airnodeToSlotIndexToSlot[airnode][slotIndex] = Slot({
             subscriptionId: subscriptionId,
             setter: msg.sender,
-            sponsor: sponsor,
             expirationTimestamp: expirationTimestamp
         });
     }

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../access-control-registry/interfaces/IAccessControlRegistry.sol";
+import "../access-control-registry/RoleDeriver.sol";
+import "../access-control-registry/AccessControlClient.sol";
+
+contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
+    struct Slot {
+        bytes32 subscriptionId;
+        address setter;
+        address sponsor;
+        uint64 expirationTimestamp;
+    }
+
+    string public adminRoleDescription;
+    bytes32 private adminRoleDescriptionHash;
+    string public constant SLOT_SETTER_ROLE_DESCRIPTION = "Slot setter";
+    bytes32 private constant SLOT_SETTER_ROLE_DESCRIPTION_HASH =
+        keccak256(abi.encodePacked(SLOT_SETTER_ROLE_DESCRIPTION));
+
+    mapping(address => mapping(uint256 => Slot))
+        public airnodeToSlotIndexToSlot;
+
+    constructor(
+        address _accessControlRegistry,
+        string memory _adminRoleDescription
+    ) AccessControlClient(_accessControlRegistry) {
+        require(
+            bytes(_adminRoleDescription).length > 0,
+            "Admin role description empty"
+        );
+        adminRoleDescription = _adminRoleDescription;
+        adminRoleDescriptionHash = keccak256(
+            abi.encodePacked(_adminRoleDescription)
+        );
+    }
+
+    function setSlot(
+        address airnode,
+        uint256 slotIndex,
+        bytes32 subscriptionId,
+        address sponsor,
+        uint64 expirationTimestamp
+    ) external {
+        require(
+            hasSlotSetterRoleOrIsAirnode(airnode, msg.sender),
+            "Not slot setter"
+        );
+        require(airnode != address(0), "Zero Airnode address");
+        require(subscriptionId != bytes32(0), "Zero subscription ID");
+        require(sponsor != address(0), "Zero sponsor address");
+        require(
+            expirationTimestamp > block.timestamp,
+            "Expiration is in the past"
+        );
+        require(slotIsOccuppied(airnode, slotIndex), "Slot occuppied");
+        airnodeToSlotIndexToSlot[airnode][slotIndex] = Slot({
+            subscriptionId: subscriptionId,
+            setter: msg.sender,
+            sponsor: sponsor,
+            expirationTimestamp: expirationTimestamp
+        });
+    }
+
+    function slotIsOccuppied(address airnode, uint256 slotIndex)
+        public
+        view
+        returns (bool)
+    {
+        Slot storage slot = airnodeToSlotIndexToSlot[airnode][slotIndex];
+        return
+            slot.expirationTimestamp < block.timestamp ||
+            !hasSlotSetterRoleOrIsAirnode(airnode, slot.setter);
+    }
+
+    function hasSlotSetterRoleOrIsAirnode(address airnode, address account)
+        public
+        view
+        returns (bool)
+    {
+        return
+            airnode == account ||
+            IAccessControlRegistry(accessControlRegistry).hasRole(
+                deriveSlotSetterRole(airnode),
+                account
+            );
+    }
+
+    function deriveSlotSetterRole(address airnode)
+        public
+        view
+        returns (bytes32 slotSetterRole)
+    {
+        slotSetterRole = _deriveRole(
+            _deriveRole(_deriveRootRole(airnode), adminRoleDescriptionHash),
+            SLOT_SETTER_ROLE_DESCRIPTION_HASH
+        );
+    }
+}

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
@@ -65,8 +65,9 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
 
     function vacateSlot(address airnode, uint256 slotIndex) external {
         require(
-            airnodeToSlotIndexToSlot[airnode][slotIndex].setter == msg.sender,
-            "Sender did not set the slot"
+            airnodeToSlotIndexToSlot[airnode][slotIndex].setter == msg.sender ||
+                !slotIsOccuppied(airnode, slotIndex),
+            "Slot not vacatable"
         );
         delete airnodeToSlotIndexToSlot[airnode][slotIndex];
     }

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithAirnode.sol
@@ -63,6 +63,14 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
         });
     }
 
+    function vacateSlot(address airnode, uint256 slotIndex) external {
+        require(
+            airnodeToSlotIndexToSlot[airnode][slotIndex].setter == msg.sender,
+            "Sender did not set the slot"
+        );
+        delete airnodeToSlotIndexToSlot[airnode][slotIndex];
+    }
+
     function slotIsOccuppied(address airnode, uint256 slotIndex)
         public
         view

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../access-control-registry/interfaces/IAccessControlRegistry.sol";
+import "../access-control-registry/RoleDeriver.sol";
+import "../access-control-registry/AccessControlClient.sol";
+
+contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
+    struct Slot {
+        bytes32 subscriptionId;
+        address setter;
+        address sponsor;
+        uint64 expirationTimestamp;
+    }
+
+    address public immutable manager;
+    string public adminRoleDescription;
+    bytes32 public immutable adminRole;
+    bytes32 public immutable slotSetterRole;
+
+    mapping(address => mapping(uint256 => Slot))
+        public airnodeToSlotIndexToSlot;
+
+    constructor(
+        address _accessControlRegistry,
+        string memory _adminRoleDescription,
+        address _manager
+    ) AccessControlClient(_accessControlRegistry) {
+        require(
+            bytes(_adminRoleDescription).length > 0,
+            "Admin role description empty"
+        );
+        adminRoleDescription = _adminRoleDescription;
+        manager = _manager;
+        adminRole = _deriveRole(
+            _deriveRootRole(_manager),
+            keccak256(abi.encodePacked(_adminRoleDescription))
+        );
+        slotSetterRole = _deriveRole(
+            adminRole,
+            keccak256(abi.encodePacked("Slot setter"))
+        );
+    }
+
+    function setSlot(
+        address airnode,
+        uint256 slotIndex,
+        bytes32 subscriptionId,
+        address sponsor,
+        uint64 expirationTimestamp
+    ) external {
+        require(hasSlotSetterRoleOrIsManager(msg.sender), "Not slot setter");
+        require(airnode != address(0), "Zero Airnode address");
+        require(subscriptionId != bytes32(0), "Zero subscription ID");
+        require(sponsor != address(0), "Zero sponsor address");
+        require(
+            expirationTimestamp > block.timestamp,
+            "Expiration is in the past"
+        );
+        require(slotIsOccuppied(airnode, slotIndex), "Slot occuppied");
+        airnodeToSlotIndexToSlot[airnode][slotIndex] = Slot({
+            subscriptionId: subscriptionId,
+            setter: msg.sender,
+            sponsor: sponsor,
+            expirationTimestamp: expirationTimestamp
+        });
+    }
+
+    function slotIsOccuppied(address airnode, uint256 slotIndex)
+        public
+        view
+        returns (bool)
+    {
+        Slot storage slot = airnodeToSlotIndexToSlot[airnode][slotIndex];
+        return
+            slot.expirationTimestamp < block.timestamp ||
+            !hasSlotSetterRoleOrIsManager(slot.setter);
+    }
+
+    function hasSlotSetterRoleOrIsManager(address account)
+        public
+        view
+        returns (bool)
+    {
+        return
+            manager == account ||
+            IAccessControlRegistry(accessControlRegistry).hasRole(
+                slotSetterRole,
+                account
+            );
+    }
+}

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
@@ -68,8 +68,9 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
 
     function vacateSlot(address airnode, uint256 slotIndex) external {
         require(
-            airnodeToSlotIndexToSlot[airnode][slotIndex].setter == msg.sender,
-            "Sender did not set the slot"
+            airnodeToSlotIndexToSlot[airnode][slotIndex].setter == msg.sender ||
+                !slotIsOccuppied(airnode, slotIndex),
+            "Slot not vacatable"
         );
         delete airnodeToSlotIndexToSlot[airnode][slotIndex];
     }

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
@@ -66,6 +66,14 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
         });
     }
 
+    function vacateSlot(address airnode, uint256 slotIndex) external {
+        require(
+            airnodeToSlotIndexToSlot[airnode][slotIndex].setter == msg.sender,
+            "Sender did not set the slot"
+        );
+        delete airnodeToSlotIndexToSlot[airnode][slotIndex];
+    }
+
     function slotIsOccuppied(address airnode, uint256 slotIndex)
         public
         view

--- a/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
+++ b/packages/airnode-protocol/contracts/psp/AllocatorWithManager.sol
@@ -9,7 +9,6 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
     struct Slot {
         bytes32 subscriptionId;
         address setter;
-        address sponsor;
         uint64 expirationTimestamp;
     }
 
@@ -46,13 +45,11 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
         address airnode,
         uint256 slotIndex,
         bytes32 subscriptionId,
-        address sponsor,
         uint64 expirationTimestamp
     ) external {
         require(hasSlotSetterRoleOrIsManager(msg.sender), "Not slot setter");
         require(airnode != address(0), "Zero Airnode address");
         require(subscriptionId != bytes32(0), "Zero subscription ID");
-        require(sponsor != address(0), "Zero sponsor address");
         require(
             expirationTimestamp > block.timestamp,
             "Expiration is in the past"
@@ -61,7 +58,6 @@ contract AllocatorWithAirnode is AccessControlClient, RoleDeriver {
         airnodeToSlotIndexToSlot[airnode][slotIndex] = Slot({
             subscriptionId: subscriptionId,
             setter: msg.sender,
-            sponsor: sponsor,
             expirationTimestamp: expirationTimestamp
         });
     }

--- a/packages/airnode-protocol/contracts/psp/BeaconServer.sol
+++ b/packages/airnode-protocol/contracts/psp/BeaconServer.sol
@@ -346,6 +346,7 @@ contract BeaconServer is
                 : beacon.value - decodedData
         );
         uint256 absoluteBeaconValue = uint256(int256(beacon.value));
+        absoluteBeaconValue = absoluteBeaconValue == 0 ? 1 : absoluteBeaconValue;
         return
             (10**18 * absoluteDelta) / absoluteBeaconValue >
             subscriptionIdToUpdatePercentageThreshold[subscriptionId];

--- a/packages/airnode-protocol/contracts/psp/BeaconServer.sol
+++ b/packages/airnode-protocol/contracts/psp/BeaconServer.sol
@@ -242,17 +242,20 @@ contract BeaconServer is
         bytes32 templateId = requestIdToTemplateId[requestId];
         require(templateId != bytes32(0), "No such request made");
         delete requestIdToTemplateId[requestId];
-        (int256 decodedData, uint256 timestamp) = abi.decode(data, (int256, uint256));
+        (int256 decodedData, uint256 timestamp) = abi.decode(
+            data,
+            (int256, uint256)
+        );
         require(
             decodedData >= type(int224).min && decodedData <= type(int224).max,
             "Value typecasting error"
         );
-        require(
-            timestamp <= type(uint32).max,
-            "Timestamp typecasting error"
-        );
+        require(timestamp <= type(uint32).max, "Timestamp typecasting error");
         require(block.timestamp - 1 hours < timestamp, "Fulfillment stale");
-        require(templateIdToBeacon[templateId].timestamp < timestamp, "Fulfillment older than beacon");
+        require(
+            templateIdToBeacon[templateId].timestamp < timestamp,
+            "Fulfillment older than beacon"
+        );
         templateIdToBeacon[templateId] = Beacon({
             value: int224(decodedData),
             timestamp: uint32(timestamp)

--- a/packages/airnode-protocol/contracts/psp/BeaconServer.sol
+++ b/packages/airnode-protocol/contracts/psp/BeaconServer.sol
@@ -279,8 +279,6 @@ contract BeaconServer is
 
     function fulfillPsp(bytes32 subscriptionId, bytes calldata data) external {
         require(msg.sender == airnodePsp, "Sender not AirnodePsp");
-        // require(condition(data), "Condition not met");
-
         (bytes32 templateId, , , , , , bytes memory parameters) = IAirnodePsp(
             airnodePsp
         ).subscriptions(subscriptionId);

--- a/packages/airnode-protocol/contracts/psp/BeaconServer.sol
+++ b/packages/airnode-protocol/contracts/psp/BeaconServer.sol
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../whitelist/Whitelist.sol";
+import "../whitelist/WhitelistRolesWithManager.sol";
+import "../rrp/requesters/RrpRequester.sol";
+import "../rrp/requesters/interfaces/IRrpBeaconServer.sol";
+
+/// @title The contract that serves beacons using Airnode RRP
+/// @notice A beacon is a live data point associated with a template ID. This
+/// is suitable where the more recent data point is always more favorable,
+/// e.g., in the context of an asset price data feed. Another definition of
+/// beacons are one-Airnode data feeds that can be used individually or
+/// combined to build decentralized data feeds.
+/// @dev This contract casts the reported data point to `int224`. If this is
+/// a problem (because the reported data may not fit into 224 bits or it is of
+/// a completely different type such as `bytes32`), do not use this contract
+/// and implement a customized version instead.
+/// The contract casts the timestamps to `uint32`, which means it will not work
+/// work past-2106 in the current form. If this is an issue, consider casting
+/// the timestamps to a larger type.
+contract BeaconServer is
+    Whitelist,
+    WhitelistRolesWithManager,
+    RrpRequester,
+    IRrpBeaconServer
+{
+    struct Beacon {
+        int224 value;
+        uint32 timestamp;
+    }
+
+    /// @notice Returns if a sponsor has permitted an account to request
+    /// updates at this contract
+    mapping(address => mapping(address => bool))
+        public
+        override sponsorToUpdateRequesterToPermissionStatus;
+
+    mapping(bytes32 => Beacon) private templateIdToBeacon;
+    mapping(bytes32 => bytes32) private requestIdToTemplateId;
+
+    /// @dev Reverts if the template with the ID is not created
+    /// @param templateId Template ID
+    modifier onlyIfTemplateExists(bytes32 templateId) {
+        (address airnode, , ) = airnodeRrp.templates(templateId);
+        require(airnode != address(0), "Template does not exist");
+        _;
+    }
+
+    /// @param _accessControlRegistry AccessControlRegistry contract address
+    /// @param _adminRoleDescription Admin role description
+    /// @param _manager Manager address
+    /// @param _airnodeRrp Airnode RRP contract address
+    constructor(
+        address _accessControlRegistry,
+        string memory _adminRoleDescription,
+        address _manager,
+        address _airnodeRrp
+    )
+        WhitelistRolesWithManager(
+            _accessControlRegistry,
+            _adminRoleDescription,
+            _manager
+        )
+        RrpRequester(_airnodeRrp)
+    {}
+
+    /// @notice Extends the expiration of the temporary whitelist of `reader`
+    /// to be able to read the beacon with `templateId` if the sender has the
+    /// whitelist expiration extender role
+    /// @param templateId Template ID
+    /// @param reader Reader address
+    /// @param expirationTimestamp Timestamp at which the temporary whitelist
+    /// will expire
+    function extendWhitelistExpiration(
+        bytes32 templateId,
+        address reader,
+        uint64 expirationTimestamp
+    ) external override {
+        require(
+            hasWhitelistExpirationExtenderRoleOrIsManager(msg.sender),
+            "Not expiration extender"
+        );
+        _extendWhitelistExpiration(templateId, reader, expirationTimestamp);
+        emit ExtendedWhitelistExpiration(
+            templateId,
+            reader,
+            msg.sender,
+            expirationTimestamp
+        );
+    }
+
+    /// @notice Sets the expiration of the temporary whitelist of `reader` to
+    /// be able to read the beacon with `templateId` if the sender has the
+    /// whitelist expiration setter role
+    /// @param templateId Template ID
+    /// @param reader Reader address
+    /// @param expirationTimestamp Timestamp at which the temporary whitelist
+    /// will expire
+    function setWhitelistExpiration(
+        bytes32 templateId,
+        address reader,
+        uint64 expirationTimestamp
+    ) external override {
+        require(
+            hasWhitelistExpirationSetterRoleOrIsManager(msg.sender),
+            "Not expiration setter"
+        );
+        _setWhitelistExpiration(templateId, reader, expirationTimestamp);
+        emit SetWhitelistExpiration(
+            templateId,
+            reader,
+            msg.sender,
+            expirationTimestamp
+        );
+    }
+
+    /// @notice Sets the indefinite whitelist status of `reader` to be able to
+    /// read the beacon with `templateId` if the sender has the indefinite
+    /// whitelister role
+    /// @param templateId Template ID
+    /// @param reader Reader address
+    /// @param status Indefinite whitelist status
+    function setIndefiniteWhitelistStatus(
+        bytes32 templateId,
+        address reader,
+        bool status
+    ) external override {
+        require(
+            hasIndefiniteWhitelisterRoleOrIsManager(msg.sender),
+            "Not indefinite whitelister"
+        );
+        uint192 indefiniteWhitelistCount = _setIndefiniteWhitelistStatus(
+            templateId,
+            reader,
+            status
+        );
+        emit SetIndefiniteWhitelistStatus(
+            templateId,
+            reader,
+            msg.sender,
+            status,
+            indefiniteWhitelistCount
+        );
+    }
+
+    /// @notice Revokes the indefinite whitelist status granted by a specific
+    /// account that no longer has the indefinite whitelister role
+    /// @param templateId Template ID
+    /// @param reader Reader address
+    /// @param setter Setter of the indefinite whitelist status
+    function revokeIndefiniteWhitelistStatus(
+        bytes32 templateId,
+        address reader,
+        address setter
+    ) external override {
+        require(
+            !hasIndefiniteWhitelisterRoleOrIsManager(setter),
+            "setter is indefinite whitelister"
+        );
+        (
+            bool revoked,
+            uint192 indefiniteWhitelistCount
+        ) = _revokeIndefiniteWhitelistStatus(templateId, reader, setter);
+        if (revoked) {
+            emit RevokedIndefiniteWhitelistStatus(
+                templateId,
+                reader,
+                setter,
+                msg.sender,
+                indefiniteWhitelistCount
+            );
+        }
+    }
+
+    /// @notice Called by the sponsor to set the update request permission
+    /// status of an account
+    /// @param updateRequester Update requester address
+    /// @param status Update permission status of the update requester
+    function setUpdatePermissionStatus(address updateRequester, bool status)
+        external
+        override
+    {
+        require(updateRequester != address(0), "Update requester zero");
+        sponsorToUpdateRequesterToPermissionStatus[msg.sender][
+            updateRequester
+        ] = status;
+        emit SetUpdatePermissionStatus(msg.sender, updateRequester, status);
+    }
+
+    /// @notice Called to request a beacon to be updated
+    /// @dev There are two requirements for this method to be called: (1) The
+    /// sponsor must call `setSponsorshipStatus()` of AirnodeRrp to sponsor
+    /// this RrpBeaconServer contract, (2) The sponsor must call
+    /// `setUpdatePermissionStatus()` of this RrpBeaconServer contract to give
+    /// request update permission to the caller of this method.
+    /// The template used here must specify a single point of data of type
+    /// `int256` to be returned because this is what `fulfill()` expects.
+    /// This point of data must be castable to `int224`.
+    /// @param templateId Template ID of the beacon to be updated
+    /// @param sponsor Sponsor whose wallet will be used to fulfill this
+    /// request
+    /// @param sponsorWallet Sponsor wallet that will be used to fulfill this
+    /// request
+    function requestBeaconUpdate(
+        bytes32 templateId,
+        address sponsor,
+        address sponsorWallet
+    ) external override {
+        require(
+            sponsorToUpdateRequesterToPermissionStatus[sponsor][msg.sender],
+            "Caller not permitted"
+        );
+        bytes32 requestId = airnodeRrp.makeTemplateRequest(
+            templateId,
+            sponsor,
+            sponsorWallet,
+            address(this),
+            this.fulfill.selector,
+            ""
+        );
+        requestIdToTemplateId[requestId] = templateId;
+        emit RequestedBeaconUpdate(
+            templateId,
+            sponsor,
+            msg.sender,
+            requestId,
+            sponsorWallet
+        );
+    }
+
+    /// @notice Called by AirnodeRrp to fulfill the request
+    /// @dev It is assumed that the fulfillment will be made with a single
+    /// point of data of type `int256`
+    /// @param requestId ID of the request being fulfilled
+    /// @param data Fulfillment data (a single `int256` encoded as `bytes`)
+    function fulfill(bytes32 requestId, bytes calldata data)
+        external
+        override
+        onlyAirnodeRrp
+    {
+        bytes32 templateId = requestIdToTemplateId[requestId];
+        require(templateId != bytes32(0), "No such request made");
+        delete requestIdToTemplateId[requestId];
+        int256 decodedData = abi.decode(data, (int256));
+        require(
+            decodedData >= type(int224).min && decodedData <= type(int224).max,
+            "Value typecasting error"
+        );
+        require(
+            block.timestamp <= type(uint32).max,
+            "Timestamp typecasting error"
+        );
+        templateIdToBeacon[templateId] = Beacon({
+            value: int224(decodedData),
+            timestamp: uint32(block.timestamp)
+        });
+        emit UpdatedBeacon(
+            templateId,
+            requestId,
+            int224(decodedData),
+            uint32(block.timestamp)
+        );
+    }
+
+    /// @notice Called to read the beacon
+    /// @dev The caller must be whitelisted.
+    /// If the `timestamp` of a beacon is zero, this means that it was never
+    /// written to before, and the zero value in the `value` field is not
+    /// valid. In general, make sure to check if the timestamp of the beacon is
+    /// fresh enough, and definitely disregard beacons with zero `timestamp`.
+    /// @param templateId Template ID of the beacon that will be returned
+    /// @return value Beacon value
+    /// @return timestamp Beacon timestamp
+    function readBeacon(bytes32 templateId)
+        external
+        view
+        override
+        returns (int224 value, uint32 timestamp)
+    {
+        require(
+            readerCanReadBeacon(templateId, msg.sender),
+            "Caller not whitelisted"
+        );
+        Beacon storage beacon = templateIdToBeacon[templateId];
+        return (beacon.value, beacon.timestamp);
+    }
+
+    /// @notice Called to check if a reader is whitelisted to read the beacon
+    /// @param templateId Template ID
+    /// @param reader Reader address
+    /// @return isWhitelisted If the reader is whitelisted
+    function readerCanReadBeacon(bytes32 templateId, address reader)
+        public
+        view
+        override
+        onlyIfTemplateExists(templateId)
+        returns (bool)
+    {
+        return userIsWhitelisted(templateId, reader);
+    }
+
+    /// @notice Called to get the detailed whitelist status of the reader for
+    /// the beacon
+    /// @param templateId Template ID
+    /// @param reader Reader address
+    /// @return expirationTimestamp Timestamp at which the whitelisting of the
+    /// reader will expire
+    /// @return indefiniteWhitelistCount Number of times `reader` was
+    /// whitelisted indefinitely for `templateId`
+    function templateIdToReaderToWhitelistStatus(
+        bytes32 templateId,
+        address reader
+    )
+        external
+        view
+        override
+        onlyIfTemplateExists(templateId)
+        returns (uint64 expirationTimestamp, uint192 indefiniteWhitelistCount)
+    {
+        WhitelistStatus
+            storage whitelistStatus = serviceIdToUserToWhitelistStatus[
+                templateId
+            ][reader];
+        expirationTimestamp = whitelistStatus.expirationTimestamp;
+        indefiniteWhitelistCount = whitelistStatus.indefiniteWhitelistCount;
+    }
+
+    /// @notice Returns if an account has indefinitely whitelisted the reader
+    /// for the beacon
+    /// @param templateId Template ID
+    /// @param reader Reader address
+    /// @param setter Address of the account that has potentially whitelisted
+    /// the reader for the beacon indefinitely
+    /// @return indefiniteWhitelistStatus If `setter` has indefinitely
+    /// whitelisted reader for the beacon
+    function templateIdToReaderToSetterToIndefiniteWhitelistStatus(
+        bytes32 templateId,
+        address reader,
+        address setter
+    ) external view override returns (bool indefiniteWhitelistStatus) {
+        indefiniteWhitelistStatus = serviceIdToUserToSetterToIndefiniteWhitelistStatus[
+            templateId
+        ][reader][setter];
+    }
+}

--- a/packages/airnode-protocol/contracts/psp/BeaconServer.sol
+++ b/packages/airnode-protocol/contracts/psp/BeaconServer.sol
@@ -5,6 +5,7 @@ import "../whitelist/Whitelist.sol";
 import "../whitelist/WhitelistRolesWithManager.sol";
 import "../rrp/requesters/RrpRequester.sol";
 import "../rrp/requesters/interfaces/IRrpBeaconServer.sol";
+import "./IAirnodePsp.sol";
 
 /// @title The contract that serves beacons using Airnode RRP
 /// @notice A beacon is a live data point associated with a template ID. This
@@ -29,6 +30,8 @@ contract BeaconServer is
         int224 value;
         uint32 timestamp;
     }
+
+    address public immutable airnodePsp;
 
     /// @notice Returns if a sponsor has permitted an account to request
     /// updates at this contract
@@ -55,7 +58,8 @@ contract BeaconServer is
         address _accessControlRegistry,
         string memory _adminRoleDescription,
         address _manager,
-        address _airnodeRrp
+        address _airnodeRrp,
+        address _airnodePsp
     )
         WhitelistRolesWithManager(
             _accessControlRegistry,
@@ -63,7 +67,9 @@ contract BeaconServer is
             _manager
         )
         RrpRequester(_airnodeRrp)
-    {}
+    {
+        airnodePsp = _airnodePsp;
+    }
 
     /// @notice Extends the expiration of the temporary whitelist of `reader`
     /// to be able to read the beacon with `templateId` if the sender has the

--- a/packages/airnode-protocol/contracts/psp/BeaconServer.sol
+++ b/packages/airnode-protocol/contracts/psp/BeaconServer.sol
@@ -278,7 +278,7 @@ contract BeaconServer is
         require(msg.sender == airnodePsp, "Sender not AirnodePsp");
         // require(condition(data), "Condition not met");
 
-        (bytes32 templateId, , , , , bytes memory parameters) = IAirnodePsp(
+        (bytes32 templateId, , , , , , bytes memory parameters) = IAirnodePsp(
             airnodePsp
         ).subscriptions(subscriptionId);
         require(parameters.length == 0, "Subscription has parameters");

--- a/packages/airnode-protocol/contracts/psp/ExampleConditionAndFulfillContract.sol
+++ b/packages/airnode-protocol/contracts/psp/ExampleConditionAndFulfillContract.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.9;
 contract ExampleConditionAndFulfillContract {
     uint256 public constant FOO = 10;
 
-    function condition(bytes calldata data)
+    function condition(bytes32 subscriptionId, bytes calldata data)
         public
         view
         returns (bool checkResult)
@@ -14,7 +14,7 @@ contract ExampleConditionAndFulfillContract {
     }
 
     function fulfill(bytes32 subscriptionId, bytes calldata data) external {
-        require(condition(data), "Condition not met");
+        require(condition(subscriptionId, data), "Condition not met");
 
         // Check if you know about the subscription first
         // require(subscriptionId == ...)

--- a/packages/airnode-protocol/contracts/psp/ExampleConditionAndFulfillContract.sol
+++ b/packages/airnode-protocol/contracts/psp/ExampleConditionAndFulfillContract.sol
@@ -16,6 +16,13 @@ contract ExampleConditionAndFulfillContract {
     function fulfill(bytes32 subscriptionId, bytes calldata data) external {
         require(condition(data), "Condition not met");
 
+        // Check if you know about the subscription first
+        // require(subscriptionId == ...)
+        // Instead, you can also just check if the template ID/parameters is correct (e.g. for a common BeaconServer for RRP+PSP)
+        // (bytes32 templateId, , , , , bytes parameters) = airnodePsp.subscriptions(subscriptionId);
+        // require(templateId == ...);
+        // require(parameters.length == 0); // No additional parameters
+
         (uint256 response, uint256 timestamp) = abi.decode(
             data,
             (uint256, uint256)

--- a/packages/airnode-protocol/contracts/psp/ExampleConditionAndFulfillContract.sol
+++ b/packages/airnode-protocol/contracts/psp/ExampleConditionAndFulfillContract.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+contract ExampleConditionAndFulfillContract {
+    uint256 public constant FOO = 10;
+
+    function condition(bytes calldata data)
+        public
+        view
+        returns (bool checkResult)
+    {
+        (uint256 response, ) = abi.decode(data, (uint256, uint256));
+        checkResult = response > FOO;
+    }
+
+    function fulfill(bytes32 subscriptionId, bytes calldata data) external {
+        require(condition(data), "Condition not met");
+
+        (uint256 response, uint256 timestamp) = abi.decode(
+            data,
+            (uint256, uint256)
+        );
+
+        require(timestamp + 1000 < block.timestamp, "Fulfillment stale");
+
+        // ...then do whatever you want with the API response
+    }
+}

--- a/packages/airnode-protocol/contracts/psp/IAirnodePsp.sol
+++ b/packages/airnode-protocol/contracts/psp/IAirnodePsp.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+interface IAirnodePsp {
+    function subscriptions(bytes32 subscriptionId)
+        external
+        view
+        returns (
+            bytes32 templateId,
+            address conditionAddress,
+            bytes4 conditionFunctionId,
+            address fulfillAddress,
+            bytes4 fulfillFunctionId,
+            bytes memory parameters
+        );
+}

--- a/packages/airnode-protocol/contracts/psp/IAirnodePsp.sol
+++ b/packages/airnode-protocol/contracts/psp/IAirnodePsp.sol
@@ -7,6 +7,7 @@ interface IAirnodePsp {
         view
         returns (
             bytes32 templateId,
+            address sponsor,
             address conditionAddress,
             bytes4 conditionFunctionId,
             address fulfillAddress,


### PR DESCRIPTION
This mirrors the authorizer patterns and pushes the complexity to its client contracts. One potential downside is that assume the node reserved 5 slots to an allocator, which has two client contracts (or two multisigs, whatever). One of these is allowed to use up all 5 slots, leaving none for the other. The only way to reverse this is to take away its slot setter role. So the slot setters are expected to "play nice", limit the number of slots they set, etc. Someone trying to set a slot and failing is preferable over someone losing service, so this is alright imo.