### PR TITLE
AN-364: Fix docker build command - solidity compiler download.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,6 @@ RUN git clone ${repository} ${buildDir} -b ${branch}
 # Production dependencies
 FROM source${build} AS deps
 
-# Download solidity compiler as per: https://github.com/nomiclabs/hardhat/issues/1280#issuecomment-949822371
-# The binary filename is taken from: https://github.com/ethereum/solc-bin/tree/gh-pages/linux-amd64
-RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/linux-amd64 \
-  &&  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a
-
 RUN yarn global add lerna && \
     lerna bootstrap -- --production --no-optional --ignore-scripts && \
     rm -rf node_modules/@api3 && \
@@ -45,6 +40,12 @@ RUN yarn global add lerna && \
 
 # Build
 FROM source${build} AS build
+
+# Download solidity compiler as per: https://github.com/nomiclabs/hardhat/issues/1280#issuecomment-949822371
+# The sequencing of this command in this file is important.
+RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/linux-amd64 \
+  &&  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a \
+  && wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/list.json https://solc-bin.ethereum.org/linux-amd64/list.json
 
 RUN yarn bootstrap && \
     yarn build && \


### PR DESCRIPTION
Moving the `wget` commands further down in the `Dockerfile` inserts the files in the appropriate layer for HardHat.
HardHat also requires the appropriate `list.json` file for checksum verification.

Surprisingly opaque problem, easy solution.