### PR TITLE
[PoC]: Update make request file to allow sending multiple requests at once

### DIFF
--- a/packages/airnode-examples/scripts/make-request.ts
+++ b/packages/airnode-examples/scripts/make-request.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
-import { deriveAirnodeXpub, deriveSponsorWalletAddress } from '@api3/airnode-admin';
+import { deriveAirnodeXpub, deriveSponsorWalletAddress, getAirnodeRrp, sponsorRequester } from '@api3/airnode-admin';
+import range from 'lodash/range';
 import {
   getDeployedContract,
   getProvider,
@@ -16,55 +17,94 @@ const fulfilled = async (requestId: string) => {
   return new Promise((resolve) => provider.once(airnodeRrp.filters.FulfilledRequest(null, requestId), resolve));
 };
 
-export const makeRequest = async (): Promise<string> => {
+export const makeRequests = async (): Promise<string[]> => {
   const integrationInfo = readIntegrationInfo();
   const requester = await getDeployedContract(`contracts/${integrationInfo.integration}/Requester.sol`);
   const airnodeRrp = await getDeployedContract('@api3/airnode-protocol/contracts/rrp/AirnodeRrp.sol');
   const airnodeWallet = getAirnodeWallet();
-  const sponsor = ethers.Wallet.fromMnemonic(integrationInfo.mnemonic);
-  // NOTE: The request is always made to the first endpoint listed in the "triggers.rrp" inside config.json
-  const endpointId = readConfig().triggers.rrp[0].endpointId;
-  // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' from the admin CLI package
-  const sponsorWalletAddress = await deriveSponsorWalletAddress(
-    // NOTE: When doing this manually, you can use the 'derive-airnode-xpub' from the admin CLI package
-    deriveAirnodeXpub(airnodeWallet.mnemonic.phrase),
-    airnodeWallet.address,
-    sponsor.address
-  );
+  const provider = getProvider();
+  const masterSponsor = ethers.Wallet.fromMnemonic(integrationInfo.mnemonic).connect(provider);
 
-  // Import the function to get encoded parameters for the Airnode. See the respective "request-utils.ts" for details.
-  const { getEncodedParameters } = await import(`../integrations/${integrationInfo.integration}/request-utils.ts`);
-  // Trigger the Airnode request
+  const REQUEST_COUNT = 20;
+  const USE_SAME_SPONSOR = true;
 
-  const receipt = await requester.makeRequest(
-    airnodeWallet.address,
-    endpointId,
-    sponsor.address,
-    sponsorWalletAddress,
-    await getEncodedParameters()
-  );
+  const sponsors = range(REQUEST_COUNT).map(() => (USE_SAME_SPONSOR ? masterSponsor : ethers.Wallet.createRandom()));
+  const ids: string[] = [];
+  for (const sponsor of sponsors) {
+    // NOTE: The request is always made to the first endpoint listed in the "triggers.rrp" inside config.json
+    const endpointId = readConfig().triggers.rrp[0].endpointId;
+    // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' from the admin CLI package
+    const sponsorWalletAddress = await deriveSponsorWalletAddress(
+      // NOTE: When doing this manually, you can use the 'derive-airnode-xpub' from the admin CLI package
+      deriveAirnodeXpub(airnodeWallet.mnemonic.phrase),
+      airnodeWallet.address,
+      sponsor.address
+    );
 
-  // Wait until the transaction is mined
-  return new Promise((resolve) =>
-    getProvider().once(receipt.hash, (tx) => {
-      const parsedLog = airnodeRrp.interface.parseLog(tx.logs[0]);
-      resolve(parsedLog.args.requestId);
-    })
-  );
+    // Fund the sponsor wallet
+    const tx1 = await masterSponsor.sendTransaction({
+      to: sponsorWalletAddress,
+      value: ethers.utils.parseEther('0.1'),
+    });
+    await tx1.wait();
+
+    // Fund the sponsor
+    const tx2 = await masterSponsor.sendTransaction({ to: sponsor.address, value: ethers.utils.parseEther('0.1') });
+    await tx2.wait();
+
+    // Sponsor the requester
+    await sponsorRequester(
+      await getAirnodeRrp(readIntegrationInfo().providerUrl, {
+        airnodeRrpAddress: airnodeRrp.address,
+        signer: { mnemonic: sponsor.mnemonic.phrase },
+      }),
+      requester.address
+    );
+
+    // Import the function to get encoded parameters for the Airnode. See the respective "request-utils.ts" for details.
+    const { getEncodedParameters } = await import(`../integrations/${integrationInfo.integration}/request-utils.ts`);
+
+    // Trigger the Airnode request
+    console.log(`Making a request to sponsor wallet: `, sponsorWalletAddress);
+    const receipt = await requester.makeRequest(
+      airnodeWallet.address,
+      endpointId,
+      sponsor.address,
+      sponsorWalletAddress,
+      await getEncodedParameters()
+    );
+
+    // Wait until the transaction is mined
+    ids.push(
+      await new Promise<string>((resolve) =>
+        getProvider().once(receipt.hash, (tx) => {
+          const parsedLog = airnodeRrp.interface.parseLog(tx.logs[0]);
+          resolve(parsedLog.args.requestId);
+        })
+      )
+    );
+  }
+
+  return ids;
 };
 
 const main = async () => {
-  cliPrint.info('Making request...');
-  const requestId = await makeRequest();
-  cliPrint.info('Waiting for fulfillment...');
-  await fulfilled(requestId);
-  cliPrint.info('Request fulfilled');
+  cliPrint.info('Making requests...');
+  const requestIds = await makeRequests();
+  cliPrint.info('Waiting for fulfillments...');
 
-  const integrationInfo = readIntegrationInfo();
-  // Import the function to print the response from the chosen integration. See the respective "request-utils.ts" for
-  // details.
-  const { printResponse } = await import(`../integrations/${integrationInfo.integration}/request-utils.ts`);
-  await printResponse(requestId);
+  const promises = requestIds.map(async (requestId) => {
+    await fulfilled(requestId);
+    cliPrint.info('Requests fulfilled');
+
+    const integrationInfo = readIntegrationInfo();
+    // Import the function to print the response from the chosen integration. See the respective "request-utils.ts" for
+    // details.
+    const { printResponse } = await import(`../integrations/${integrationInfo.integration}/request-utils.ts`);
+    await printResponse(requestId);
+  });
+
+  await Promise.all(promises);
 };
 
 runAndHandleErrors(main);


### PR DESCRIPTION
## Intro

I've tried running Airnode locally and modified the `make-request.ts` from the examples package to send multiple requests at once with two versions:

- Same sponsor
- Different sponsor

The results were the same, because hardhat is super fast. So I've implemented https://github.com/Siegrift/hardhat-fastify-gateway to slow it down for certain calls (`eth_call` is the one made by Airnode to fulfilll the transaction). The results showed that Airnode behaves correctly - requests from same sponsor are made sequentially, while from different sponsors in parallel.

## How to run

Follow the steps in `airnode-examples` package - however:
1. During `choose-integration` - choose `http://localhost:9999` as the provider URL
2. Clone and run the server (it runs on port 9999) https://github.com/Siegrift/hardhat-fastify-gateway
3. You may skip step 13 and 14 (they are done by the script now)

It's recommended to run `make-request` (which makes multiple requests now) while airnode is not running, and only run the airnode (by `yarn run-airnode-locally`) after all of those requests were made and are waiting for fulfillment.