### PR TITLE
Add support for GCP cloud provider

### DIFF
--- a/.changeset/moody-tools-thank.md
+++ b/.changeset/moody-tools-thank.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-deployer': minor
+'@api3/airnode-node': minor
+---
+
+Add support for GCP cloud provider (except for HTTP gateway)

--- a/packages/airnode-deployer/README.md
+++ b/packages/airnode-deployer/README.md
@@ -16,12 +16,19 @@ the deployer for users is using the [deployer docker image](./docker/README.md).
 
 - Install [Terraform v0.15.x](https://www.terraform.io/downloads.html) and make sure that the `terraform` binary is
   available in your `PATH`
-- Make sure your AWS credentials are stored in the
+- AWS deployment - Make sure your AWS credentials are stored in the
   [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where)
   or exported as
   [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set). If
   you need help setting up an AWS IAM user you can follow
   [this video tutorial](https://www.youtube.com/watch?v=bT19B3IBWHE).
+- GCP deployment
+  - Create a [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
+  - Install [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) and obtain your
+    [Application Default Credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login)
+  - Enable [CloudFunction API](https://console.cloud.google.com/apis/library/cloudfunctions.googleapis.com),
+    [Cloud Build API](https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com) and
+    [Cloud Scheduler API](https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com) for your project
 
 ### Setup
 
@@ -67,7 +74,6 @@ Options:
   -c, --configuration, --config, --conf  Path to configuration file             [string] [default: "config/config.json"]
   -s, --secrets                          Path to secrets file                   [string] [default: "config/secrets.env"]
   -r, --receipt                          Output path for receipt file          [string] [default: "output/receipt.json"]
-      --interactive                      Run in interactive mode                               [boolean] [default: true]
 ```
 
 #### remove
@@ -76,12 +82,13 @@ Options:
 Removes a deployed Airnode instance
 
 Options:
-      --version             Show version number                                                                    [boolean]
-      --debug               Run in debug mode                                                     [boolean] [default: false]
-      --help                Show help                                                                              [boolean]
-  -r, --receipt             Path to receipt file                                                                    [string]
-  -a, --airnodeAddressShort Airnode address (short version)                                                         [string]
-  -s, --stage               Stage (environment)                                                                     [string]
-  -c, --cloudProvider       Cloud provider                                                                          [string]
-  -e, --region              Region                                                                                  [string]
+      --version                Show version number                                                             [boolean]
+      --debug                  Run in debug mode                                              [boolean] [default: false]
+      --help                   Show help                                                                       [boolean]
+  -r, --receipt                Path to receipt file                                                             [string]
+  -a, --airnode-address-short  Airnode Address (short version)                                                  [string]
+  -s, --stage                  Stage (environment)                                                              [string]
+  -c, --cloud-provider         Cloud provider                                                    [choices: "aws", "gcp"]
+  -e, --region                 Region                                                                           [string]
+  -p, --project-id             Project ID (GCP only)                                                            [string]
 ```

--- a/packages/airnode-deployer/docker/Dockerfile
+++ b/packages/airnode-deployer/docker/Dockerfile
@@ -24,6 +24,9 @@ RUN apk add --update --no-cache su-exec git && \
     ln -s ${appDir}/bin/deployer.js ${appBin} && \
     chmod +x ${appBin}
 
+# Default placement for GCP credentials
+ENV GOOGLE_APPLICATION_CREDENTIALS=/app/gcloud/application_default_credentials.json
+
 WORKDIR ${appDir}
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/packages/airnode-deployer/package.json
+++ b/packages/airnode-deployer/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf -rf ./dist ./.webpack *.tgz",
     "cli": "ts-node bin/deployer.ts",
     "compile": "tsc -p tsconfig.build.json",
-    "copy:terraform": "copyfiles terraform/**/**/*.tf terraform/**/**/*.tpl  dist/",
+    "copy:terraform": "copyfiles terraform/**/**/**/*.tf terraform/**/**/**/*.tpl  dist/",
     "copy:webpack": "copyfiles .webpack/**/*.js .webpack/templates/**/*.json .webpack/conversions/**/*.json dist/",
     "pack": "yarn pack",
     "test": "jest --coverage",

--- a/packages/airnode-deployer/package.json
+++ b/packages/airnode-deployer/package.json
@@ -16,7 +16,7 @@
     "cli": "ts-node bin/deployer.ts",
     "compile": "tsc -p tsconfig.build.json",
     "copy:terraform": "copyfiles terraform/**/**/*.tf terraform/**/**/*.tpl  dist/",
-    "copy:webpack": "copyfiles .webpack/**/**/*.js .webpack/templates/**/*.json .webpack/conversions/**/*.json dist/",
+    "copy:webpack": "copyfiles .webpack/**/*.js .webpack/templates/**/*.json .webpack/conversions/**/*.json dist/",
     "pack": "yarn pack",
     "test": "jest --coverage",
     "webpack": "webpack",
@@ -36,6 +36,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
+    "@google-cloud/functions-framework": "^2.0.0",
     "@types/lodash": "^4.14.169",
     "@types/node": "^15.12.2",
     "@types/yargs": "^17.0.2",
@@ -47,6 +48,7 @@
     "ts-node": "^10.1.0",
     "typescript": "^4.2.4",
     "webpack": "^5.51.1",
-    "webpack-cli": "^4.8.0"
+    "webpack-cli": "^4.8.0",
+    "webpack-ignore-dynamic-require": "^1.0.0"
   }
 }

--- a/packages/airnode-deployer/src/entrypoint.ts
+++ b/packages/airnode-deployer/src/entrypoint.ts
@@ -1,0 +1,34 @@
+const cloudProvider = process.env.AIRNODE_CLOUD_PROVIDER;
+
+if (!cloudProvider) {
+  throw new Error('Missing cloud specification');
+}
+
+async function cloudHandler() {
+  return await import(/* webpackIgnore: true */ `./handlers/${cloudProvider}`);
+}
+
+export async function startCoordinator(...args: any[]) {
+  const handler = await cloudHandler();
+  return await handler.startCoordinator(...args);
+}
+
+export async function initializeProvider(...args: any[]) {
+  const handler = await cloudHandler();
+  return await handler.initializeProvider(...args);
+}
+
+export async function callApi(...args: any[]) {
+  const handler = await cloudHandler();
+  return await handler.callApi(...args);
+}
+
+export async function processProviderRequests(...args: any[]) {
+  const handler = await cloudHandler();
+  return await handler.processProviderRequests(...args);
+}
+
+export async function testApi(...args: any[]) {
+  const handler = await cloudHandler();
+  return await handler.testApi(...args);
+}

--- a/packages/airnode-deployer/src/entrypoint.ts
+++ b/packages/airnode-deployer/src/entrypoint.ts
@@ -8,27 +8,27 @@ async function cloudHandler() {
   return await import(/* webpackIgnore: true */ `./handlers/${cloudProvider}`);
 }
 
-export async function startCoordinator(...args: any[]) {
+export async function startCoordinator(...args: unknown[]) {
   const handler = await cloudHandler();
   return await handler.startCoordinator(...args);
 }
 
-export async function initializeProvider(...args: any[]) {
+export async function initializeProvider(...args: unknown[]) {
   const handler = await cloudHandler();
   return await handler.initializeProvider(...args);
 }
 
-export async function callApi(...args: any[]) {
+export async function callApi(...args: unknown[]) {
   const handler = await cloudHandler();
   return await handler.callApi(...args);
 }
 
-export async function processProviderRequests(...args: any[]) {
+export async function processProviderRequests(...args: unknown[]) {
   const handler = await cloudHandler();
   return await handler.processProviderRequests(...args);
 }
 
-export async function testApi(...args: any[]) {
+export async function testApi(...args: unknown[]) {
   const handler = await cloudHandler();
   return await handler.testApi(...args);
 }

--- a/packages/airnode-deployer/src/handlers/gcp/index.ts
+++ b/packages/airnode-deployer/src/handlers/gcp/index.ts
@@ -1,0 +1,53 @@
+import * as path from 'path';
+import { Request, Response } from '@google-cloud/functions-framework/build/src/functions';
+import { config, handlers, logger, promiseUtils, providerState } from '@api3/airnode-node';
+
+const configFile = path.resolve(`${__dirname}/../../config-data/config.json`);
+const parsedConfig = config.parseConfig(configFile, process.env);
+
+export async function startCoordinator(_req: Request, res: Response) {
+  await handlers.startCoordinator(parsedConfig);
+  const response = { ok: true, data: { message: 'Coordinator completed' } };
+  res.status(200).send(response);
+}
+
+export async function initializeProvider(req: Request, res: Response) {
+  const stateWithConfig = { ...req.body.state, config: parsedConfig };
+
+  const [err, initializedState] = await promiseUtils.go(() => handlers.initializeProvider(stateWithConfig));
+  if (err || !initializedState) {
+    const msg = `Failed to initialize provider: ${stateWithConfig.settings.name}`;
+    console.log(err!.toString());
+    const errorLog = logger.pend('ERROR', msg, err);
+    const body = { ok: false, errorLog };
+    res.status(500).send(body);
+    return;
+  }
+
+  const body = { ok: true, data: providerState.scrub(initializedState) };
+  res.status(200).send(body);
+}
+
+export async function callApi(req: Request, res: Response) {
+  const { aggregatedApiCall, logOptions, apiCallOptions } = req.body;
+  const [logs, apiCallResponse] = await handlers.callApi({ config: parsedConfig, apiCallOptions, aggregatedApiCall });
+  logger.logPending(logs, logOptions);
+  const response = { ok: true, data: apiCallResponse };
+  res.status(200).send(response);
+}
+
+export async function processProviderRequests(req: Request, res: Response) {
+  const stateWithConfig = { ...req.body.state, config: parsedConfig };
+
+  const [err, updatedState] = await promiseUtils.go(() => handlers.processTransactions(stateWithConfig));
+  if (err || !updatedState) {
+    const msg = `Failed to process provider requests: ${stateWithConfig.settings.name}`;
+    const errorLog = logger.pend('ERROR', msg, err);
+    const body = { ok: false, errorLog };
+    res.status(500).send(body);
+    return;
+  }
+
+  const body = { ok: true, data: providerState.scrub(updatedState) };
+  res.status(200).send(body);
+}

--- a/packages/airnode-deployer/src/infrastructure/index.ts
+++ b/packages/airnode-deployer/src/infrastructure/index.ts
@@ -162,14 +162,14 @@ async function terraformAirnodeManage(
 
   // Run import ONLY for an `apply` command (deployment). Do NOT run for `destroy` command (removal).
   if (command === 'apply') {
-    const importOptions = cloudProviderAirnodeImportOptions[cloudProvider.name](cloudProvider as any);
+    const importOptions = cloudProviderAirnodeImportOptions[cloudProvider.type](cloudProvider as any);
 
     if (!isEmpty(importOptions)) {
       await execTerraform(
         { ...execOptions, ignoreError: true },
         'import',
         prepareAirnodeManageArguments(cloudProvider, commonArguments),
-        cloudProviderAirnodeImportOptions[cloudProvider.name](cloudProvider as any)
+        cloudProviderAirnodeImportOptions[cloudProvider.type](cloudProvider as any)
       );
     }
   }

--- a/packages/airnode-deployer/terraform/airnode/aws/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/aws/main.tf
@@ -6,7 +6,7 @@ module "initializeProvider" {
   source = "./modules/function"
 
   name               = "${local.name_prefix}-initializeProvider"
-  handler            = "handlers/aws/index.initializeProvider"
+  handler            = "index.initializeProvider"
   source_dir         = var.handler_dir
   memory_size        = 768
   timeout            = 17
@@ -21,7 +21,7 @@ module "callApi" {
   source = "./modules/function"
 
   name               = "${local.name_prefix}-callApi"
-  handler            = "handlers/aws/index.callApi"
+  handler            = "index.callApi"
   source_dir         = var.handler_dir
   timeout            = 10
   configuration_file = var.configuration_file
@@ -36,7 +36,7 @@ module "processProviderRequests" {
   source = "./modules/function"
 
   name               = "${local.name_prefix}-processProviderRequests"
-  handler            = "handlers/aws/index.processProviderRequests"
+  handler            = "index.processProviderRequests"
   source_dir         = var.handler_dir
   memory_size        = 768
   timeout            = 32
@@ -51,7 +51,7 @@ module "startCoordinator" {
   source = "./modules/function"
 
   name               = "${local.name_prefix}-startCoordinator"
-  handler            = "handlers/aws/index.startCoordinator"
+  handler            = "index.startCoordinator"
   source_dir         = var.handler_dir
   memory_size        = 768
   timeout            = 65
@@ -73,7 +73,7 @@ module "testApi" {
   count  = var.api_key == null ? 0 : 1
 
   name               = "${local.name_prefix}-testApi"
-  handler            = "handlers/aws/index.testApi"
+  handler            = "index.testApi"
   source_dir         = var.handler_dir
   memory_size        = 256
   timeout            = 30

--- a/packages/airnode-deployer/terraform/airnode/aws/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/aws/modules/function/main.tf
@@ -7,6 +7,9 @@ resource "null_resource" "fetch_lambda_files" {
 rm -rf ${local.tmp_dir}
 mkdir -p "${local.tmp_input_dir}" "${local.tmp_configuration_dir}"
 cp -r "${var.source_dir}/." "${local.tmp_input_dir}"
+rm -rf "${local.tmp_handlers_dir}"
+mkdir -p "${local.tmp_handlers_dir}"
+cp -r "${var.source_dir}/handlers/aws" "${local.tmp_handlers_dir}/aws"
 cp "${var.configuration_file}" "${local.tmp_configuration_dir}"
 EOC
   }
@@ -56,7 +59,7 @@ resource "aws_lambda_function" "lambda" {
   ]
 
   environment {
-    variables = merge(var.environment_variables, fileexists(var.secrets_file) ? jsondecode(file(var.secrets_file)) : {})
+    variables = merge(merge(var.environment_variables, fileexists(var.secrets_file) ? jsondecode(file(var.secrets_file)) : {}), { AIRNODE_CLOUD_PROVIDER = "aws" })
   }
 }
 

--- a/packages/airnode-deployer/terraform/airnode/gcp/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/main.tf
@@ -1,5 +1,53 @@
-resource "null_resource" "mock_deployment" {
-  provisioner "local-exec" {
-    command = "echo 'Airnode deployed!'"
-  }
+module "initializeProvider" {
+  source = "./modules/function"
+
+  name               = "${local.name_prefix}-initializeProvider"
+  entry_point        = "initializeProvider"
+  source_dir         = var.handler_dir
+  timeout            = 20
+  configuration_file = var.configuration_file
+  secrets_file       = var.secrets_file
+  region             = var.gcp_region
+}
+
+module "callApi" {
+  source = "./modules/function"
+
+  name               = "${local.name_prefix}-callApi"
+  entry_point        = "callApi"
+  source_dir         = var.handler_dir
+  timeout            = 30
+  configuration_file = var.configuration_file
+  secrets_file       = var.secrets_file
+  region             = var.gcp_region
+}
+
+module "processProviderRequests" {
+  source = "./modules/function"
+
+  name               = "${local.name_prefix}-processProviderRequests"
+  entry_point        = "processProviderRequests"
+  source_dir         = var.handler_dir
+  timeout            = 10
+  configuration_file = var.configuration_file
+  secrets_file       = var.secrets_file
+  region             = var.gcp_region
+}
+
+module "startCoordinator" {
+  source = "./modules/function"
+
+  name               = "${local.name_prefix}-startCoordinator"
+  entry_point        = "startCoordinator"
+  source_dir         = var.handler_dir
+  timeout            = 60
+  configuration_file = var.configuration_file
+  secrets_file       = var.secrets_file
+  region             = var.gcp_region
+
+  schedule_interval = 1
+  max_instances     = 1
+  invoke_targets    = [module.initializeProvider.function_name, module.callApi.function_name, module.processProviderRequests.function_name]
+
+  depends_on = [module.initializeProvider, module.callApi, module.processProviderRequests]
 }

--- a/packages/airnode-deployer/terraform/airnode/gcp/modules/function/data.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/modules/function/data.tf
@@ -1,0 +1,10 @@
+data "google_project" "project" {
+}
+
+data "archive_file" "function_zip" {
+  type        = "zip"
+  output_path = "${local.tmp_output_dir}/${var.name}.zip"
+  source_dir  = local.tmp_input_dir
+
+  depends_on = [null_resource.fetch_function_files]
+}

--- a/packages/airnode-deployer/terraform/airnode/gcp/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/modules/function/main.tf
@@ -1,0 +1,132 @@
+resource "random_uuid" "uuid" {
+}
+
+resource "random_string" "function_service_account_id" {
+  length  = 20
+  lower   = true
+  upper   = false
+  special = false
+  number  = false
+}
+
+resource "random_string" "scheduler_service_account_id" {
+  length  = 20
+  lower   = true
+  upper   = false
+  special = false
+  number  = false
+}
+
+resource "null_resource" "fetch_function_files" {
+  provisioner "local-exec" {
+    command = <<EOC
+rm -rf ${local.tmp_dir}
+mkdir -p "${local.tmp_input_dir}" "${local.tmp_configuration_dir}"
+cp -r "${var.source_dir}/." "${local.tmp_input_dir}"
+rm -rf "${local.tmp_handlers_dir}"
+mkdir -p "${local.tmp_handlers_dir}"
+cp -r "${var.source_dir}/handlers/gcp" "${local.tmp_handlers_dir}/gcp"
+cp "${var.configuration_file}" "${local.tmp_configuration_dir}"
+EOC
+  }
+
+  triggers = {
+    // Run always
+    trigger = uuid()
+  }
+}
+
+resource "google_service_account" "function_service_account" {
+  account_id   = random_string.function_service_account_id.result
+  display_name = "${var.name}-service-account"
+}
+
+resource "google_project_iam_member" "function_monitoring_writer_role" {
+  role   = "roles/monitoring.metricWriter"
+  member = "serviceAccount:${google_service_account.function_service_account.email}"
+}
+
+resource "google_project_iam_member" "function_logging_writer_role" {
+  role   = "roles/logging.logWriter"
+  member = "serviceAccount:${google_service_account.function_service_account.email}"
+}
+
+resource "google_cloudfunctions_function_iam_member" "invoker" {
+  for_each = toset(var.invoke_targets)
+
+  cloud_function = each.key
+  role           = "roles/cloudfunctions.invoker"
+  member         = "serviceAccount:${google_service_account.function_service_account.email}"
+}
+
+resource "google_storage_bucket" "function_bucket" {
+  name                        = lower("${var.name}-code")
+  location                    = var.region
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "function_zip" {
+  # Append file SHA256 to force bucket to be recreated
+  name   = "${var.name}-source.zip#${data.archive_file.function_zip.output_base64sha256}"
+  bucket = google_storage_bucket.function_bucket.name
+  source = data.archive_file.function_zip.output_path
+}
+
+resource "google_cloudfunctions_function" "function" {
+  name    = var.name
+  runtime = "nodejs14"
+
+  available_memory_mb   = 256
+  source_archive_bucket = google_storage_bucket.function_bucket.name
+  source_archive_object = google_storage_bucket_object.function_zip.name
+  trigger_http          = true
+  entry_point           = var.entry_point
+  timeout               = var.timeout
+  max_instances         = var.max_instances
+  environment_variables = merge(merge(var.environment_variables, fileexists(var.secrets_file) ? jsondecode(file(var.secrets_file)) : {}), { AIRNODE_CLOUD_PROVIDER = "gcp" })
+
+}
+
+resource "google_app_engine_application" "app" {
+  count = var.schedule_interval == 0 ? 0 : 1
+
+  project     = data.google_project.project.project_id
+  location_id = var.region
+}
+
+resource "google_service_account" "scheduler_service_account" {
+  count = var.schedule_interval == 0 ? 0 : 1
+
+  account_id   = random_string.scheduler_service_account_id.result
+  display_name = "${var.name}-service-account"
+}
+
+resource "google_cloudfunctions_function_iam_member" "scheduler_invoker" {
+  count          = var.schedule_interval == 0 ? 0 : 1
+  cloud_function = google_cloudfunctions_function.function.name
+
+  role   = "roles/cloudfunctions.invoker"
+  member = "serviceAccount:${google_service_account.scheduler_service_account[0].email}"
+}
+
+resource "google_cloud_scheduler_job" "scheduler_job" {
+  count = var.schedule_interval == 0 ? 0 : 1
+
+  name             = "${var.name}-scheduler-job"
+  schedule         = "*/${var.schedule_interval} * * * *"
+  attempt_deadline = "${var.timeout}s"
+
+  http_target {
+    http_method = "GET"
+    uri         = google_cloudfunctions_function.function.https_trigger_url
+
+    oidc_token {
+      service_account_email = google_service_account.scheduler_service_account[0].email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app
+  ]
+}

--- a/packages/airnode-deployer/terraform/airnode/gcp/modules/function/outputs.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/modules/function/outputs.tf
@@ -1,0 +1,3 @@
+output "function_name" {
+  value = google_cloudfunctions_function.function.name
+}

--- a/packages/airnode-deployer/terraform/airnode/gcp/modules/function/variables.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/modules/function/variables.tf
@@ -6,41 +6,37 @@ locals {
   tmp_output_dir        = "${local.tmp_dir}/output"
 }
 
-variable "handler" {
-  description = "Lambda handler in a form of `file.function`"
+variable "entry_point" {
+  description = "Cloud function entry point"
 }
 
 variable "source_dir" {
-  description = "Directory with the source code for lambda function"
+  description = "Directory with the source code for cloud function"
 }
 
 variable "timeout" {
-  description = "Lambda function timeout in seconds"
+  description = "Cloud function timeout in seconds"
   default     = 10
 }
 
-variable "reserved_concurrent_executions" {
-  description = "Amount of reserved concurrent executions for this lambda function"
-  default     = -1
-}
-
 variable "invoke_targets" {
-  description = "ARNs of other lambda functions that can be invoked from the lambda function"
+  description = "Names of other cloud functions that can be invoked from the cloud function"
   type        = list(string)
   default     = []
 }
 
 variable "schedule_interval" {
-  description = "How often should the lambda function run in minutes"
+  description = "How often should the cloud function run in minutes"
+  default     = 0
+}
+
+variable "max_instances" {
+  description = "Maximum number of function instances"
   default     = 0
 }
 
 variable "name" {
-  description = "Lambda name"
-}
-
-variable "memory_size" {
-  description = "Lambda memory allocation"
+  description = "Cloud function name"
 }
 
 variable "configuration_file" {
@@ -52,7 +48,11 @@ variable "secrets_file" {
 }
 
 variable "environment_variables" {
-  description = "Additional Lambda environment variables"
+  description = "Additional cloud function environment variables"
   type        = map(any)
   default     = {}
+}
+
+variable "region" {
+  description = "GCP region"
 }

--- a/packages/airnode-deployer/webpack.config.js
+++ b/packages/airnode-deployer/webpack.config.js
@@ -1,12 +1,14 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
+const IgnoreDynamicRequire = require('webpack-ignore-dynamic-require');
 
 module.exports = {
   devtool: 'source-map',
   entry: {
+    index: './dist/src/entrypoint.js',
     'handlers/aws/index': './dist/src/handlers/aws/index.js',
+    'handlers/gcp/index': './dist/src/handlers/gcp/index.js',
   },
-  externals: '../../config-data/config.json',
   mode: 'production',
   output: {
     filename: '[name].js',
@@ -25,5 +27,6 @@ module.exports = {
         { from: '../airnode-validator/dist/conversions', to: 'conversions' },
       ],
     }),
+    new IgnoreDynamicRequire(),
   ],
 };

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -22,8 +22,8 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@api3/airnode-adapter": "^0.2.2",
     "@api3/airnode-abi": "^0.2.2",
+    "@api3/airnode-adapter": "^0.2.2",
     "@api3/airnode-ois": "^0.2.2",
     "@api3/airnode-protocol": "^0.2.2",
     "@api3/airnode-validator": "^0.2.2",
@@ -32,6 +32,7 @@
     "date-fns": "^2.16.1",
     "dotenv": "^10.0.0",
     "ethers": "^5.4.5",
+    "google-auth-library": "^7.10.2",
     "lodash": "^4.17.21",
     "yargs": "^17.0.1"
   },

--- a/packages/airnode-node/src/workers/cloud-platforms/aws.test.ts
+++ b/packages/airnode-node/src/workers/cloud-platforms/aws.test.ts
@@ -36,7 +36,6 @@ describe('spawn', () => {
   });
 
   it('throws an error if the lambda returns an error', async () => {
-    expect.assertions(3);
     const lambda = new AWS.Lambda();
     const invoke = lambda.invoke as jest.Mock;
     invoke.mockImplementationOnce((params, callback) => callback(new Error('Something went wrong'), null));

--- a/packages/airnode-node/src/workers/cloud-platforms/gcp.test.ts
+++ b/packages/airnode-node/src/workers/cloud-platforms/gcp.test.ts
@@ -1,0 +1,67 @@
+const requestMock = jest.fn();
+const getIdTokenClientMock = jest.fn().mockImplementation(() => ({
+  request: requestMock,
+}));
+jest.mock('google-auth-library', () => ({
+  GoogleAuth: jest.fn().mockImplementation(() => ({
+    getIdTokenClient: getIdTokenClientMock,
+  })),
+}));
+
+import * as gcp from './gcp';
+import * as fixtures from '../../../test/fixtures';
+import { WorkerFunctionName } from '../../types';
+
+describe('spawn', () => {
+  it('derives the function URL, authenticates, invokes and returns the response', async () => {
+    requestMock.mockImplementationOnce(() => ({ data: { value: 7777 } }));
+    const workerOpts = fixtures.buildWorkerOptions({
+      cloudProvider: { name: 'gcp', region: 'us-east1', projectId: 'projectId123' },
+    });
+    const parameters = {
+      ...workerOpts,
+      functionName: 'some-function' as WorkerFunctionName,
+      payload: { from: 'ETH', to: 'USD' },
+    };
+    const url = 'https://us-east1-projectId123.cloudfunctions.net/airnode-19255a4-test-some-function';
+
+    const res = await gcp.spawn(parameters);
+    expect(res).toEqual({ value: 7777 });
+
+    expect(getIdTokenClientMock).toHaveBeenCalledTimes(1);
+    expect(getIdTokenClientMock).toHaveBeenCalledWith(url);
+
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    expect(requestMock).toHaveBeenCalledWith({
+      url,
+      method: 'POST',
+      data: parameters.payload,
+    });
+  });
+
+  it('throws an error if the cloud function returns an error', async () => {
+    expect.assertions(5);
+    requestMock.mockRejectedValueOnce(new Error('Something went wrong'));
+    const workerOpts = fixtures.buildWorkerOptions({
+      cloudProvider: { name: 'gcp', region: 'us-east1', projectId: 'projectId123' },
+    });
+    const parameters = {
+      ...workerOpts,
+      functionName: 'some-function' as WorkerFunctionName,
+      payload: { from: 'ETH', to: 'USD' },
+    };
+    const url = 'https://us-east1-projectId123.cloudfunctions.net/airnode-19255a4-test-some-function';
+
+    await expect(gcp.spawn(parameters)).rejects.toThrow(new Error('Something went wrong'));
+
+    expect(getIdTokenClientMock).toHaveBeenCalledTimes(1);
+    expect(getIdTokenClientMock).toHaveBeenCalledWith(url);
+
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    expect(requestMock).toHaveBeenCalledWith({
+      url,
+      method: 'POST',
+      data: parameters.payload,
+    });
+  });
+});

--- a/packages/airnode-node/src/workers/cloud-platforms/gcp.test.ts
+++ b/packages/airnode-node/src/workers/cloud-platforms/gcp.test.ts
@@ -40,7 +40,6 @@ describe('spawn', () => {
   });
 
   it('throws an error if the cloud function returns an error', async () => {
-    expect.assertions(5);
     requestMock.mockRejectedValueOnce(new Error('Something went wrong'));
     const workerOpts = fixtures.buildWorkerOptions({
       cloudProvider: { type: 'gcp', region: 'us-east1', projectId: 'projectId123' },

--- a/packages/airnode-node/src/workers/cloud-platforms/gcp.test.ts
+++ b/packages/airnode-node/src/workers/cloud-platforms/gcp.test.ts
@@ -16,7 +16,7 @@ describe('spawn', () => {
   it('derives the function URL, authenticates, invokes and returns the response', async () => {
     requestMock.mockImplementationOnce(() => ({ data: { value: 7777 } }));
     const workerOpts = fixtures.buildWorkerOptions({
-      cloudProvider: { name: 'gcp', region: 'us-east1', projectId: 'projectId123' },
+      cloudProvider: { type: 'gcp', region: 'us-east1', projectId: 'projectId123' },
     });
     const parameters = {
       ...workerOpts,
@@ -43,7 +43,7 @@ describe('spawn', () => {
     expect.assertions(5);
     requestMock.mockRejectedValueOnce(new Error('Something went wrong'));
     const workerOpts = fixtures.buildWorkerOptions({
-      cloudProvider: { name: 'gcp', region: 'us-east1', projectId: 'projectId123' },
+      cloudProvider: { type: 'gcp', region: 'us-east1', projectId: 'projectId123' },
     });
     const parameters = {
       ...workerOpts,

--- a/packages/airnode-node/src/workers/cloud-platforms/gcp.ts
+++ b/packages/airnode-node/src/workers/cloud-platforms/gcp.ts
@@ -1,0 +1,20 @@
+import { GoogleAuth } from 'google-auth-library';
+import { GcpCloudProvider, WorkerParameters, WorkerResponse } from '../../types';
+
+export async function spawn(params: WorkerParameters): Promise<WorkerResponse> {
+  const auth = new GoogleAuth();
+
+  const resolvedName = `airnode-${params.airnodeAddressShort}-${params.stage}-${params.functionName}`;
+  const cloudProvider = params.cloudProvider as GcpCloudProvider;
+  const url = `https://${cloudProvider.region}-${cloudProvider.projectId}.cloudfunctions.net/${resolvedName}`;
+
+  const axiosClient = await auth.getIdTokenClient(url);
+
+  const response = await axiosClient.request<WorkerResponse>({
+    url,
+    method: 'POST',
+    data: params.payload,
+  });
+
+  return response.data;
+}

--- a/packages/airnode-node/src/workers/index.ts
+++ b/packages/airnode-node/src/workers/index.ts
@@ -1,4 +1,5 @@
 import * as aws from './cloud-platforms/aws';
+import * as gcp from './cloud-platforms/gcp';
 import * as localHandlers from './local-handlers';
 import { WorkerParameters, WorkerResponse } from '../types';
 
@@ -8,7 +9,7 @@ export function spawn(params: WorkerParameters): Promise<WorkerResponse> {
       return aws.spawn(params);
 
     case 'gcp':
-      throw new Error('Not supported yet');
+      return gcp.spawn(params);
 
     case 'local':
       return localHandlers[params.functionName](params.payload);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,6 +1289,18 @@
     retry-request "^4.2.2"
     teeny-request "^7.0.0"
 
+"@google-cloud/functions-framework@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/functions-framework/-/functions-framework-2.0.0.tgz#9dd73ce7ee971c59e71267e7545177749c758fab"
+  integrity sha512-ekimQYvTFjVLZiSGXWOGMj56DU2mXzQdaK57x20EPeDdG6BxwLuCCBxIC/N5EYX+y/2SbvGs0K9hBaFYHP9n2A==
+  dependencies:
+    body-parser "^1.18.3"
+    express "^4.16.4"
+    minimist "^1.2.5"
+    on-finished "^2.3.0"
+    read-pkg-up "^7.0.1"
+    semver "^7.3.5"
+
 "@google-cloud/paginator@^3.0.0":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-3.0.6.tgz#02a59dccd348d515069779a4f77a4a4fd15594da"
@@ -4999,7 +5011,7 @@ bodec@^0.1.0:
   resolved "https://registry.yarnpkg.com/bodec/-/bodec-0.1.0.tgz#bc851555430f23c9f7650a75ef64c6a94c3418cc"
   integrity sha1-vIUVVUMPI8n3ZQp172TGqUw0GMw=
 
-body-parser@1.19.0, body-parser@^1.16.0:
+body-parser@1.19.0, body-parser@^1.16.0, body-parser@^1.18.3:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -7917,7 +7929,7 @@ expect@^27.2.5:
     jest-message-util "^27.2.5"
     jest-regex-util "^27.0.6"
 
-express@^4.14.0, express@^4.17.1:
+express@^4.14.0, express@^4.16.4, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -12990,7 +13002,7 @@ oboe@2.1.5:
   dependencies:
     http-https "^1.0.0"
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -17278,6 +17290,11 @@ webpack-cli@^4.8.0:
     interpret "^2.2.0"
     rechoir "^0.7.0"
     webpack-merge "^5.7.3"
+
+webpack-ignore-dynamic-require@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-ignore-dynamic-require/-/webpack-ignore-dynamic-require-1.0.0.tgz#b8629d67c881fe0ff3f09cc21c40474b488b13d2"
+  integrity sha512-WeGFPgwDochKPwizAu5XsHcPq3aaQLl2E+n1piD/VPGNUo5HIwrtURWNMfrPDfkHVOx+flkAihXbUiILAv5x4Q==
 
 webpack-merge@^5.7.3:
   version "5.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8874,7 +8874,7 @@ globby@^11.0.0, globby@^11.0.2, globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-google-auth-library@^7.0.0, google-auth-library@^7.9.2:
+google-auth-library@^7.0.0, google-auth-library@^7.10.2, google-auth-library@^7.9.2:
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.10.2.tgz#7e48176f50e725e1d65b6a838ec9e9464e6ba689"
   integrity sha512-M37o9Kxa/TLvOLgF71SXvLeVEP5sbSTmKl1zlIgl72SFy5PtsU3pOdu8G8MIHHpQ3/NZabDI8rQkA9DvQVKkPA==


### PR DESCRIPTION
Issues [AN-307](https://api3dao.atlassian.net/browse/AN-307), [AN-309](https://api3dao.atlassian.net/browse/AN-309)

I was able to include AN-309 as it wasn't that hard to do and testing was much easier that way.

Main changes:
* Added full support for GCP cloud (except HTTP gateway) - you can now deploy Airnode to GCP via deployer (just CLI, there may be some changes needed to support credential passing for containers)
* Extracted common handler to be available in the root of cloud function (needed by GCP)
* Added possible `import` step to the Terraform flow (needed because of the GCP's AppEngine)
* Increase AWS lambdas memory size - both AWS and GCP functions were failing for me on 128 MB memory limit so I set both to 256 MB. This will probably change soon anyway based on the stress test results.