### PR TITLE
Fix jest typings in test, use consistent e2e folder structure

### DIFF
--- a/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
+++ b/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-import { killBackgroundProcess, runCommand, runCommandInBackground } from './utils';
+import { killBackgroundProcess, runCommand, runCommandInBackground } from '../utils';
 
 const chooseIntegration = () => {
   // We can't use the interactive script to choose the integration, so we specify the details manually
@@ -15,7 +15,7 @@ const chooseIntegration = () => {
     null,
     2
   );
-  writeFileSync(join(__dirname, '../integration-info.json'), content);
+  writeFileSync(join(__dirname, '../../integration-info.json'), content);
 };
 
 describe('Coingecko integration with containerized Airnode and hardhat', () => {

--- a/packages/airnode-examples/tsconfig.json
+++ b/packages/airnode-examples/tsconfig.json
@@ -4,6 +4,6 @@
     "baseUrl": "./",
     "outDir": "dist"
   },
-  "include": ["./src/**/*", "./deploy/**/*", "./scripts/**/*", "./hardhat.config.ts"],
+  "include": ["./src/**/*", "./test/**/*", "./scripts/**/*"],
   "exclude": ["dist/**/*", "node_modules/**/*"]
 }


### PR DESCRIPTION
I realized that the examples were using Mocha typings instead of Jest typings.

This PRs fixes that (by not including hardhat.config.json in the TS sources - this is preferable since there are no mocha tests).
Also moves the test file in the e2e folder for conistency with other modules.