### PR TITLE
Consolidate protocols

### DIFF
--- a/packages/airnode-protocol/contracts/WIP/Airnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/Airnode.sol
@@ -29,6 +29,7 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         bytes32 endpointId,
         bytes calldata parameters
     ) external returns (bytes32 templateId) {
+        require(airnode != address(0), "Airnode address zero");
         templateId = keccak256(
             abi.encodePacked(airnode, endpointId, parameters)
         );
@@ -61,6 +62,7 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         bytes4 fulfillFunctionId,
         bytes calldata parameters
     ) external returns (bytes32 requestId) {
+        require(templates[templateId].airnode != address(0), "Template does not exist");
         require(fulfillAddress != address(this), "Fulfill address AirnodeRrp");
         require(
             sponsorToRequesterToSponsorshipStatus[sponsor][msg.sender],

--- a/packages/airnode-protocol/contracts/WIP/Airnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/Airnode.sol
@@ -213,6 +213,7 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         bytes4 fulfillFunctionId,
         bytes calldata parameters
     ) external returns (bytes32 subscriptionId) {
+        require(templates[templateId].airnode != address(0), "Template does not exist");
         subscriptionId = keccak256(
             abi.encodePacked(
                 templateId,
@@ -254,6 +255,7 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         bytes calldata signature
     ) external returns (bool callSuccess, bytes memory callData) {
         Subscription storage subscription = subscriptions[subscriptionId];
+        require(subscription.templateId != bytes32(0), "Subscription does not exist");
         require(
             (
                 keccak256(abi.encodePacked(subscriptionId, data))

--- a/packages/airnode-protocol/contracts/WIP/Airnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/Airnode.sol
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/Multicall.sol";
+import "./WithdrawalUtils.sol";
+import "./interfaces/IAirnode.sol";
+
+contract Airnode is Multicall, WithdrawalUtils, IAirnode {
+    using ECDSA for bytes32;
+
+    struct Template {
+        address airnode;
+        bytes32 endpointId;
+        bytes parameters;
+    }
+
+    mapping(bytes32 => Template) public templates;
+
+    mapping(address => mapping(address => bool))
+        public sponsorToRequesterToSponsorshipStatus;
+
+    mapping(address => uint256) public requesterToRequestCountPlusOne;
+
+    mapping(bytes32 => bytes32) private requestIdToFulfillmentParameters;
+
+    function createTemplate(
+        address airnode,
+        bytes32 endpointId,
+        bytes calldata parameters
+    ) external returns (bytes32 templateId) {
+        templateId = keccak256(
+            abi.encodePacked(airnode, endpointId, parameters)
+        );
+        templates[templateId] = Template({
+            airnode: airnode,
+            endpointId: endpointId,
+            parameters: parameters
+        });
+        emit CreatedTemplate(templateId, airnode, endpointId, parameters);
+    }
+
+    function setSponsorshipStatus(address requester, bool sponsorshipStatus)
+        external
+    {
+        if (requesterToRequestCountPlusOne[requester] == 0) {
+            requesterToRequestCountPlusOne[requester] = 1;
+        }
+        sponsorToRequesterToSponsorshipStatus[msg.sender][
+            requester
+        ] = sponsorshipStatus;
+        emit SetSponsorshipStatus(msg.sender, requester, sponsorshipStatus);
+    }
+
+    function makeRequest(
+        bytes32 templateId,
+        address reporter,
+        address sponsor,
+        address sponsorWallet,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata parameters
+    ) external returns (bytes32 requestId) {
+        require(fulfillAddress != address(this), "Fulfill address AirnodeRrp");
+        require(
+            sponsorToRequesterToSponsorshipStatus[sponsor][msg.sender],
+            "Requester not sponsored"
+        );
+        uint256 requesterRequestCount = requesterToRequestCountPlusOne[
+            msg.sender
+        ];
+        requestId = keccak256(
+            abi.encodePacked(
+                block.chainid,
+                address(this),
+                msg.sender,
+                requesterRequestCount,
+                templateId,
+                reporter,
+                sponsor,
+                sponsorWallet,
+                fulfillAddress,
+                fulfillFunctionId,
+                parameters
+            )
+        );
+        requestIdToFulfillmentParameters[requestId] = keccak256(
+            abi.encodePacked(
+                templates[templateId].airnode,
+                reporter,
+                sponsorWallet,
+                fulfillAddress,
+                fulfillFunctionId
+            )
+        );
+        requesterToRequestCountPlusOne[msg.sender]++;
+        emit MadeRequest(
+            reporter,
+            requestId,
+            requesterRequestCount,
+            block.chainid,
+            msg.sender,
+            templateId,
+            sponsor,
+            sponsorWallet,
+            fulfillAddress,
+            fulfillFunctionId,
+            parameters
+        );
+    }
+
+    function fulfillRequest(
+        bytes32 requestId,
+        address airnode,
+        address reporter,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata data,
+        bytes calldata signature
+    ) external returns (bool callSuccess, bytes memory callData) {
+        require(
+            keccak256(
+                abi.encodePacked(
+                    airnode,
+                    reporter,
+                    msg.sender,
+                    fulfillAddress,
+                    fulfillFunctionId
+                )
+            ) == requestIdToFulfillmentParameters[requestId],
+            "Invalid request fulfillment"
+        );
+        require(
+            (
+                keccak256(abi.encodePacked(requestId, data))
+                    .toEthSignedMessageHash()
+            ).recover(signature) == airnode,
+            "Invalid signature"
+        );
+        delete requestIdToFulfillmentParameters[requestId];
+        (callSuccess, callData) = fulfillAddress.call( // solhint-disable-line avoid-low-level-calls
+            abi.encodeWithSelector(fulfillFunctionId, requestId, data)
+        );
+        if (callSuccess) {
+            emit FulfilledRequest(reporter, requestId, data);
+        } else {
+            // We do not bubble up the revert string from `callData`
+            emit FailedRequest(
+                reporter,
+                requestId,
+                "Fulfillment failed unexpectedly"
+            );
+        }
+    }
+
+    function failRequest(
+        bytes32 requestId,
+        address airnode,
+        address reporter,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        string calldata errorMessage
+    ) external {
+        require(
+            keccak256(
+                abi.encodePacked(
+                    airnode,
+                    reporter,
+                    msg.sender,
+                    fulfillAddress,
+                    fulfillFunctionId
+                )
+            ) == requestIdToFulfillmentParameters[requestId],
+            "Invalid request fulfillment"
+        );
+        delete requestIdToFulfillmentParameters[requestId];
+        emit FailedRequest(reporter, requestId, errorMessage);
+    }
+
+    function requestIsAwaitingFulfillment(bytes32 requestId)
+        external
+        view
+        returns (bool isAwaitingFulfillment)
+    {
+        isAwaitingFulfillment =
+            requestIdToFulfillmentParameters[requestId] != bytes32(0);
+    }
+
+    // PSP starts here
+
+    struct Subscription {
+        bytes32 templateId;
+        address reporter;
+        address sponsor;
+        address conditionAddress;
+        bytes4 conditionFunctionId;
+        address fulfillAddress;
+        bytes4 fulfillFunctionId;
+        bytes parameters;
+    }
+
+    mapping(bytes32 => Subscription) public subscriptions;
+
+    function createSubscription(
+        bytes32 templateId,
+        address reporter,
+        address sponsor,
+        address conditionAddress,
+        bytes4 conditionFunctionId,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata parameters
+    ) external returns (bytes32 subscriptionId) {
+        subscriptionId = keccak256(
+            abi.encodePacked(
+                templateId,
+                reporter,
+                sponsor,
+                conditionAddress,
+                conditionFunctionId,
+                fulfillAddress,
+                fulfillFunctionId,
+                parameters
+            )
+        );
+        subscriptions[subscriptionId] = Subscription({
+            templateId: templateId,
+            reporter: reporter,
+            sponsor: sponsor,
+            conditionAddress: conditionAddress,
+            conditionFunctionId: conditionFunctionId,
+            fulfillAddress: fulfillAddress,
+            fulfillFunctionId: fulfillFunctionId,
+            parameters: parameters
+        });
+        emit CreatedSubscription(
+            subscriptionId,
+            templateId,
+            reporter,
+            sponsor,
+            conditionAddress,
+            conditionFunctionId,
+            fulfillAddress,
+            fulfillFunctionId,
+            parameters
+        );
+    }
+
+    function fulfill(
+        bytes32 subscriptionId,
+        bytes calldata data,
+        bytes calldata signature
+    ) external returns (bool callSuccess, bytes memory callData) {
+        Subscription storage subscription = subscriptions[subscriptionId];
+        require(
+            (
+                keccak256(abi.encodePacked(subscriptionId, data))
+                    .toEthSignedMessageHash()
+            ).recover(signature) == templates[subscription.templateId].airnode,
+            "Invalid signature"
+        );
+        (callSuccess, callData) = subscription.fulfillAddress.call( // solhint-disable-line avoid-low-level-calls
+            abi.encodeWithSelector(
+                subscription.fulfillFunctionId,
+                subscriptionId,
+                data
+            )
+        );
+        if (callSuccess) {
+            emit FulfilledSubscription(subscriptionId, data);
+        }
+    }
+}

--- a/packages/airnode-protocol/contracts/WIP/Airnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/Airnode.sol
@@ -246,7 +246,7 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         );
     }
 
-    function fulfill(
+    function fulfillSubscription(
         bytes32 subscriptionId,
         bytes calldata data,
         bytes calldata signature

--- a/packages/airnode-protocol/contracts/WIP/Airnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/Airnode.sol
@@ -62,7 +62,10 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         bytes4 fulfillFunctionId,
         bytes calldata parameters
     ) external returns (bytes32 requestId) {
-        require(templates[templateId].airnode != address(0), "Template does not exist");
+        require(
+            templates[templateId].airnode != address(0),
+            "Template does not exist"
+        );
         require(fulfillAddress != address(this), "Fulfill address AirnodeRrp");
         require(
             sponsorToRequesterToSponsorshipStatus[sponsor][msg.sender],
@@ -213,7 +216,10 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         bytes4 fulfillFunctionId,
         bytes calldata parameters
     ) external returns (bytes32 subscriptionId) {
-        require(templates[templateId].airnode != address(0), "Template does not exist");
+        require(
+            templates[templateId].airnode != address(0),
+            "Template does not exist"
+        );
         subscriptionId = keccak256(
             abi.encodePacked(
                 templateId,
@@ -255,7 +261,10 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         bytes calldata signature
     ) external returns (bool callSuccess, bytes memory callData) {
         Subscription storage subscription = subscriptions[subscriptionId];
-        require(subscription.templateId != bytes32(0), "Subscription does not exist");
+        require(
+            subscription.templateId != bytes32(0),
+            "Subscription does not exist"
+        );
         require(
             (
                 keccak256(abi.encodePacked(subscriptionId, data))

--- a/packages/airnode-protocol/contracts/WIP/Airnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/Airnode.sol
@@ -61,7 +61,7 @@ contract Airnode is Multicall, WithdrawalUtils, IAirnode {
         address fulfillAddress,
         bytes4 fulfillFunctionId,
         bytes calldata parameters
-    ) external returns (bytes32 requestId) {
+    ) external override returns (bytes32 requestId) {
         require(
             templates[templateId].airnode != address(0),
             "Template does not exist"

--- a/packages/airnode-protocol/contracts/WIP/ExampleSubscriberContract.sol
+++ b/packages/airnode-protocol/contracts/WIP/ExampleSubscriberContract.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+// This contract is for dev reference and will be removed later on
+contract ExampleSubscriberContract {
+    uint256 public constant FOO = 10;
+
+    function condition(bytes32 subscriptionId, bytes calldata data)
+        public
+        view
+        returns (bool checkResult)
+    {
+        (uint256 response, ) = abi.decode(data, (uint256, uint256));
+        checkResult = response > FOO;
+    }
+
+    function fulfill(bytes32 subscriptionId, bytes calldata data) external {
+        require(condition(subscriptionId, data), "Condition not met");
+
+        // Check if you know about the subscription first
+        // require(subscriptionId == ...)
+        // Instead, you can also just check if the template ID/parameters is correct (e.g. for a common BeaconServer for RRP+PSP)
+        // (bytes32 templateId, , , , , bytes parameters) = airnodePsp.subscriptions(subscriptionId);
+        // require(templateId == ...);
+        // require(parameters.length == 0); // No additional parameters
+
+        (uint256 response, uint256 timestamp) = abi.decode(
+            data,
+            (uint256, uint256)
+        );
+
+        // Check for staleness or not, it depends on your use case
+        require(timestamp + 1000 < block.timestamp, "Fulfillment stale");
+
+        // ...then do whatever you want with the API response
+    }
+}

--- a/packages/airnode-protocol/contracts/WIP/WithdrawalUtils.sol
+++ b/packages/airnode-protocol/contracts/WIP/WithdrawalUtils.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "./interfaces/IWithdrawalUtils.sol";
+
+contract WithdrawalUtils is IWithdrawalUtils {
+    mapping(address => uint256) public sponsorToWithdrawalRequestCount;
+
+    mapping(bytes32 => bytes32) private withdrawalRequestIdToParameters;
+
+    function requestWithdrawal(
+        address reporter,
+        uint256 protocolId,
+        address sponsorWallet
+    ) external {
+        bytes32 withdrawalRequestId = keccak256(
+            abi.encodePacked(
+                block.chainid,
+                address(this),
+                msg.sender,
+                ++sponsorToWithdrawalRequestCount[msg.sender]
+            )
+        );
+        withdrawalRequestIdToParameters[withdrawalRequestId] = keccak256(
+            abi.encodePacked(reporter, msg.sender, protocolId, sponsorWallet)
+        );
+        emit RequestedWithdrawal(
+            reporter,
+            msg.sender,
+            withdrawalRequestId,
+            protocolId,
+            sponsorWallet
+        );
+    }
+
+    function fulfillWithdrawal(
+        bytes32 withdrawalRequestId,
+        address reporter,
+        address sponsor,
+        uint256 protocolId
+    ) external payable {
+        require(
+            withdrawalRequestIdToParameters[withdrawalRequestId] ==
+                keccak256(
+                    abi.encodePacked(reporter, sponsor, protocolId, msg.sender)
+                ),
+            "Invalid withdrawal fulfillment"
+        );
+        delete withdrawalRequestIdToParameters[withdrawalRequestId];
+        emit FulfilledWithdrawal(
+            reporter,
+            sponsor,
+            withdrawalRequestId,
+            protocolId,
+            msg.sender,
+            msg.value
+        );
+        (bool success, ) = sponsor.call{value: msg.value}(""); // solhint-disable-line avoid-low-level-calls
+        require(success, "Transfer failed");
+    }
+}

--- a/packages/airnode-protocol/contracts/WIP/allocators/Allocator.sol
+++ b/packages/airnode-protocol/contracts/WIP/allocators/Allocator.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "./interfaces/IAllocator.sol";
+
+abstract contract Allocator is IAllocator {
+    struct Slot {
+        bytes32 subscriptionId;
+        address setter;
+        uint64 expirationTimestamp;
+    }
+
+    string public override adminRoleDescription;
+    bytes32 internal adminRoleDescriptionHash;
+
+    string public constant override SLOT_SETTER_ROLE_DESCRIPTION =
+        "Slot setter";
+    bytes32 internal constant SLOT_SETTER_ROLE_DESCRIPTION_HASH =
+        keccak256(abi.encodePacked(SLOT_SETTER_ROLE_DESCRIPTION));
+
+    mapping(address => mapping(uint256 => Slot))
+        public
+        override airnodeToSlotIndexToSlot;
+
+    function _setSlot(
+        address airnode,
+        uint256 slotIndex,
+        bytes32 subscriptionId,
+        uint64 expirationTimestamp
+    ) internal {
+        require(airnode != address(0), "Zero Airnode address");
+        require(subscriptionId != bytes32(0), "Zero subscription ID");
+        require(
+            expirationTimestamp > block.timestamp,
+            "Expiration is in the past"
+        );
+        vacateSlot(airnode, slotIndex);
+        airnodeToSlotIndexToSlot[airnode][slotIndex] = Slot({
+            subscriptionId: subscriptionId,
+            setter: msg.sender,
+            expirationTimestamp: expirationTimestamp
+        });
+    }
+
+    function vacateSlot(address airnode, uint256 slotIndex) public override {
+        require(
+            airnodeToSlotIndexToSlot[airnode][slotIndex].setter == msg.sender ||
+                slotIsVacatable(airnode, slotIndex),
+            "Slot occuppied"
+        );
+        delete airnodeToSlotIndexToSlot[airnode][slotIndex];
+    }
+
+    function slotIsVacatable(address airnode, uint256 slotIndex)
+        public
+        view
+        virtual
+        override
+        returns (bool);
+}

--- a/packages/airnode-protocol/contracts/WIP/allocators/AllocatorWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/allocators/AllocatorWithAirnode.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../../access-control-registry/RoleDeriver.sol";
+import "../../access-control-registry/AccessControlClient.sol";
+import "../../access-control-registry/interfaces/IAccessControlRegistry.sol";
+import "./Allocator.sol";
+import "./interfaces/IAllocatorWithAirnode.sol";
+
+contract AllocatorWithAirnode is
+    RoleDeriver,
+    AccessControlClient,
+    Allocator,
+    IAllocatorWithAirnode
+{
+    constructor(
+        address _accessControlRegistry,
+        string memory _adminRoleDescription
+    ) AccessControlClient(_accessControlRegistry) {
+        require(
+            bytes(_adminRoleDescription).length > 0,
+            "Admin role description empty"
+        );
+        adminRoleDescription = _adminRoleDescription;
+        adminRoleDescriptionHash = keccak256(
+            abi.encodePacked(_adminRoleDescription)
+        );
+    }
+
+    function setSlot(
+        address airnode,
+        uint256 slotIndex,
+        bytes32 subscriptionId,
+        uint64 expirationTimestamp
+    ) external override {
+        require(
+            hasSlotSetterRoleOrIsAirnode(airnode, msg.sender),
+            "Not slot setter"
+        );
+        _setSlot(airnode, slotIndex, subscriptionId, expirationTimestamp);
+    }
+
+    function slotIsVacatable(address airnode, uint256 slotIndex)
+        public
+        view
+        override(Allocator, IAllocator)
+        returns (bool)
+    {
+        Slot storage slot = airnodeToSlotIndexToSlot[airnode][slotIndex];
+        return
+            slot.expirationTimestamp < block.timestamp ||
+            !hasSlotSetterRoleOrIsAirnode(airnode, slot.setter);
+    }
+
+    function hasSlotSetterRoleOrIsAirnode(address airnode, address account)
+        public
+        view
+        override
+        returns (bool)
+    {
+        return
+            airnode == account ||
+            IAccessControlRegistry(accessControlRegistry).hasRole(
+                deriveSlotSetterRole(airnode),
+                account
+            );
+    }
+
+    function deriveSlotSetterRole(address airnode)
+        public
+        view
+        override
+        returns (bytes32 slotSetterRole)
+    {
+        slotSetterRole = _deriveRole(
+            _deriveRole(_deriveRootRole(airnode), adminRoleDescriptionHash),
+            SLOT_SETTER_ROLE_DESCRIPTION_HASH
+        );
+    }
+}

--- a/packages/airnode-protocol/contracts/WIP/allocators/AllocatorWithManager.sol
+++ b/packages/airnode-protocol/contracts/WIP/allocators/AllocatorWithManager.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../../access-control-registry/RoleDeriver.sol";
+import "../../access-control-registry/AccessControlClient.sol";
+import "../../access-control-registry/interfaces/IAccessControlRegistry.sol";
+import "./Allocator.sol";
+import "./interfaces/IAllocatorWithManager.sol";
+
+contract AllocatorWithManager is
+    RoleDeriver,
+    AccessControlClient,
+    Allocator,
+    IAllocatorWithManager
+{
+    address public immutable override manager;
+    bytes32 public immutable override adminRole;
+    bytes32 public immutable override slotSetterRole;
+
+    constructor(
+        address _accessControlRegistry,
+        string memory _adminRoleDescription,
+        address _manager
+    ) AccessControlClient(_accessControlRegistry) {
+        require(
+            bytes(_adminRoleDescription).length > 0,
+            "Admin role description empty"
+        );
+        manager = _manager;
+        adminRoleDescription = _adminRoleDescription;
+        adminRoleDescriptionHash = keccak256(
+            abi.encodePacked(_adminRoleDescription)
+        );
+        adminRole = _deriveRole(
+            _deriveRootRole(_manager),
+            adminRoleDescriptionHash
+        );
+        slotSetterRole = _deriveRole(
+            adminRole,
+            SLOT_SETTER_ROLE_DESCRIPTION_HASH
+        );
+    }
+
+    function setSlot(
+        address airnode,
+        uint256 slotIndex,
+        bytes32 subscriptionId,
+        uint64 expirationTimestamp
+    ) external override {
+        require(hasSlotSetterRoleOrIsManager(msg.sender), "Not slot setter");
+        _setSlot(airnode, slotIndex, subscriptionId, expirationTimestamp);
+    }
+
+    function slotIsVacatable(address airnode, uint256 slotIndex)
+        public
+        view
+        override(Allocator, IAllocator)
+        returns (bool)
+    {
+        Slot storage slot = airnodeToSlotIndexToSlot[airnode][slotIndex];
+        return
+            slot.expirationTimestamp < block.timestamp ||
+            !hasSlotSetterRoleOrIsManager(slot.setter);
+    }
+
+    function hasSlotSetterRoleOrIsManager(address account)
+        public
+        view
+        override
+        returns (bool)
+    {
+        return
+            manager == account ||
+            IAccessControlRegistry(accessControlRegistry).hasRole(
+                slotSetterRole,
+                account
+            );
+    }
+}

--- a/packages/airnode-protocol/contracts/WIP/allocators/interfaces/IAllocator.sol
+++ b/packages/airnode-protocol/contracts/WIP/allocators/interfaces/IAllocator.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+interface IAllocator {
+    function setSlot(
+        address airnode,
+        uint256 slotIndex,
+        bytes32 subscriptionId,
+        uint64 expirationTimestamp
+    ) external;
+
+    function vacateSlot(address airnode, uint256 slotIndex) external;
+
+    function slotIsVacatable(address airnode, uint256 slotIndex)
+        external
+        view
+        returns (bool);
+
+    function adminRoleDescription() external view returns (string memory);
+
+    // solhint-disable-next-line func-name-mixedcase
+    function SLOT_SETTER_ROLE_DESCRIPTION()
+        external
+        view
+        returns (string memory);
+
+    function airnodeToSlotIndexToSlot(address airnode, uint256 slotIndex)
+        external
+        view
+        returns (
+            bytes32 subscriptionId,
+            address setter,
+            uint64 expirationTimestamp
+        );
+}

--- a/packages/airnode-protocol/contracts/WIP/allocators/interfaces/IAllocatorWithAirnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/allocators/interfaces/IAllocatorWithAirnode.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "./IAllocator.sol";
+
+interface IAllocatorWithAirnode is IAllocator {
+    function hasSlotSetterRoleOrIsAirnode(address airnode, address account)
+        external
+        view
+        returns (bool);
+
+    function deriveSlotSetterRole(address airnode)
+        external
+        view
+        returns (bytes32 slotSetterRole);
+}

--- a/packages/airnode-protocol/contracts/WIP/allocators/interfaces/IAllocatorWithManager.sol
+++ b/packages/airnode-protocol/contracts/WIP/allocators/interfaces/IAllocatorWithManager.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "./IAllocator.sol";
+
+interface IAllocatorWithManager is IAllocator {
+    function hasSlotSetterRoleOrIsManager(address account)
+        external
+        view
+        returns (bool);
+
+    function manager() external view returns (address);
+
+    function adminRole() external view returns (bytes32);
+
+    function slotSetterRole() external view returns (bytes32);
+}

--- a/packages/airnode-protocol/contracts/WIP/dapi/BeaconServer.sol
+++ b/packages/airnode-protocol/contracts/WIP/dapi/BeaconServer.sol
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "../../whitelist/Whitelist.sol";
+import "../../whitelist/WhitelistRolesWithManager.sol";
+import "../interfaces/IAirnode.sol";
+import "./interfaces/IBeaconServer.sol";
+
+/// @title The contract that serves beacons using Airnode RRP
+/// @notice A beacon is a live data point associated with a beacon ID, which is
+/// derived from a template ID and additional parameters. This is suitable
+/// where the more recent data point is always more favorable, e.g., in the
+/// context of an asset price data feed. Another definition of beacons are
+/// one-Airnode data feeds that can be used individually or combined to build
+/// decentralized data feeds.
+/// @dev This contract casts the reported data point to `int224`. If this is
+/// a problem (because the reported data may not fit into 224 bits or it is of
+/// a completely different type such as `bytes32`), do not use this contract
+/// and implement a customized version instead.
+/// The contract casts the timestamps to `uint32`, which means it will not work
+/// work past-2106 in the current form. If this is an issue, consider casting
+/// the timestamps to a larger type.
+contract RrpBeaconServer is
+    Whitelist,
+    WhitelistRolesWithManager,
+    IBeaconServer
+{
+    struct Beacon {
+        int224 value;
+        uint32 timestamp;
+    }
+
+    address public immutable override airnode;
+
+    mapping(bytes32 => uint256)
+        public
+        override subscriptionIdToUpdatePercentageThreshold;
+
+    /// @notice Returns if a sponsor has permitted an account to request
+    /// updates at this contract
+    mapping(address => mapping(address => bool))
+        public
+        override sponsorToUpdateRequesterToPermissionStatus;
+
+    mapping(bytes32 => Beacon) private beacons;
+    mapping(bytes32 => bytes32) private requestIdToBeaconId;
+
+    /// @param _accessControlRegistry AccessControlRegistry contract address
+    /// @param _adminRoleDescription Admin role description
+    /// @param _manager Manager address
+    /// @param _airnode Airnode contract address
+    constructor(
+        address _accessControlRegistry,
+        string memory _adminRoleDescription,
+        address _manager,
+        address _airnode
+    )
+        WhitelistRolesWithManager(
+            _accessControlRegistry,
+            _adminRoleDescription,
+            _manager
+        )
+    {
+        airnode = _airnode;
+    }
+
+    /// @notice Extends the expiration of the temporary whitelist of `reader`
+    /// to be able to read the beacon with `beaconId` if the sender has the
+    /// whitelist expiration extender role
+    /// @param beaconId Beacon ID
+    /// @param reader Reader address
+    /// @param expirationTimestamp Timestamp at which the temporary whitelist
+    /// will expire
+    function extendWhitelistExpiration(
+        bytes32 beaconId,
+        address reader,
+        uint64 expirationTimestamp
+    ) external override {
+        require(
+            hasWhitelistExpirationExtenderRoleOrIsManager(msg.sender),
+            "Not expiration extender"
+        );
+        _extendWhitelistExpiration(beaconId, reader, expirationTimestamp);
+        emit ExtendedWhitelistExpiration(
+            beaconId,
+            reader,
+            msg.sender,
+            expirationTimestamp
+        );
+    }
+
+    /// @notice Sets the expiration of the temporary whitelist of `reader` to
+    /// be able to read the beacon with `beaconId` if the sender has the
+    /// whitelist expiration setter role
+    /// @param beaconId Beacon ID
+    /// @param reader Reader address
+    /// @param expirationTimestamp Timestamp at which the temporary whitelist
+    /// will expire
+    function setWhitelistExpiration(
+        bytes32 beaconId,
+        address reader,
+        uint64 expirationTimestamp
+    ) external override {
+        require(
+            hasWhitelistExpirationSetterRoleOrIsManager(msg.sender),
+            "Not expiration setter"
+        );
+        _setWhitelistExpiration(beaconId, reader, expirationTimestamp);
+        emit SetWhitelistExpiration(
+            beaconId,
+            reader,
+            msg.sender,
+            expirationTimestamp
+        );
+    }
+
+    /// @notice Sets the indefinite whitelist status of `reader` to be able to
+    /// read the beacon with `beaconId` if the sender has the indefinite
+    /// whitelister role
+    /// @param beaconId Beacon ID
+    /// @param reader Reader address
+    /// @param status Indefinite whitelist status
+    function setIndefiniteWhitelistStatus(
+        bytes32 beaconId,
+        address reader,
+        bool status
+    ) external override {
+        require(
+            hasIndefiniteWhitelisterRoleOrIsManager(msg.sender),
+            "Not indefinite whitelister"
+        );
+        uint192 indefiniteWhitelistCount = _setIndefiniteWhitelistStatus(
+            beaconId,
+            reader,
+            status
+        );
+        emit SetIndefiniteWhitelistStatus(
+            beaconId,
+            reader,
+            msg.sender,
+            status,
+            indefiniteWhitelistCount
+        );
+    }
+
+    /// @notice Revokes the indefinite whitelist status granted by a specific
+    /// account that no longer has the indefinite whitelister role
+    /// @param beaconId Beacon ID
+    /// @param reader Reader address
+    /// @param setter Setter of the indefinite whitelist status
+    function revokeIndefiniteWhitelistStatus(
+        bytes32 beaconId,
+        address reader,
+        address setter
+    ) external override {
+        require(
+            !hasIndefiniteWhitelisterRoleOrIsManager(setter),
+            "setter is indefinite whitelister"
+        );
+        (
+            bool revoked,
+            uint192 indefiniteWhitelistCount
+        ) = _revokeIndefiniteWhitelistStatus(beaconId, reader, setter);
+        if (revoked) {
+            emit RevokedIndefiniteWhitelistStatus(
+                beaconId,
+                reader,
+                setter,
+                msg.sender,
+                indefiniteWhitelistCount
+            );
+        }
+    }
+
+    /// @notice Called by the sponsor to set the update request permission
+    /// status of an account
+    /// @param updateRequester Update requester address
+    /// @param status Update permission status of the update requester
+    function setUpdatePermissionStatus(address updateRequester, bool status)
+        external
+        override
+    {
+        require(updateRequester != address(0), "Update requester zero");
+        sponsorToUpdateRequesterToPermissionStatus[msg.sender][
+            updateRequester
+        ] = status;
+        emit SetUpdatePermissionStatus(msg.sender, updateRequester, status);
+    }
+
+    /// @notice Called to request a beacon to be updated
+    /// @dev There are two requirements for this method to be called: (1) The
+    /// sponsor must call `setSponsorshipStatus()` of AirnodeRrp to sponsor
+    /// this RrpBeaconServer contract, (2) The sponsor must call
+    /// `setUpdatePermissionStatus()` of this RrpBeaconServer contract to give
+    /// request update permission to the caller of this method.
+    /// The template and additional parameters used here must specify a single
+    /// point of data of type `int256` and an additional timestamp of type
+    /// `uint256` to be returned because this is what `fulfill()` expects.
+    /// This point of data must be castable to `int224` and the timestamp must
+    /// be castable to `uint32`.
+    /// @param templateId Template ID of the beacon to be updated
+    /// @param sponsor Sponsor whose wallet will be used to fulfill this
+    /// request
+    /// @param sponsorWallet Sponsor wallet that will be used to fulfill this
+    /// request
+    /// @param parameters Parameters provided by the requester in addition to
+    /// the parameters in the template
+    function requestBeaconUpdate(
+        bytes32 templateId,
+        address reporter,
+        address sponsor,
+        address sponsorWallet,
+        bytes calldata parameters
+    ) external override {
+        require(
+            sponsorToUpdateRequesterToPermissionStatus[sponsor][msg.sender],
+            "Caller not permitted"
+        );
+        bytes32 beaconId = deriveBeaconId(templateId, parameters);
+        bytes32 requestId = IAirnode(airnode).makeRequest(
+            templateId,
+            reporter,
+            sponsor,
+            sponsorWallet,
+            address(this),
+            this.fulfillRrp.selector,
+            parameters
+        );
+        requestIdToBeaconId[requestId] = beaconId;
+        emit RequestedBeaconUpdate(
+            beaconId,
+            sponsor,
+            msg.sender,
+            requestId,
+            templateId,
+            sponsorWallet,
+            parameters
+        );
+    }
+
+    /// @notice Called by AirnodeRrp to fulfill the request
+    /// @dev It is assumed that the fulfillment will be made with a single
+    /// point of data of type `int256` and an additional timestamp of type
+    /// `uint256`
+    /// @param requestId ID of the request being fulfilled
+    /// @param data Fulfillment data (a single `int256` and an additional
+    /// timestamp of type `uint256` encoded as `bytes`)
+    function fulfillRrp(bytes32 requestId, bytes calldata data)
+        external
+        override
+    {
+        require(msg.sender == airnode, "Sender not Airnode");
+        bytes32 beaconId = requestIdToBeaconId[requestId];
+        require(beaconId != bytes32(0), "No such request made");
+        delete requestIdToBeaconId[requestId];
+        (int256 decodedData, uint256 decodedTimestamp) = abi.decode(
+            data,
+            (int256, uint256)
+        );
+        require(
+            decodedData >= type(int224).min && decodedData <= type(int224).max,
+            "Value typecasting error"
+        );
+        require(
+            decodedTimestamp <= type(uint32).max,
+            "Timestamp typecasting error"
+        );
+        require(
+            decodedTimestamp > beacons[beaconId].timestamp,
+            "Fulfillment older than beacon"
+        );
+        require(
+            decodedTimestamp + 1 hours > block.timestamp,
+            "Fulfillment stale"
+        );
+        require(
+            decodedTimestamp - 1 hours < block.timestamp,
+            "Fulfillment from future"
+        );
+        beacons[beaconId] = Beacon({
+            value: int224(decodedData),
+            timestamp: uint32(decodedTimestamp)
+        });
+        emit UpdatedBeaconWithRrp(
+            beaconId,
+            requestId,
+            int224(decodedData),
+            uint32(decodedTimestamp)
+        );
+    }
+
+    function fulfillPsp(bytes32 subscriptionId, bytes calldata data)
+        external
+        override
+    {
+        require(msg.sender == airnode, "Sender not Airnode");
+        (bytes32 templateId, , , , , , , bytes memory parameters) = IAirnode(
+            airnode
+        ).subscriptions(subscriptionId);
+        bytes32 beaconId = deriveBeaconId(templateId, parameters);
+        (int256 decodedData, uint256 decodedTimestamp) = abi.decode(
+            data,
+            (int256, uint256)
+        );
+        require(
+            decodedData >= type(int224).min && decodedData <= type(int224).max,
+            "Value typecasting error"
+        );
+        require(
+            decodedTimestamp <= type(uint32).max,
+            "Timestamp typecasting error"
+        );
+        require(
+            decodedTimestamp > beacons[beaconId].timestamp,
+            "Fulfillment older than beacon"
+        );
+        require(
+            decodedTimestamp + 1 hours > block.timestamp,
+            "Fulfillment stale"
+        );
+        require(
+            decodedTimestamp - 1 hours < block.timestamp,
+            "Fulfillment from future"
+        );
+        beacons[beaconId] = Beacon({
+            value: int224(decodedData),
+            timestamp: uint32(decodedTimestamp)
+        });
+        emit UpdatedBeaconWithPsp(
+            beaconId,
+            subscriptionId,
+            int224(decodedData),
+            uint32(decodedTimestamp)
+        );
+    }
+
+    function setUpdatePercentageThreshold(
+        bytes32 subscriptionId,
+        uint256 updatePercentageThreshold
+    ) external override {
+        (, address sponsor, , , , , , ) = IAirnode(airnode).subscriptions(
+            subscriptionId
+        );
+        require(msg.sender == sponsor, "Sender not sponsor");
+        subscriptionIdToUpdatePercentageThreshold[
+            subscriptionId
+        ] = updatePercentageThreshold;
+    }
+
+    function condition(bytes32 subscriptionId, bytes calldata data)
+        external
+        view
+        override
+        returns (bool)
+    {
+        require(msg.sender == address(0), "Sender address not zero");
+        (bytes32 templateId, , , , , , , bytes memory parameters) = IAirnode(
+            airnode
+        ).subscriptions(subscriptionId);
+        bytes32 beaconId = deriveBeaconId(templateId, parameters);
+        (int256 decodedData, ) = abi.decode(data, (int256, uint256));
+        require(
+            decodedData >= type(int224).min && decodedData <= type(int224).max,
+            "Value typecasting error"
+        );
+        Beacon storage beacon = beacons[beaconId];
+        uint256 absoluteDelta = uint256(
+            decodedData > beacon.value
+                ? decodedData - beacon.value
+                : beacon.value - decodedData
+        );
+        uint256 absoluteBeaconValue = uint256(int256(beacon.value));
+        absoluteBeaconValue = absoluteBeaconValue == 0
+            ? 1
+            : absoluteBeaconValue;
+        return
+            (10**18 * absoluteDelta) / absoluteBeaconValue >
+            subscriptionIdToUpdatePercentageThreshold[subscriptionId];
+    }
+
+    /// @notice Called to read the beacon
+    /// @dev The caller must be whitelisted.
+    /// If the `timestamp` of a beacon is zero, this means that it was never
+    /// written to before, and the zero value in the `value` field is not
+    /// valid. In general, make sure to check if the timestamp of the beacon is
+    /// fresh enough, and definitely disregard beacons with zero `timestamp`.
+    /// @param beaconId ID of the beacon that will be returned
+    /// @return value Beacon value
+    /// @return timestamp Beacon timestamp
+    function readBeacon(bytes32 beaconId)
+        external
+        view
+        override
+        returns (int224 value, uint32 timestamp)
+    {
+        require(
+            readerCanReadBeacon(beaconId, msg.sender),
+            "Caller not whitelisted"
+        );
+        Beacon storage beacon = beacons[beaconId];
+        return (beacon.value, beacon.timestamp);
+    }
+
+    /// @notice Called to check if a reader is whitelisted to read the beacon
+    /// @param beaconId Beacon ID
+    /// @param reader Reader address
+    /// @return isWhitelisted If the reader is whitelisted
+    function readerCanReadBeacon(bytes32 beaconId, address reader)
+        public
+        view
+        override
+        returns (bool)
+    {
+        return userIsWhitelisted(beaconId, reader) || reader == address(0);
+    }
+
+    /// @notice Called to get the detailed whitelist status of the reader for
+    /// the beacon
+    /// @param beaconId Beacon ID
+    /// @param reader Reader address
+    /// @return expirationTimestamp Timestamp at which the whitelisting of the
+    /// reader will expire
+    /// @return indefiniteWhitelistCount Number of times `reader` was
+    /// whitelisted indefinitely for `templateId`
+    function beaconIdToReaderToWhitelistStatus(bytes32 beaconId, address reader)
+        external
+        view
+        override
+        returns (uint64 expirationTimestamp, uint192 indefiniteWhitelistCount)
+    {
+        WhitelistStatus
+            storage whitelistStatus = serviceIdToUserToWhitelistStatus[
+                beaconId
+            ][reader];
+        expirationTimestamp = whitelistStatus.expirationTimestamp;
+        indefiniteWhitelistCount = whitelistStatus.indefiniteWhitelistCount;
+    }
+
+    /// @notice Returns if an account has indefinitely whitelisted the reader
+    /// for the beacon
+    /// @param beaconId Beacon ID
+    /// @param reader Reader address
+    /// @param setter Address of the account that has potentially whitelisted
+    /// the reader for the beacon indefinitely
+    /// @return indefiniteWhitelistStatus If `setter` has indefinitely
+    /// whitelisted reader for the beacon
+    function beaconIdToReaderToSetterToIndefiniteWhitelistStatus(
+        bytes32 beaconId,
+        address reader,
+        address setter
+    ) external view override returns (bool indefiniteWhitelistStatus) {
+        indefiniteWhitelistStatus = serviceIdToUserToSetterToIndefiniteWhitelistStatus[
+            beaconId
+        ][reader][setter];
+    }
+
+    /// @notice Derives the beacon ID from the respective template ID and
+    /// additional parameters
+    /// @param templateId Template ID
+    /// @param parameters Parameters provided by the requester in addition to
+    /// the parameters in the template
+    /// @return beaconId Beacon ID
+    function deriveBeaconId(bytes32 templateId, bytes memory parameters)
+        public
+        pure
+        override
+        returns (bytes32 beaconId)
+    {
+        beaconId = keccak256(abi.encodePacked(templateId, parameters));
+    }
+}

--- a/packages/airnode-protocol/contracts/WIP/dapi/interfaces/IBeaconServer.sol
+++ b/packages/airnode-protocol/contracts/WIP/dapi/interfaces/IBeaconServer.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+interface IBeaconServer {
+    event ExtendedWhitelistExpiration(
+        bytes32 indexed beaconId,
+        address indexed reader,
+        address indexed sender,
+        uint256 expiration
+    );
+
+    event SetWhitelistExpiration(
+        bytes32 indexed beaconId,
+        address indexed reader,
+        address indexed sender,
+        uint256 expiration
+    );
+
+    event SetIndefiniteWhitelistStatus(
+        bytes32 indexed beaconId,
+        address indexed reader,
+        address indexed sender,
+        bool status,
+        uint192 indefiniteWhitelistCount
+    );
+
+    event RevokedIndefiniteWhitelistStatus(
+        bytes32 indexed beaconId,
+        address indexed reader,
+        address indexed setter,
+        address sender,
+        uint192 indefiniteWhitelistCount
+    );
+
+    event SetUpdatePermissionStatus(
+        address indexed sponsor,
+        address indexed updateRequester,
+        bool status
+    );
+
+    event RequestedBeaconUpdate(
+        bytes32 indexed beaconId,
+        address indexed sponsor,
+        address indexed requester,
+        bytes32 requestId,
+        bytes32 templateId,
+        address sponsorWallet,
+        bytes parameters
+    );
+
+    event UpdatedBeaconWithRrp(
+        bytes32 indexed beaconId,
+        bytes32 requestId,
+        int224 value,
+        uint32 timestamp
+    );
+
+    event UpdatedBeaconWithPsp(
+        bytes32 indexed beaconId,
+        bytes32 subscriptionId,
+        int224 value,
+        uint32 timestamp
+    );
+
+    function extendWhitelistExpiration(
+        bytes32 beaconId,
+        address reader,
+        uint64 expirationTimestamp
+    ) external;
+
+    function setWhitelistExpiration(
+        bytes32 beaconId,
+        address reader,
+        uint64 expirationTimestamp
+    ) external;
+
+    function setIndefiniteWhitelistStatus(
+        bytes32 beaconId,
+        address reader,
+        bool status
+    ) external;
+
+    function revokeIndefiniteWhitelistStatus(
+        bytes32 beaconId,
+        address reader,
+        address setter
+    ) external;
+
+    function setUpdatePermissionStatus(address updateRequester, bool status)
+        external;
+
+    function requestBeaconUpdate(
+        bytes32 beaconId,
+        address reporter,
+        address sponsor,
+        address sponsorWallet,
+        bytes calldata parameters
+    ) external;
+
+    function fulfillRrp(bytes32 requestId, bytes calldata data) external;
+
+    function fulfillPsp(bytes32 subscriptionId, bytes calldata data) external;
+
+    function setUpdatePercentageThreshold(
+        bytes32 subscriptionId,
+        uint256 updatePercentageThreshold
+    ) external;
+
+    function condition(bytes32 subscriptionId, bytes calldata data)
+        external
+        view
+        returns (bool);
+
+    function readBeacon(bytes32 beaconId)
+        external
+        view
+        returns (int224 value, uint32 timestamp);
+
+    function readerCanReadBeacon(bytes32 beaconId, address reader)
+        external
+        view
+        returns (bool);
+
+    function beaconIdToReaderToWhitelistStatus(bytes32 beaconId, address reader)
+        external
+        view
+        returns (uint64 expirationTimestamp, uint192 indefiniteWhitelistCount);
+
+    function beaconIdToReaderToSetterToIndefiniteWhitelistStatus(
+        bytes32 beaconId,
+        address reader,
+        address setter
+    ) external view returns (bool indefiniteWhitelistStatus);
+
+    function sponsorToUpdateRequesterToPermissionStatus(
+        address sponsor,
+        address updateRequester
+    ) external view returns (bool permissionStatus);
+
+    function deriveBeaconId(bytes32 templateId, bytes memory parameters)
+        external
+        pure
+        returns (bytes32 beaconId);
+
+    function airnode() external view returns (address);
+
+    function subscriptionIdToUpdatePercentageThreshold(bytes32 subscriptionId)
+        external
+        view
+        returns (uint256);
+}

--- a/packages/airnode-protocol/contracts/WIP/interfaces/IAirnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/interfaces/IAirnode.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "./IWithdrawalUtils.sol";
+
+interface IAirnode is IWithdrawalUtils {
+    event CreatedTemplate(
+        bytes32 indexed templateId,
+        address airnode,
+        bytes32 endpointId,
+        bytes parameters
+    );
+
+    event SetSponsorshipStatus(
+        address indexed sponsor,
+        address indexed requester,
+        bool sponsorshipStatus
+    );
+
+    event MadeRequest(
+        address indexed reporter,
+        bytes32 indexed requestId,
+        uint256 requesterRequestCount,
+        uint256 chainId,
+        address requester,
+        bytes32 templateId,
+        address sponsor,
+        address sponsorWallet,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes parameters
+    );
+
+    event FulfilledRequest(
+        address indexed reporter,
+        bytes32 indexed requestId,
+        bytes data
+    );
+
+    event FailedRequest(
+        address indexed reporter,
+        bytes32 indexed requestId,
+        string errorMessage
+    );
+
+    event CreatedSubscription(
+        bytes32 indexed subscriptionId,
+        bytes32 templateId,
+        address reporter,
+        address sponsor,
+        address conditionAddress,
+        bytes4 conditionFunctionId,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes parameters
+    );
+
+    event FulfilledSubscription(bytes32 indexed subscriptionId, bytes data);
+}

--- a/packages/airnode-protocol/contracts/WIP/interfaces/IAirnode.sol
+++ b/packages/airnode-protocol/contracts/WIP/interfaces/IAirnode.sol
@@ -56,4 +56,28 @@ interface IAirnode is IWithdrawalUtils {
     );
 
     event FulfilledSubscription(bytes32 indexed subscriptionId, bytes data);
+
+    function makeRequest(
+        bytes32 templateId,
+        address reporter,
+        address sponsor,
+        address sponsorWallet,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata parameters
+    ) external returns (bytes32 requestId);
+
+    function subscriptions(bytes32 subscriptionId)
+        external
+        view
+        returns (
+            bytes32 templateId,
+            address reporter,
+            address sponsor,
+            address conditionAddress,
+            bytes4 conditionFunctionId,
+            address fulfillAddress,
+            bytes4 fulfillFunctionId,
+            bytes memory parameters
+        );
 }

--- a/packages/airnode-protocol/contracts/WIP/interfaces/IWithdrawalUtils.sol
+++ b/packages/airnode-protocol/contracts/WIP/interfaces/IWithdrawalUtils.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+interface IWithdrawalUtils {
+    event RequestedWithdrawal(
+        address indexed reporter,
+        address indexed sponsor,
+        bytes32 indexed withdrawalRequestId,
+        uint256 protocolId,
+        address sponsorWallet
+    );
+
+    event FulfilledWithdrawal(
+        address indexed reporter,
+        address indexed sponsor,
+        bytes32 indexed withdrawalRequestId,
+        uint256 protocolId,
+        address sponsorWallet,
+        uint256 amount
+    );
+}


### PR DESCRIPTION
This continues from https://github.com/api3dao/airnode/pull/725 (but we can still merge that too) and does the following
- Merges AirnodeRrp and AirnodePsp into a single contract
- Replaces convenience functions with Multicall
- Replaces the RRP withdrawal utility with a protocol-agnostic one (where `protocolId` is the 0 mentioned [here](https://github.com/api3dao/airnode/blob/master/packages/airnode-protocol/README.md#sponsor-wallet-derivation))
- Differentiates between `airnode` and `reporter` in preparation of second-party oracles (`airnode==reporter` for a first-party oracle)
- Removes full requests

I removed full requests and modified the `require(airnode != address(0))` checks to avoid stack too deep errors. `airnode` is also not emitted in logs for the same reason. This doesn't feel ideal (except the removal of full requests, I think that's a good decision because we're very template focused now), let me know if you can think of a workaround.