### PR TITLE
Add ignored example files to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,8 @@
 
 packages/airnode-validator/test/fixtures
 packages/airnode-protocol/src/contracts
+packages/airnode-examples/deployments
+packages/airnode-examples/integration-info.json
 
 # https://github.com/protofire/solhint/issues/317
 #


### PR DESCRIPTION
Running through the `airnode-examples` flow generates files / directories that should be ignored by `prettier`. They are already ignored in the airnode-examples `.gitignore` file, as shown here:
https://github.com/api3dao/airnode/blob/06f14e72c34daeef08ae56b15c7e24b470ad4002/packages/airnode-examples/.gitignore#L8-L11