### PR TITLE
Moving the manual build instructions back to the README.

### DIFF
--- a/packages/airnode-validator/README.md
+++ b/packages/airnode-validator/README.md
@@ -7,7 +7,32 @@ them.
 ## Usage
 
 General usage of validator and convertor is described in the
-[API3 Documentation](https://docs.api3.org/airnode/latest/reference/packages/validator.html). For debugging purposes it
+[API3 Documentation](https://docs.api3.org/airnode/latest/reference/packages/validator.html). 
+
+## Build Manually
+
+You can clone and build the Airnode monorepo then run the validator as a yarn
+script from inside the `packages/airnode-validator` directory.
+
+```sh
+# download and build the airnode monorepo
+git clone git@github.com:api3dao/airnode.git
+cd airnode
+yarn run bootstrap
+yarn run build
+cd packages/airnode-validator
+
+# execute the validator
+yarn run cli:validator --template="config" --specs="exampleSpecs/config.json"
+
+# validator output
+{
+  "valid": true,
+  "messages": []
+}
+```
+
+For debugging purposes it
 might be useful to run the validator with path to template file instead of providing the format name:
 
 ```sh
@@ -32,7 +57,7 @@ specification conversion and validation. Usage of these keywords is described in
 - [optional parameters](docs/optional.md)
 - [nested templates](docs/template.md)
 
-## Documentation
+## Other Documentation
 
 Source documentation markdown files are located in `docs/src/` directory. All template related examples are located in
 `test/fixtures/` and injected into markdown using

--- a/packages/airnode-validator/README.md
+++ b/packages/airnode-validator/README.md
@@ -7,12 +7,12 @@ them.
 ## Usage
 
 General usage of validator and convertor is described in the
-[API3 Documentation](https://docs.api3.org/airnode/latest/reference/packages/validator.html). 
+[API3 Documentation](https://docs.api3.org/airnode/latest/reference/packages/validator.html).
 
 ## Build Manually
 
-You can clone and build the Airnode monorepo then run the validator as a yarn
-script from inside the `packages/airnode-validator` directory.
+You can clone and build the Airnode monorepo then run the validator as a yarn script from inside the
+`packages/airnode-validator` directory.
 
 ```sh
 # download and build the airnode monorepo
@@ -32,8 +32,8 @@ yarn run cli:validator --template="config" --specs="exampleSpecs/config.json"
 }
 ```
 
-For debugging purposes it
-might be useful to run the validator with path to template file instead of providing the format name:
+For debugging purposes it might be useful to run the validator with path to template file instead of providing the
+format name:
 
 ```sh
 yarn run cli:validator --template="templates/0.2/config.json" --specs="myProject/config/config.json"


### PR DESCRIPTION
As per the discussion in AN-407 the monorepo package should now retain any manual build instructions. The docs will have the content regarding things such as npx and Docker image usage. The manual build instructions have already been removed (see AN-406) and the reference to a manual build now is linked back to the monorepo README.