### PR TITLE
A3P-39: switch readonly variables from storage to memory

### DIFF
--- a/packages/airnode-protocol/contracts/rrp/authorizers/admin/AirnodeTokenPayment.sol
+++ b/packages/airnode-protocol/contracts/rrp/authorizers/admin/AirnodeTokenPayment.sol
@@ -294,8 +294,9 @@ contract AirnodeTokenPayment is
         view
         returns (uint64 maximumWhitelistDuration)
     {
-        WhitelistDuration
-            storage whitelistDuration = airnodeToWhitelistDuration[_airnode];
+        WhitelistDuration memory whitelistDuration = airnodeToWhitelistDuration[
+            _airnode
+        ];
         maximumWhitelistDuration = whitelistDuration.maximum != 0
             ? whitelistDuration.maximum
             : DEFAULT_MAXIMUM_WHITELIST_DURATION;
@@ -310,8 +311,9 @@ contract AirnodeTokenPayment is
         view
         returns (uint64 minimumWhitelistDuration)
     {
-        WhitelistDuration
-            storage whitelistDuration = airnodeToWhitelistDuration[_airnode];
+        WhitelistDuration memory whitelistDuration = airnodeToWhitelistDuration[
+            _airnode
+        ];
         minimumWhitelistDuration = whitelistDuration.minimum != 0
             ? whitelistDuration.minimum
             : DEFAULT_MINIMUM_WHITELIST_DURATION;


### PR DESCRIPTION
Realized that I was using storage instead of memory for local vars on those getter functions that I created just to avoid the "stack to deep" error in AirnodeTokenPayment.sol