### PR TITLE
Add retryOn429 for CI doc link checking

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@master
       - name: Check hyperlinks
         uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: .github/workflows/mlc_config.json
       - name: Slack Notification
         uses: lazy-actions/slatify@master
         env:

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,5 @@
+{
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "10s"
+}


### PR DESCRIPTION
The Continuous Build workflow fails somewhat frequently because of 429 "Too Many Requests" errors returned when checking many github.com links. This PR adds a retry with delay. 