### PR TITLE
Force stage deployment variable to be lowercase

### DIFF
--- a/.changeset/late-apples-decide.md
+++ b/.changeset/late-apples-decide.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-deployer': patch
+'@api3/airnode-validator': patch
+---
+
+Force stage deployment variable to be lowercase

--- a/packages/airnode-deployer/src/infrastructure/index.ts
+++ b/packages/airnode-deployer/src/infrastructure/index.ts
@@ -135,6 +135,10 @@ function prepareAirnodeManageArguments(cloudProvider: CloudProvider, commonArgum
   return [...cloudProviderAirnodeManageArguments[cloudProvider.type](cloudProvider as any), ...commonArguments];
 }
 
+function getBucketName(airnodeAddressShort: string, stage: string) {
+  return `airnode-${airnodeAddressShort}-${stage}-terraform`.toLowerCase();
+}
+
 async function terraformAirnodeManage(
   command: string,
   execOptions: child.ExecOptions,
@@ -214,7 +218,7 @@ async function deploy(
   }
 
   const { type: cloudProviderType } = cloudProvider;
-  const bucket = `airnode-${airnodeAddressShort}-${stage}-terraform`;
+  const bucket = getBucketName(airnodeAddressShort, stage);
   const terraformStateCloudProviderDir = path.join(terraformStateDir, cloudProviderType);
 
   if (!(await cloudProviderLib[cloudProviderType].stateExists(bucket, cloudProvider as any))) {
@@ -269,7 +273,7 @@ async function remove(airnodeAddressShort: string, stage: string, cloudProvider:
   }
 
   const { type: cloudProviderType } = cloudProvider;
-  const bucket = `airnode-${airnodeAddressShort}-${stage}-terraform`;
+  const bucket = getBucketName(airnodeAddressShort, stage);
 
   // Remove airnode
   logger.debug('Removing Airnode via Terraform recipes');

--- a/packages/airnode-deployer/terraform/state/aws/main.tf
+++ b/packages/airnode-deployer/terraform/state/aws/main.tf
@@ -1,9 +1,9 @@
 module "terraform_state_backend_aws" {
   source        = "cloudposse/tfstate-backend/aws"
   version       = "0.33.0"
-  namespace     = var.infrastructure_name
-  environment   = var.airnode_address_short
-  stage         = var.stage
+  namespace     = lower(var.infrastructure_name)
+  environment   = lower(var.airnode_address_short)
+  stage         = lower(var.stage)
   name          = "terraform"
   delimiter     = "-"
   force_destroy = true

--- a/packages/airnode-deployer/terraform/state/gcp/main.tf
+++ b/packages/airnode-deployer/terraform/state/gcp/main.tf
@@ -1,5 +1,5 @@
 resource "google_storage_bucket" "tfstate_bucket" {
-  name                        = "${var.infrastructure_name}-${var.airnode_address_short}-${var.stage}-terraform"
+  name                        = lower("${var.infrastructure_name}-${var.airnode_address_short}-${var.stage}-terraform")
   storage_class               = "STANDARD"
   location                    = var.gcp_region
   force_destroy               = true

--- a/packages/airnode-validator/exampleSpecs/secrets.config.json
+++ b/packages/airnode-validator/exampleSpecs/secrets.config.json
@@ -41,7 +41,7 @@
       "type": "${CLOUD_PROVIDER}",
       "region": "us-east-1"
     },
-    "stage": "FILL"
+    "stage": "test"
   },
   "triggers": {
     "rrp": [

--- a/packages/airnode-validator/templates/0.2/config.json
+++ b/packages/airnode-validator/templates/0.2/config.json
@@ -97,7 +97,7 @@
       "__type": "string"
     },
     "stage": {
-      "__regexp": "^[a-zA-Z0-9-_]{1,16}$",
+      "__regexp": "^[a-z0-9-_]{1,16}$",
       "__catch": {
         "__message": "__fullPath can contain only alphanumeric characters, '-' or '_' and cannot be longer than 16 characters"
       }

--- a/packages/airnode-validator/templates/0.3/config.json
+++ b/packages/airnode-validator/templates/0.3/config.json
@@ -173,7 +173,7 @@
       }
     },
     "stage": {
-      "__regexp": "^[a-zA-Z0-9-_]{1,16}$",
+      "__regexp": "^[a-z0-9-_]{1,16}$",
       "__catch": {
         "__message": "__fullPath can contain only alphanumeric characters, '-' or '_' and cannot be longer than 16 characters"
       }

--- a/packages/airnode-validator/templates/0.4/config.json
+++ b/packages/airnode-validator/templates/0.4/config.json
@@ -271,7 +271,7 @@
       }
     },
     "stage": {
-      "__regexp": "^[a-zA-Z0-9-_]{1,16}$",
+      "__regexp": "^[a-z0-9-_]{1,16}$",
       "__catch": {
         "__message": "__fullPath can contain only alphanumeric characters, '-' or '_' and cannot be longer than 16 characters"
       }


### PR DESCRIPTION
Close #757

There was a difference between how the bucket name is handled by the state recipes and airnode recipes (one was lowercasing the name and the second one wasn't), that's why it was possible to create a bucket but not find it afterward.

I united it so the bucket name is always lowercase but I would also like to force `stage` to contain only lower case characters (numbers and underscore `_` are ok) just to be on the safe side. I've already modified the validator templates.

@wkande Can you update the docs to reflect that?