### PR TITLE
AN-364: Fix docker build by swapping in Debian for artifacts image base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,7 @@ RUN yarn global add lerna && \
 # Build
 FROM source${build} AS build
 
+# Download solidity compiler as per: https://github.com/nomiclabs/hardhat/issues/1280#issuecomment-949822371
 RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/linux-amd64 && \
   wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a && \
   wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/list.json https://solc-bin.ethereum.org/linux-amd64/list.json

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,8 @@ FROM source${build} AS build
 
 # Download solidity compiler as per: https://github.com/nomiclabs/hardhat/issues/1280#issuecomment-949822371
 RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/linux-amd64 && \
-  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a && \
-  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/list.json https://solc-bin.ethereum.org/linux-amd64/list.json
+    wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a && \
+    wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/list.json https://solc-bin.ethereum.org/linux-amd64/list.json
 
 RUN yarn bootstrap && \
     yarn build && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG build=local
 
 # Environment
-FROM node:14.17-alpine3.14 AS environment
+FROM node:14.17-bullseye AS environment
 
 ENV buildDir="/build" \
     dependenciesDir="/dependencies" \
@@ -12,7 +12,9 @@ WORKDIR ${buildDir}
 # Build preparation
 FROM environment AS preparation
 
-RUN apk add --update --no-cache git
+RUN apt-get update && \
+    apt-get install -y git && \
+    apt-get clean
 
 # Source preparation - local
 FROM preparation as sourcelocal
@@ -41,11 +43,9 @@ RUN yarn global add lerna && \
 # Build
 FROM source${build} AS build
 
-# Download solidity compiler as per: https://github.com/nomiclabs/hardhat/issues/1280#issuecomment-949822371
-# The sequencing of this command in this file is important.
-RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/linux-amd64 \
-  &&  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a \
-  && wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/list.json https://solc-bin.ethereum.org/linux-amd64/list.json
+RUN mkdir -p /root/.cache/hardhat-nodejs/compilers/linux-amd64 && \
+  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a && \
+  wget -O /root/.cache/hardhat-nodejs/compilers/linux-amd64/list.json https://solc-bin.ethereum.org/linux-amd64/list.json
 
 RUN yarn bootstrap && \
     yarn build && \

--- a/packages/airnode-admin/docker/Dockerfile
+++ b/packages/airnode-admin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine3.14
+FROM node:14.17-bullseye
 
 ENV name="airnode-admin"
 ENV appDir="/app"
@@ -16,7 +16,7 @@ COPY --from=api3/airnode-artifacts /build/packages/airnode-admin/dist ${appDir}/
 # Make the binary available within PATH
 RUN ln -s ${appDir}/bin/admin.js "/usr/local/bin/airnode-admin" && chmod +x "/usr/local/bin/airnode-admin"
 # Create Airnode user
-RUN adduser -h ${appDir} -s /bin/false -S -D -H ${name}
+RUN useradd --home-dir ${appDir} --shell /bin/false --system --no-create-home ${name}
 USER ${name}
 
 ENTRYPOINT ["node", "/usr/local/bin/airnode-admin"]

--- a/packages/airnode-deployer/docker/Dockerfile
+++ b/packages/airnode-deployer/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine3.14
+FROM node:14.17-bullseye
 
 ENV name="airnode-deployer"
 ENV terraformURL="https://releases.hashicorp.com/terraform/1.0.6/terraform_1.0.6_linux_amd64.zip" \
@@ -14,10 +14,13 @@ COPY --from=api3/airnode-artifacts /packages ${appDir}/node_modules/@api3/
 COPY --from=api3/airnode-artifacts /build/packages/airnode-deployer/dist ${appDir}/
 COPY packages/airnode-deployer/docker/entrypoint.sh /entrypoint.sh
 
-    # Install external dependencies
-RUN apk add --update --no-cache su-exec git && \
-    # Download Terraform binary
-    wget ${terraformURL} && \
+# Install external dependencies
+RUN apt-get update && \
+    apt-get install -y git gosu && \
+    apt-get clean
+
+# Install Terraform
+RUN wget ${terraformURL} && \
     unzip *.zip -d /bin && \
     rm -rf *.zip && \
     # Make the binary available within PATH

--- a/packages/airnode-deployer/docker/entrypoint.sh
+++ b/packages/airnode-deployer/docker/entrypoint.sh
@@ -4,4 +4,4 @@ DEPLOYER_BINARY="/usr/local/bin/airnode-deployer"
 USER_ID="${USER_ID:-0}"
 GROUP_ID="${GROUP_ID:-0}"
 
-su-exec ${USER_ID}:${GROUP_ID} ${DEPLOYER_BINARY} "$@"
+gosu ${USER_ID}:${GROUP_ID} ${DEPLOYER_BINARY} "$@"

--- a/packages/airnode-node/docker/Dockerfile
+++ b/packages/airnode-node/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine3.14
+FROM node:14.17-bullseye
 
 ENV name="airnode-node"
 ENV appDir="/app" \
@@ -15,12 +15,22 @@ COPY --from=api3/airnode-artifacts /packages ${appDir}/node_modules/@api3/
 COPY --from=api3/airnode-artifacts /build/packages/airnode-node/dist ${appDir}/
 COPY packages/airnode-node/docker/airnode-crontab ${cronjob}
 
-    # Install Tini to pass signals correctly
-RUN apk add --update --no-cache tini && \
-    # Create Airnode user
-    adduser -h ${appDir} -s /bin/false -S -D -H ${name} && \
-    # Enable Airnode cronjob
-    chmod +x ${cronjob} && \
+# Install Tini to pass signals correctly
+# Install busybox for Alpine-like cron commands
+RUN apt-get update && \
+    apt-get install -y tini busybox-static && \
+    apt-get clean
+
+# Link busybox's cron functions and set up cron environment
+RUN ln -s /bin/busybox /bin/crond && \
+    ln -s /bin/busybox /bin/crontab && \
+    mkdir -p /var/spool/cron/crontabs
+
+# Create Airnode user
+RUN useradd --home-dir ${appDir} --shell /bin/false --system --no-create-home ${name}
+
+# Enable Airnode cronjob
+RUN chmod +x ${cronjob} && \
     crontab -u ${name} ${cronjob}
 
 # We need to run the cron daemon as root but the Airnode itself is run under the airnode user


### PR DESCRIPTION
Debian uses `glibc` vs `musl` for Alpine. Despite the advertising, `solc` relies on the `glibc` binary library.
I've left in the `solc` download as it will help with problematic connections and proxies - but it is no longer necessary.
[Fix relates to this conversation](https://api3workspace.slack.com/archives/C02AYRX8D89/p1637914176266000)