### PR TITLE
Ignore CHANGELOG.md files with Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,9 @@ coverage.json
 **/dist/**
 **/.webpack/**
 
+# Changelog files are auto-generated using the @changesets package
+**/CHANGELOG.md
+
 packages/airnode-validator/test/fixtures
 packages/airnode-protocol/src/contracts
 packages/airnode-examples/deployments


### PR DESCRIPTION
CHANGELOG files are auto-generated and don't need to be maintained by users, so there is no need to include them when Prettier is run. This is interfering with the release process: https://github.com/api3dao/airnode/runs/4444927728?check_suite_focus=true