### PR TITLE
Minor correction to validator specification for v0.4

### DIFF
--- a/packages/airnode-examples/integrations/coingecko/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko/config.example.json
@@ -13,12 +13,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
-        "baseFeeMultiplier": "2",
-        "priorityFee": {
-          "value": "3.12",
-          "unit": "gwei"
-        }
+        "txType": "eip1559"
       }
     }
   ],

--- a/packages/airnode-validator/templates/0.4/config.json
+++ b/packages/airnode-validator/templates/0.4/config.json
@@ -85,8 +85,10 @@
               "txType": "eip1559"
             },
             "__then": {
-              "baseFeeMultiplier": {},
-              "priorityFee": {}
+              "__optional": {
+                "baseFeeMultiplier": {},
+                "priorityFee": {}
+              }
             }
           }
         ],


### PR DESCRIPTION
- Corrected validator specification for v0.4 to make gas price fields optional
- Removed optional fields from one example to create a negative test case for the future