### PR TITLE
Exports things needed by Airkeeper and updates beacon reader condition

### DIFF
--- a/packages/airnode-deployer/src/handlers/aws/index.ts
+++ b/packages/airnode-deployer/src/handlers/aws/index.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { config, handlers, logger, promiseUtils, providerState, WorkerResponse } from '@api3/airnode-node';
+import { config, handlers, logger, utils, providers, WorkerResponse } from '@api3/airnode-node';
 
 const configFile = path.resolve(`${__dirname}/../../config-data/config.json`);
 const parsedConfig = config.parseConfig(configFile, process.env);
@@ -17,7 +17,7 @@ export async function startCoordinator() {
 export async function initializeProvider(event: any) {
   const stateWithConfig = { ...event.state, config: parsedConfig };
 
-  const [err, initializedState] = await promiseUtils.go(() => handlers.initializeProvider(stateWithConfig));
+  const [err, initializedState] = await utils.go(() => handlers.initializeProvider(stateWithConfig));
   if (err || !initializedState) {
     const msg = `Failed to initialize provider: ${stateWithConfig.settings.name}`;
     const errorLog = logger.pend('ERROR', msg, err);
@@ -25,7 +25,7 @@ export async function initializeProvider(event: any) {
     return { statusCode: 500, body };
   }
 
-  const body = encodeBody({ ok: true, data: providerState.scrub(initializedState) });
+  const body = encodeBody({ ok: true, data: providers.scrub(initializedState) });
   return { statusCode: 200, body };
 }
 
@@ -40,7 +40,7 @@ export async function callApi(event: any) {
 export async function processProviderRequests(event: any) {
   const stateWithConfig = { ...event.state, config: parsedConfig };
 
-  const [err, updatedState] = await promiseUtils.go(() => handlers.processTransactions(stateWithConfig));
+  const [err, updatedState] = await utils.go(() => handlers.processTransactions(stateWithConfig));
   if (err || !updatedState) {
     const msg = `Failed to process provider requests: ${stateWithConfig.settings.name}`;
     const errorLog = logger.pend('ERROR', msg, err);
@@ -48,7 +48,7 @@ export async function processProviderRequests(event: any) {
     return { statusCode: 500, body };
   }
 
-  const body = encodeBody({ ok: true, data: providerState.scrub(updatedState) });
+  const body = encodeBody({ ok: true, data: providers.scrub(updatedState) });
   return { statusCode: 200, body };
 }
 

--- a/packages/airnode-node/src/adapters/http/index.ts
+++ b/packages/airnode-node/src/adapters/http/index.ts
@@ -1,0 +1,1 @@
+export * as parameters from './parameters';

--- a/packages/airnode-node/src/adapters/index.ts
+++ b/packages/airnode-node/src/adapters/index.ts
@@ -1,0 +1,1 @@
+export * as http from './http';

--- a/packages/airnode-node/src/evm/handlers/index.ts
+++ b/packages/airnode-node/src/evm/handlers/index.ts
@@ -1,2 +1,3 @@
+export * from './fetch-pending-requests';
 export * from './initialize-provider';
 export * from './process-transactions';

--- a/packages/airnode-node/src/evm/index.ts
+++ b/packages/airnode-node/src/evm/index.ts
@@ -1,9 +1,15 @@
-import * as encoding from './abi-encoding';
-import * as contracts from './contracts';
-
-export { contracts, encoding };
+export * as authorization from './authorization';
+export * as contracts from './contracts';
+export * as fulfillments from './fulfillments';
+export * as handlers from './handlers';
+export * as requests from './requests';
+export * as templates from './templates';
+export * as verification from './verification';
+export * as encoding from './abi-encoding';
+export * from './evm-provider';
 export * from './gas-prices';
 export * from './networks';
-export * from './evm-provider';
+export * from './transaction-counts';
 export * from './utils';
 export * from './wallet';
+export * from './workers';

--- a/packages/airnode-node/src/evm/requests/index.ts
+++ b/packages/airnode-node/src/evm/requests/index.ts
@@ -1,0 +1,5 @@
+export * as apiCalls from './api-calls';
+export * from './blocking';
+export * from './event-logs';
+export * from './events';
+export * from './withdrawals';

--- a/packages/airnode-node/src/index.ts
+++ b/packages/airnode-node/src/index.ts
@@ -1,10 +1,9 @@
-export * as handlers from './handlers';
+export * as adapters from './adapters';
 export * as config from './config';
-export * as providerState from './providers/state';
-export * as logger from './logger';
-export * as promiseUtils from './utils/promise-utils';
 export * as evm from './evm';
-export * as adapterHttpParameters from './adapters/http/parameters';
+export * as handlers from './handlers';
+export * as logger from './logger';
+export * as providers from './providers';
 export * as utils from './utils';
-export * from './version';
 export * from './types';
+export * from './version';

--- a/packages/airnode-node/src/index.ts
+++ b/packages/airnode-node/src/index.ts
@@ -3,5 +3,8 @@ export * as config from './config';
 export * as providerState from './providers/state';
 export * as logger from './logger';
 export * as promiseUtils from './utils/promise-utils';
+export * as evm from './evm';
+export * as adapterHttpParameters from './adapters/http/parameters';
+export * as utils from './utils';
 export * from './version';
 export * from './types';

--- a/packages/airnode-node/src/requests/index.ts
+++ b/packages/airnode-node/src/requests/index.ts
@@ -1,2 +1,4 @@
 export * from './grouping';
+export * from './nonces';
 export * from './request';
+export * from './sorting';

--- a/packages/airnode-operation/src/config/evm-dev-config.json
+++ b/packages/airnode-operation/src/config/evm-dev-config.json
@@ -17,7 +17,7 @@
             { "type": "bytes32", "name": "to", "value": "USD" },
             { "type": "bytes32", "name": "_type", "value": "int256" },
             { "type": "bytes32", "name": "_path", "value": "result" },
-            { "type": "bytes32", "name": "_times", "value": "100000" }
+            { "type": "bytes32", "name": "_times", "value": "1000000" }
           ]
         }
       }
@@ -64,7 +64,7 @@
         { "type": "bytes32", "name": "to", "value": "USD" },
         { "type": "bytes32", "name": "_type", "value": "int256" },
         { "type": "bytes32", "name": "_path", "value": "result" },
-        { "type": "bytes32", "name": "_times", "value": "100000" }
+        { "type": "bytes32", "name": "_times", "value": "1000000" }
       ]
     },
     {

--- a/packages/airnode-protocol/contracts/rrp/requesters/RrpBeaconServer.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/RrpBeaconServer.sol
@@ -297,7 +297,7 @@ contract RrpBeaconServer is
         onlyIfTemplateExists(templateId)
         returns (bool)
     {
-        return userIsWhitelisted(templateId, reader);
+        return userIsWhitelisted(templateId, reader) || reader == address(0);
     }
 
     /// @notice Called to get the detailed whitelist status of the reader for

--- a/packages/airnode-protocol/src/index.ts
+++ b/packages/airnode-protocol/src/index.ts
@@ -15,6 +15,7 @@ import {
   AirnodeRrp__factory as AirnodeRrpFactory,
   AccessControlRegistry__factory as AccessControlRegistryFactory,
   RequesterAuthorizerWithAirnode__factory as RequesterAuthorizerWithAirnodeFactory,
+  RrpBeaconServer__factory as RrpBeaconServerFactory,
 } from './contracts';
 import AirnodeRrpDeploymentMainnet from '../deployments/mainnet/AirnodeRrp.json';
 import AccessControlRegistryDeploymentMainnet from '../deployments/mainnet/AccessControlRegistry.json';
@@ -66,11 +67,18 @@ export {
   RequesterAuthorizerWithAirnodeAddresses,
   AirnodeRrpFactory,
   AccessControlRegistryFactory,
+  RrpBeaconServerFactory,
   mocks,
   authorizers,
 };
 
-export type { AirnodeRrp, MockRrpRequester, AccessControlRegistry, RequesterAuthorizerWithAirnode } from './contracts';
+export type {
+  AirnodeRrp,
+  MockRrpRequester,
+  AccessControlRegistry,
+  RequesterAuthorizerWithAirnode,
+  RrpBeaconServer,
+} from './contracts';
 export {
   MadeTemplateRequestEvent,
   MadeFullRequestEvent,

--- a/packages/airnode-protocol/test/rrp/requesters/RrpBeaconServerWithManager.sol.js
+++ b/packages/airnode-protocol/test/rrp/requesters/RrpBeaconServerWithManager.sol.js
@@ -9,6 +9,7 @@ let rrpBeaconServerAdminRoleDescription = 'RrpBeaconServer admin';
 let adminRole, whitelistExpirationExtenderRole, whitelistExpirationSetterRole, indefiniteWhitelisterRole;
 let airnodeAddress, airnodeMnemonic, airnodeXpub, airnodeWallet;
 let sponsorWalletAddress, sponsorWallet;
+let voidSignerAddressZero;
 let endpointId, parameters, templateId;
 
 beforeEach(async () => {
@@ -74,6 +75,7 @@ beforeEach(async () => {
   ({ airnodeAddress, airnodeMnemonic, airnodeXpub } = utils.generateRandomAirnodeWallet());
   airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic, "m/44'/60'/0'/0/0");
   sponsorWalletAddress = utils.deriveSponsorWalletAddress(airnodeXpub, roles.sponsor.address);
+  voidSignerAddressZero = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, hre.ethers.provider);
   await roles.deployer.sendTransaction({
     to: sponsorWalletAddress,
     value: hre.ethers.utils.parseEther('1'),
@@ -746,12 +748,66 @@ describe('readBeacon', function () {
           { gasLimit: 500000 }
         );
       // Read the beacon again
-      let currentBeacon = await rrpBeaconServer.connect(roles.beaconReader).readBeacon(templateId);
+      const currentBeacon = await rrpBeaconServer.connect(roles.beaconReader).readBeacon(templateId);
       expect(currentBeacon.value).to.be.equal(decodedData);
       expect(currentBeacon.timestamp).to.be.equal(nextBlockTimestamp);
-      // Read beacon with address(0)
-      const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, hre.ethers.provider);
-      currentBeacon = await rrpBeaconServer.connect(voidSigner).readBeacon(templateId);
+    });
+  });
+  context('Caller address zero', function () {
+    it('reads beacon', async function () {
+      await airnodeRrp.connect(roles.sponsor).setSponsorshipStatus(rrpBeaconServer.address, true);
+      await rrpBeaconServer.connect(roles.sponsor).setUpdatePermissionStatus(roles.updateRequester.address, true);
+      // Confirm that the beacon is empty
+      const initialBeacon = await rrpBeaconServer.connect(voidSignerAddressZero).readBeacon(templateId);
+      expect(initialBeacon.value).to.be.equal(0);
+      expect(initialBeacon.timestamp).to.be.equal(0);
+      // Compute the expected request ID
+      const requestId = hre.ethers.utils.keccak256(
+        hre.ethers.utils.solidityPack(
+          ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+          [
+            (await hre.ethers.provider.getNetwork()).chainId,
+            airnodeRrp.address,
+            rrpBeaconServer.address,
+            await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
+            templateId,
+            roles.sponsor.address,
+            sponsorWalletAddress,
+            rrpBeaconServer.address,
+            rrpBeaconServer.interface.getSighash('fulfill'),
+            '0x',
+          ]
+        )
+      );
+      // Request the beacon update
+      await rrpBeaconServer
+        .connect(roles.updateRequester)
+        .requestBeaconUpdate(templateId, roles.sponsor.address, sponsorWalletAddress);
+      // Fulfill with 0 status code
+      const lastBlockTimestamp = (await hre.ethers.provider.getBlock(await hre.ethers.provider.getBlockNumber()))
+        .timestamp;
+      const nextBlockTimestamp = lastBlockTimestamp + 1;
+      await hre.ethers.provider.send('evm_setNextBlockTimestamp', [nextBlockTimestamp]);
+      const decodedData = 123;
+      const data = hre.ethers.utils.defaultAbiCoder.encode(['int256'], [decodedData]);
+      const signature = await airnodeWallet.signMessage(
+        hre.ethers.utils.arrayify(
+          hre.ethers.utils.keccak256(hre.ethers.utils.solidityPack(['bytes32', 'bytes'], [requestId, data]))
+        )
+      );
+      await airnodeRrp
+        .connect(sponsorWallet)
+        .fulfill(
+          requestId,
+          airnodeAddress,
+          rrpBeaconServer.address,
+          rrpBeaconServer.interface.getSighash('fulfill'),
+          data,
+          signature,
+          { gasLimit: 500000 }
+        );
+      // Read the beacon again
+      const currentBeacon = await rrpBeaconServer.connect(voidSignerAddressZero).readBeacon(templateId);
       expect(currentBeacon.value).to.be.equal(decodedData);
       expect(currentBeacon.timestamp).to.be.equal(nextBlockTimestamp);
     });
@@ -787,9 +843,11 @@ describe('readerCanReadBeacon', function () {
           .connect(roles.indefiniteWhitelister)
           .setIndefiniteWhitelistStatus(templateId, roles.beaconReader.address, false);
         expect(await rrpBeaconServer.readerCanReadBeacon(templateId, roles.beaconReader.address)).to.equal(false);
-        // VoidSigner of address(0) is considered whitelisted
-        const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, hre.ethers.provider);
-        expect(await rrpBeaconServer.readerCanReadBeacon(templateId, voidSigner.address)).to.equal(true);
+      });
+    });
+    context('User zero address', function () {
+      it('returns true', async function () {
+        expect(await rrpBeaconServer.readerCanReadBeacon(templateId, hre.ethers.constants.AddressZero)).to.equal(true);
       });
     });
     context('User not whitelisted', function () {

--- a/packages/airnode-protocol/test/rrp/requesters/RrpBeaconServerWithManager.sol.js
+++ b/packages/airnode-protocol/test/rrp/requesters/RrpBeaconServerWithManager.sol.js
@@ -746,7 +746,12 @@ describe('readBeacon', function () {
           { gasLimit: 500000 }
         );
       // Read the beacon again
-      const currentBeacon = await rrpBeaconServer.connect(roles.beaconReader).readBeacon(templateId);
+      let currentBeacon = await rrpBeaconServer.connect(roles.beaconReader).readBeacon(templateId);
+      expect(currentBeacon.value).to.be.equal(decodedData);
+      expect(currentBeacon.timestamp).to.be.equal(nextBlockTimestamp);
+      // Read beacon with address(0)
+      const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, hre.ethers.provider);
+      currentBeacon = await rrpBeaconServer.connect(voidSigner).readBeacon(templateId);
       expect(currentBeacon.value).to.be.equal(decodedData);
       expect(currentBeacon.timestamp).to.be.equal(nextBlockTimestamp);
     });
@@ -782,6 +787,9 @@ describe('readerCanReadBeacon', function () {
           .connect(roles.indefiniteWhitelister)
           .setIndefiniteWhitelistStatus(templateId, roles.beaconReader.address, false);
         expect(await rrpBeaconServer.readerCanReadBeacon(templateId, roles.beaconReader.address)).to.equal(false);
+        // VoidSigner of address(0) is considered whitelisted
+        const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, hre.ethers.provider);
+        expect(await rrpBeaconServer.readerCanReadBeacon(templateId, voidSigner.address)).to.equal(true);
       });
     });
     context('User not whitelisted', function () {


### PR DESCRIPTION
@andreogle Airkeeper requires a few functions and types from airnode that are not currently being exported. I've exported only what's needed but we were wondering with Burak if we should be exporting everything by default.

@bbenligiray maybe I should have done this in a separate PR but I've also updated the RrpBeaconServer contract to support reading the beacon value with address(0) using the VoidSigner discussed [here](https://api3workspace.slack.com/archives/C027Y2FAV0S/p1637666522074300).