### PR TITLE
AN-333: Fix endpoint ID derivation implementation

### DIFF
--- a/packages/airnode-deployer/config/config.json.example
+++ b/packages/airnode-deployer/config/config.json.example
@@ -36,7 +36,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153",
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }

--- a/packages/airnode-examples/README.md
+++ b/packages/airnode-examples/README.md
@@ -112,7 +112,7 @@ yarn create-airnode-secrets
 
 > If you are not using docker for linux and you want to connect to your local hardhat network, you will need to modify
 > the generated `secrets.env` file found in `integrations/<integration-name>/` by replacing the provider URL with the
-> following: `PROVIDER_URL=http://host.docker.internal:8545`. This is a docker limitaton. See:
+> following: `PROVIDER_URL=http://host.docker.internal:8545`. This is a docker limitation. See:
 > https://stackoverflow.com/a/24326540
 
 Refer to the

--- a/packages/airnode-examples/integrations/coingecko-testable/README.md
+++ b/packages/airnode-examples/integrations/coingecko-testable/README.md
@@ -25,5 +25,5 @@ Before making the request, you need to replace the example values:
 The correct command may look like this:
 
 ```sh
-curl -X POST -H 'x-api-key: 05701bc4-4eb4-4f60-b4eb-075c80ea98c6' -d '{"parameters": {"coinId": "bitcoin"}}' 'https://x9sidy9ln0.execute-api.us-east-1.amazonaws.com/v1/test/0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c'
+curl -X POST -H 'x-api-key: 05701bc4-4eb4-4f60-b4eb-075c80ea98c6' -d '{"parameters": {"coinId": "bitcoin"}}' 'https://x9sidy9ln0.execute-api.us-east-1.amazonaws.com/v1/test/0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153'
 ```

--- a/packages/airnode-examples/integrations/coingecko-testable/config.json
+++ b/packages/airnode-examples/integrations/coingecko-testable/config.json
@@ -33,7 +33,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153",
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }

--- a/packages/airnode-examples/integrations/coingecko/config.json
+++ b/packages/airnode-examples/integrations/coingecko/config.json
@@ -32,7 +32,7 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153",
         "oisTitle": "CoinGecko basic request",
         "endpointName": "coinMarketData"
       }

--- a/packages/airnode-validator/test/validatorTests/endpoints.json
+++ b/packages/airnode-validator/test/validatorTests/endpoints.json
@@ -223,22 +223,22 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x49d5f00e6bd2ebbf59c57c1e02255cbed121d7c5be5bccee92a8b1d3b8f03853",
         "oisTitle": "myOisTitle",
         "endpointName": "endpt1"
       },
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x6f1c150246d8934c04d6ef1ce940b530689b8449cc8e6924a11fa7776784db35",
         "oisTitle": "myOisTitle",
         "endpointName": "endpt2"
       },
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xd5786a182805c9d2db287fbd8e3b9f2689ae5cb3058a9063577e9cbbff01c829",
         "oisTitle": "anotherOis",
         "endpointName": "endpt3"
       },
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0x9c7441258622ce228c1fed4e3bb26fc782b3a990a6ad794c1d6975c3162bcb76",
         "oisTitle": "myOisTitle",
         "endpointName": "endpt4"
       }

--- a/packages/airnode-validator/test/validatorTests/multipleOIS.json
+++ b/packages/airnode-validator/test/validatorTests/multipleOIS.json
@@ -165,17 +165,17 @@
   "triggers": {
     "rrp": [
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xa77603cbb5a573fb4a238f8eb8d2a39a56225a3a08a0c9e4d53e9b8eb750802e",
         "oisTitle": "ois2",
         "endpointName": "endpt1"
       },
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xe012277a23715fc8efa5552dae9bf52f642b88d3f014657bd36cb1ee07757981",
         "oisTitle": "ois3",
         "endpointName": "endpt1"
       },
       {
-        "endpointId": "0xf466b8feec41e9e50815e0c9dca4db1ff959637e564bb13fefa99e9f9f90453c",
+        "endpointId": "0xf5e5dbb51e72bc054caa5c0f9e490d7477e73b8f965d483ddbe2d9b0b078c802",
         "oisTitle": "ois2",
         "endpointName": "endpt2"
       }


### PR DESCRIPTION
Updates `endpointId` in airnode examples and other places where it was hardcoded with an invalid hash value