### PR TITLE
AN-364: Further changes to override HardHat automatic solidity compiler download

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,10 +42,10 @@ RUN yarn global add lerna && \
 FROM source${build} AS build
 
 # Download solidity compiler as per: https://github.com/nomiclabs/hardhat/issues/1280#issuecomment-949822371
-# The sequencing of this command in this file is important.
-RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/linux-amd64 \
-  &&  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a \
-  && wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/list.json https://solc-bin.ethereum.org/linux-amd64/list.json
+# This path is hard-coded in hardhat.config.ts in airnode-adapter and airnode-protocol.
+RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/wasm \
+  &&  wget -O /root/.cache/hardhat-nodejs/compilers/wasm/soljson-v0.8.9+commit.e5eed63a.js https://solc-bin.ethereum.org/wasm/soljson-v0.8.9+commit.e5eed63a.js \
+  &&  wget -O /root/.cache/hardhat-nodejs/compilers/wasm/list.json https://solc-bin.ethereum.org/wasm/list.json
 
 RUN yarn bootstrap && \
     yarn build && \

--- a/packages/airnode-adapter/hardhat.config.ts
+++ b/packages/airnode-adapter/hardhat.config.ts
@@ -13,8 +13,10 @@ export const customCompiler = async (
   next: RunSuperFunction<{ readonly solcVersion: string }>
 ) => {
   if (args.solcVersion === '0.8.9') {
-    const compilerPath =
-      path.join(os.homedir(), '.cache/hardhat-nodejs/compilers/wasm/soljson-v0.8.9+commit.e5eed63a.js');
+    const compilerPath = path.join(
+      os.homedir(),
+      '.cache/hardhat-nodejs/compilers/wasm/soljson-v0.8.9+commit.e5eed63a.js'
+    );
 
     return {
       compilerPath,

--- a/packages/airnode-adapter/hardhat.config.ts
+++ b/packages/airnode-adapter/hardhat.config.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 import { HardhatUserConfig, subtask } from 'hardhat/config';
 import { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } from 'hardhat/builtin-tasks/task-names';
 import '@nomiclabs/hardhat-waffle';
@@ -10,7 +13,8 @@ export const customCompiler = async (
   next: RunSuperFunction<{ readonly solcVersion: string }>
 ) => {
   if (args.solcVersion === '0.8.9') {
-    const compilerPath = '/root/.cache/hardhat-nodejs/compilers/wasm/soljson-v0.8.9+commit.e5eed63a.js';
+    const compilerPath =
+      path.join(os.homedir(), '.cache/hardhat-nodejs/compilers/wasm/soljson-v0.8.9+commit.e5eed63a.js');
 
     return {
       compilerPath,
@@ -26,7 +30,9 @@ export const customCompiler = async (
 /**
  * This overrides the standard compiler version to use a custom compiled version.
  */
-subtask<{ readonly solcVersion: string }>(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, customCompiler);
+if (fs.existsSync('/.dockerenv')) {
+  subtask<{ readonly solcVersion: string }>(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, customCompiler);
+}
 
 const config: HardhatUserConfig = {
   solidity: '0.8.9',

--- a/packages/airnode-adapter/hardhat.config.ts
+++ b/packages/airnode-adapter/hardhat.config.ts
@@ -1,6 +1,32 @@
-import { HardhatUserConfig } from 'hardhat/config';
+import { HardhatUserConfig, subtask } from 'hardhat/config';
+import { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } from 'hardhat/builtin-tasks/task-names';
 import '@nomiclabs/hardhat-waffle';
 import '@nomiclabs/hardhat-ethers';
+import { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types';
+
+export const customCompiler = async (
+  args: { readonly solcVersion: string },
+  hre: HardhatRuntimeEnvironment,
+  next: RunSuperFunction<{ readonly solcVersion: string }>
+) => {
+  if (args.solcVersion === '0.8.9') {
+    const compilerPath = '/root/.cache/hardhat-nodejs/compilers/wasm/soljson-v0.8.9+commit.e5eed63a.js';
+
+    return {
+      compilerPath,
+      isSolcJs: true,
+      version: args.solcVersion,
+      longVersion: '0.8.9+commit.e5eed63a',
+    };
+  }
+
+  return next();
+};
+
+/**
+ * This overrides the standard compiler version to use a custom compiled version.
+ */
+subtask<{ readonly solcVersion: string }>(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, customCompiler);
 
 const config: HardhatUserConfig = {
   solidity: '0.8.9',

--- a/packages/airnode-protocol/hardhat.config.ts
+++ b/packages/airnode-protocol/hardhat.config.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { subtask } from 'hardhat/config';
 import { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } from 'hardhat/builtin-tasks/task-names';
 import '@nomiclabs/hardhat-waffle';
@@ -10,10 +11,11 @@ import { customCompiler } from '@api3/airnode-adapter/hardhat.config';
 /**
  * This overrides the standard compiler version to use a custom compiled version.
  */
+if (fs.existsSync('/.dockerenv')) {
 // @ts-ignore
-subtask<{ readonly solcVersion: string }>(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, customCompiler);
+  subtask<{ readonly solcVersion: string }>(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, customCompiler);
+}
 
-const fs = require('fs');
 let credentials = require('./credentials.example.json');
 if (fs.existsSync('./credentials.json')) {
   credentials = require('./credentials.json');

--- a/packages/airnode-protocol/hardhat.config.ts
+++ b/packages/airnode-protocol/hardhat.config.ts
@@ -12,7 +12,7 @@ import { customCompiler } from '@api3/airnode-adapter/hardhat.config';
  * This overrides the standard compiler version to use a custom compiled version.
  */
 if (fs.existsSync('/.dockerenv')) {
-// @ts-ignore
+  // @ts-ignore
   subtask<{ readonly solcVersion: string }>(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, customCompiler);
 }
 

--- a/packages/airnode-protocol/hardhat.config.ts
+++ b/packages/airnode-protocol/hardhat.config.ts
@@ -1,8 +1,17 @@
-require('@nomiclabs/hardhat-waffle');
-require('@nomiclabs/hardhat-etherscan');
-require('solidity-coverage');
-require('hardhat-deploy');
-require('hardhat-gas-reporter');
+import { subtask } from 'hardhat/config';
+import { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } from 'hardhat/builtin-tasks/task-names';
+import '@nomiclabs/hardhat-waffle';
+import '@nomiclabs/hardhat-etherscan';
+import 'solidity-coverage';
+import 'hardhat-deploy';
+import 'hardhat-gas-reporter';
+import { customCompiler } from '@api3/airnode-adapter/hardhat.config';
+
+/**
+ * This overrides the standard compiler version to use a custom compiled version.
+ */
+// @ts-ignore
+subtask<{ readonly solcVersion: string }>(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, customCompiler);
 
 const fs = require('fs');
 let credentials = require('./credentials.example.json');
@@ -15,7 +24,7 @@ module.exports = {
     apiKey: credentials.etherscanApiKey,
   },
   gasReporter: {
-    enabled: process.env.REPORT_GAS ? true : false,
+    enabled: !!process.env.REPORT_GAS,
     outputFile: 'gas_report',
     noColors: true,
   },


### PR DESCRIPTION
The compiler downloaded now is JS based, which means it is architecture and OS-agnostic.

I insert a function into HardHat's TASK subsystem so as to force both the compiler type and path.
The platform is no longer detected and used to inform compiler selection.
The reasons for this are:
- Sometimes HardHat switches from `linux-amd64` as a platform to `wasm`
- The `linux-amd64` solidity binary doesn't run on the node docker image downloaded due to a missing library dependency.

While I was at it I swapped hardhat.conf.js for .ts in airnode-protocol.

I'll ask @bbenligiray to test this as his build was still failing after the last _fix_.