### PR TITLE
Fix deployer warning message for unsuccessful Terraform import

### DIFF
--- a/packages/airnode-deployer/src/infrastructure/index.ts
+++ b/packages/airnode-deployer/src/infrastructure/index.ts
@@ -45,15 +45,17 @@ async function runCommand(command: string, options: CommandOptions) {
     return stdout;
   } catch (err) {
     if (options.ignoreError) {
-      spinner.info();
+      if (logger.inDebugMode()) {
+        spinner.info();
+        logger.warn(`Warning: ${(err as Error).message}`);
+      }
       commandSpinner.warn(`Command '${command}' with options ${stringifiedOptions} failed`);
-      logger.warn((err as Error).toString());
       return '';
     }
 
     spinner.info();
-    commandSpinner.fail(`Command '${command}' with options ${stringifiedOptions} failed`);
     logger.fail((err as Error).toString());
+    commandSpinner.fail(`Command '${command}' with options ${stringifiedOptions} failed`);
     throw new Error(`Command failed: ${(err as any).cmd}`);
   }
 }


### PR DESCRIPTION
Issue [AN-413](https://api3dao.atlassian.net/browse/AN-413)

I made it so the warning is displayed only in the debug mode and with the correct wording (saying `Warning` not an `Error`). When not in debug mode, there is no indication of failure. I think this is fine since we expect to possibly fail only the Terraform `import` command and nothing else. All the other commands will fail with an exception.
![Screenshot_20211202_150356](https://user-images.githubusercontent.com/1655405/144438454-aa5389d1-02c0-4532-958f-424864664460.png)
The screenshot is made with mock commands just to showcase the fix.
