### PR TITLE
Do not run the validator in cloud environments.

### DIFF
--- a/.changeset/pretty-files-notice.md
+++ b/.changeset/pretty-files-notice.md
@@ -1,0 +1,7 @@
+---
+'@api3/airnode-deployer': patch
+'@api3/airnode-node': patch
+'@api3/airnode-validator': patch
+---
+
+Disable validation for cloud handler functions and introduce tests for the deployer

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:admin:watch:debug": "cd packages/airnode-admin && yarn run test:watch:debug",
     "test:airnode-abi": "(cd packages/airnode-abi && yarn run test)",
     "test:airnode-abi:watch": "(cd packages/airnode-abi && yarn run test:watch)",
+    "test:deployer": "(cd packages/airnode-deployer && yarn run test)",
     "test:e2e": "lerna run test:e2e --stream",
     "test:e2e-admin": "cd packages/airnode-admin && yarn run test:e2e",
     "test:e2e-examples": "cd packages/airnode-examples && yarn run test:e2e",

--- a/packages/airnode-deployer/jest.config.js
+++ b/packages/airnode-deployer/jest.config.js
@@ -3,4 +3,6 @@ const config = require('../../jest.config.base');
 module.exports = {
   ...config,
   // Add custom settings below
+  setupFiles: ['<rootDir>/test/setup/init/set-define-property.ts'],
+  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)'],
 };

--- a/packages/airnode-deployer/src/cli/commands.ts
+++ b/packages/airnode-deployer/src/cli/commands.ts
@@ -16,7 +16,7 @@ import * as logger from '../utils/logger';
 
 export async function deploy(configFile: string, secretsFile: string, receiptFile: string) {
   const secrets = parseSecretsFile(secretsFile);
-  const config = loadConfig(configFile, secrets);
+  const config = loadConfig(configFile, secrets, true);
 
   if (config.nodeSettings.cloudProvider.type === 'local') {
     // We want to check cloud provider type regardless of "skipValidation" value.

--- a/packages/airnode-deployer/src/handlers/aws/index.ts
+++ b/packages/airnode-deployer/src/handlers/aws/index.ts
@@ -1,10 +1,9 @@
 import * as path from 'path';
 import { handlers, logger, utils, providers, WorkerResponse } from '@api3/airnode-node';
 import { loadConfig } from '../../utils';
-import { isCloudFunction } from '../../utils/infrastructure';
 
 const configFile = path.resolve(`${__dirname}/../../config-data/config.json`);
-const parsedConfig = loadConfig(configFile, process.env, !isCloudFunction());
+const parsedConfig = loadConfig(configFile, process.env, false);
 
 function encodeBody(data: WorkerResponse): string {
   return JSON.stringify(data);

--- a/packages/airnode-deployer/src/handlers/aws/index.ts
+++ b/packages/airnode-deployer/src/handlers/aws/index.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 import { handlers, logger, utils, providers, WorkerResponse } from '@api3/airnode-node';
 import { loadConfig } from '../../utils';
+import { isCloudFunction } from '../../utils/infrastructure';
 
 const configFile = path.resolve(`${__dirname}/../../config-data/config.json`);
-const parsedConfig = loadConfig(configFile, process.env);
+const parsedConfig = loadConfig(configFile, process.env, !isCloudFunction());
 
 function encodeBody(data: WorkerResponse): string {
   return JSON.stringify(data);

--- a/packages/airnode-deployer/src/handlers/gcp/index.ts
+++ b/packages/airnode-deployer/src/handlers/gcp/index.ts
@@ -2,10 +2,9 @@ import * as path from 'path';
 import { Request, Response } from '@google-cloud/functions-framework/build/src/functions';
 import { handlers, logger, utils, providers } from '@api3/airnode-node';
 import { loadConfig } from '../../utils';
-import { isCloudFunction } from '../../utils/infrastructure';
 
 const configFile = path.resolve(`${__dirname}/../../config-data/config.json`);
-const parsedConfig = loadConfig(configFile, process.env, !isCloudFunction());
+const parsedConfig = loadConfig(configFile, process.env, false);
 
 export async function startCoordinator(_req: Request, res: Response) {
   await handlers.startCoordinator(parsedConfig);

--- a/packages/airnode-deployer/src/handlers/gcp/index.ts
+++ b/packages/airnode-deployer/src/handlers/gcp/index.ts
@@ -2,9 +2,10 @@ import * as path from 'path';
 import { Request, Response } from '@google-cloud/functions-framework/build/src/functions';
 import { handlers, logger, utils, providers } from '@api3/airnode-node';
 import { loadConfig } from '../../utils';
+import { isCloudFunction } from '../../utils/infrastructure';
 
 const configFile = path.resolve(`${__dirname}/../../config-data/config.json`);
-const parsedConfig = loadConfig(configFile, process.env);
+const parsedConfig = loadConfig(configFile, process.env, !isCloudFunction());
 
 export async function startCoordinator(_req: Request, res: Response) {
   await handlers.startCoordinator(parsedConfig);

--- a/packages/airnode-deployer/src/utils/files.ts
+++ b/packages/airnode-deployer/src/utils/files.ts
@@ -7,7 +7,7 @@ import * as logger from '../utils/logger';
 import { deriveAirnodeAddress, deriveAirnodeXpub, shortenAirnodeAddress } from '../utils';
 import { DeployAirnodeOutput } from '../infrastructure';
 
-export function loadConfig(configFile: string, secrets: Record<string, string | undefined>, shouldValidate = true) {
+export function loadConfig(configFile: string, secrets: Record<string, string | undefined>, shouldValidate: boolean) {
   const { shouldSkipValidation, config, validationOutput } = parseConfig(configFile, secrets, shouldValidate);
   const { messages, valid } = validationOutput;
 

--- a/packages/airnode-deployer/src/utils/files.ts
+++ b/packages/airnode-deployer/src/utils/files.ts
@@ -7,8 +7,8 @@ import * as logger from '../utils/logger';
 import { deriveAirnodeAddress, deriveAirnodeXpub, shortenAirnodeAddress } from '../utils';
 import { DeployAirnodeOutput } from '../infrastructure';
 
-export function loadConfig(configFile: string, secrets: Record<string, string | undefined>) {
-  const { shouldSkipValidation, config, validationOutput } = parseConfig(configFile, secrets);
+export function loadConfig(configFile: string, secrets: Record<string, string | undefined>, shouldValidate = true) {
+  const { shouldSkipValidation, config, validationOutput } = parseConfig(configFile, secrets, shouldValidate);
   const { messages, valid } = validationOutput;
 
   if (shouldSkipValidation) {

--- a/packages/airnode-deployer/src/utils/infrastructure.ts
+++ b/packages/airnode-deployer/src/utils/infrastructure.ts
@@ -17,3 +17,8 @@ export function formatTerraformArguments(args: CommandArg[]) {
     })
     .map((arg) => `-${arg}`);
 }
+
+/**
+ * Checks if the environment is a GCP or AWS cloud function
+ */
+export const isCloudFunction = () => process.env.LAMBDA_TASK_ROOT || process.env.FUNCTION_TARGET;

--- a/packages/airnode-deployer/src/utils/validation.test.ts
+++ b/packages/airnode-deployer/src/utils/validation.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import { loadConfig } from './files';
+import * as fixtures from '../../test/fixtures';
+
+describe('deployer-validation', () => {
+  it('loads the config without validation', () => {
+    const config = fixtures.buildConfig();
+    jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(JSON.stringify(config));
+
+    const notThrowingFunction = () => loadConfig('config.json', process.env, false);
+    expect(notThrowingFunction).not.toThrow();
+  });
+
+  it('loads the config with validation and fails because the config is invalid', () => {
+    const config = fixtures.buildConfig();
+    jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(JSON.stringify(config));
+
+    const throwingFunction = () => loadConfig('config.json', process.env, true);
+    expect(throwingFunction).toThrow();
+  });
+});

--- a/packages/airnode-deployer/src/utils/validation.ts
+++ b/packages/airnode-deployer/src/utils/validation.ts
@@ -2,5 +2,5 @@ import { validateJsonWithTemplate } from '@api3/airnode-validator';
 
 export function validateReceipt(supposedReceipt: any, nodeVersion: string) {
   // TODO: Validate receipt version https://api3dao.atlassian.net/browse/AN-423
-  return validateJsonWithTemplate(supposedReceipt, `receipt@${nodeVersion}`);
+  return validateJsonWithTemplate(supposedReceipt, `receipt@${nodeVersion}`, true);
 }

--- a/packages/airnode-deployer/test/fixtures/config/config.ts
+++ b/packages/airnode-deployer/test/fixtures/config/config.ts
@@ -1,0 +1,51 @@
+import { ApiCredentials, Config, Trigger } from '@api3/airnode-node';
+import * as ois from './ois';
+import * as settings from './node-settings';
+
+export function buildTrigger(overrides?: Partial<Trigger>): Trigger {
+  return {
+    endpointId: '0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6',
+    endpointName: 'convertToUSD',
+    oisTitle: 'Currency Converter API',
+    ...overrides,
+  };
+}
+
+export function buildApiCredentials(overrides?: Partial<ApiCredentials>): ApiCredentials {
+  return {
+    securitySchemeName: 'My Security Scheme',
+    securitySchemeValue: 'supersecret',
+    oisTitle: 'Currency Converter API',
+    ...overrides,
+  };
+}
+
+export function buildConfig(overrides?: Partial<Config>): Config {
+  return {
+    chains: [
+      {
+        authorizers: [],
+        contracts: {
+          AirnodeRrp: '0x197F3826040dF832481f835652c290aC7c41f073',
+        },
+        id: '31337',
+        type: 'evm',
+        // We set an invalid options value to keep us honest in the use of both txType cases in downstream tests.
+        options: {} as any,
+        providers: {
+          ['EVM local']: {
+            url: 'http://localhost:4111',
+          },
+        },
+      },
+    ],
+    nodeSettings: settings.buildNodeSettings(),
+    triggers: {
+      rrp: [buildTrigger()],
+      http: [buildTrigger()],
+    },
+    ois: [ois.buildOIS()],
+    apiCredentials: [buildApiCredentials()],
+    ...overrides,
+  };
+}

--- a/packages/airnode-deployer/test/fixtures/config/index.ts
+++ b/packages/airnode-deployer/test/fixtures/config/index.ts
@@ -1,0 +1,3 @@
+export * from './config';
+export * from './node-settings';
+export * from './ois';

--- a/packages/airnode-deployer/test/fixtures/config/node-settings.ts
+++ b/packages/airnode-deployer/test/fixtures/config/node-settings.ts
@@ -1,0 +1,24 @@
+import { NodeSettings } from '@api3/airnode-node/src/types';
+
+export function buildNodeSettings(settings?: Partial<NodeSettings>): NodeSettings {
+  return {
+    cloudProvider: {
+      type: 'local',
+    },
+    airnodeWalletMnemonic: 'achieve climb couple wait accident symbol spy blouse reduce foil echo label',
+    httpGateway: {
+      enabled: false,
+    },
+    heartbeat: {
+      enabled: true,
+      apiKey: '3a7af83f-6450-46d3-9937-5f9773ce2849',
+      id: '2d14a39a-9f6f-41af-9905-99abf0e5e1f0',
+      url: 'https://example.com',
+    },
+    logFormat: 'plain',
+    logLevel: 'DEBUG',
+    nodeVersion: '1.0.0',
+    stage: 'test',
+    ...settings,
+  };
+}

--- a/packages/airnode-deployer/test/fixtures/config/ois.ts
+++ b/packages/airnode-deployer/test/fixtures/config/ois.ts
@@ -1,0 +1,97 @@
+import { OIS } from '@api3/airnode-ois';
+
+export function buildOIS(ois?: Partial<OIS>): OIS {
+  return {
+    oisFormat: '1.0.0',
+    version: '1.2.3',
+    title: 'Currency Converter API',
+    apiSpecifications: {
+      servers: [
+        {
+          url: 'http://localhost:5000',
+        },
+      ],
+      paths: {
+        '/convert': {
+          get: {
+            parameters: [
+              {
+                in: 'query',
+                name: 'from',
+              },
+              {
+                in: 'query',
+                name: 'to',
+              },
+              {
+                in: 'query',
+                name: 'amount',
+              },
+              {
+                in: 'query',
+                name: 'date',
+              },
+            ],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          'My Security Scheme': {
+            in: 'query',
+            type: 'apiKey',
+            name: 'access_key',
+          },
+        },
+      },
+      security: {
+        myapiApiScheme: [],
+      },
+    },
+    endpoints: [
+      {
+        name: 'convertToUSD',
+        operation: {
+          method: 'get',
+          path: '/convert',
+        },
+        fixedOperationParameters: [
+          {
+            operationParameter: {
+              in: 'query',
+              name: 'to',
+            },
+            value: 'USD',
+          },
+        ],
+        reservedParameters: [
+          { name: '_type' },
+          { name: '_path' },
+          {
+            name: '_times',
+            default: '100000',
+          },
+        ],
+        parameters: [
+          {
+            name: 'from',
+            default: 'EUR',
+            operationParameter: {
+              in: 'query',
+              name: 'from',
+            },
+          },
+          {
+            name: 'amount',
+            default: '1',
+            operationParameter: {
+              name: 'amount',
+              in: 'query',
+            },
+          },
+        ],
+      },
+    ],
+    ...ois,
+  };
+}

--- a/packages/airnode-deployer/test/fixtures/index.ts
+++ b/packages/airnode-deployer/test/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './config';

--- a/packages/airnode-deployer/test/setup/init/set-define-property.ts
+++ b/packages/airnode-deployer/test/setup/init/set-define-property.ts
@@ -1,0 +1,17 @@
+// Sometimes Jest can have issues when trying to spy on an internal module. Import
+// and use this function as a workaround at the top of your test.
+//
+// Credit: https://github.com/facebook/jest/issues/6914#issuecomment-654710111
+const { defineProperty } = Object;
+
+Object.defineProperty = function (object, name, meta) {
+  if (meta.get && !meta.configurable) {
+    // it might be an ES6 exports object
+    return defineProperty(object, name, {
+      ...meta,
+      configurable: true, // prevent freezing
+    });
+  }
+
+  return defineProperty(object, name, meta);
+};

--- a/packages/airnode-deployer/tsconfig.json
+++ b/packages/airnode-deployer/tsconfig.json
@@ -4,6 +4,6 @@
     "baseUrl": "./",
     "outDir": "dist"
   },
-  "include": ["./src/**/*"],
+  "include": ["./src/**/*", "./test/**/*"],
   "exclude": ["dist/**/*", "node_modules/**/*"]
 }

--- a/packages/airnode-node/src/config/index.ts
+++ b/packages/airnode-node/src/config/index.ts
@@ -30,9 +30,13 @@ export interface ParseConfigResult {
   shouldSkipValidation: boolean;
 }
 
-export function parseConfig(configPath: string, secrets: Record<string, string | undefined>): ParseConfigResult {
+export function parseConfig(
+  configPath: string,
+  secrets: Record<string, string | undefined>,
+  shouldValidate = false
+): ParseConfigResult {
   const config = readConfig(configPath);
-  const validationResult = validateConfig(config, secrets);
+  const validationResult = validateConfig(config, secrets, shouldValidate);
   const parsedConfig: Config = validationResult.specs as Config;
   const ois = parseOises(parsedConfig.ois);
 
@@ -56,7 +60,17 @@ export function getEnvValue(envName: string) {
   return process.env[envName];
 }
 
-function validateConfig(supposedConfig: unknown, secrets: Record<string, string | undefined>): Result {
+function validateConfig(
+  supposedConfig: unknown,
+  secrets: Record<string, string | undefined>,
+  shouldValidate = true
+): Result {
   // TODO: Improve TS types
-  return validateJsonWithTemplate(supposedConfig as object, `config@${getNodeVersion()}`, secrets, true);
+  return validateJsonWithTemplate(
+    supposedConfig as object,
+    `config@${getNodeVersion()}`,
+    secrets,
+    true,
+    shouldValidate
+  );
 }

--- a/packages/airnode-node/src/config/index.ts
+++ b/packages/airnode-node/src/config/index.ts
@@ -33,7 +33,7 @@ export interface ParseConfigResult {
 export function parseConfig(
   configPath: string,
   secrets: Record<string, string | undefined>,
-  shouldValidate = false
+  shouldValidate: boolean
 ): ParseConfigResult {
   const config = readConfig(configPath);
   const validationResult = validateConfig(config, secrets, shouldValidate);
@@ -63,14 +63,14 @@ export function getEnvValue(envName: string) {
 function validateConfig(
   supposedConfig: unknown,
   secrets: Record<string, string | undefined>,
-  shouldValidate = true
+  shouldValidate: boolean
 ): Result {
   // TODO: Improve TS types
   return validateJsonWithTemplate(
     supposedConfig as object,
     `config@${getNodeVersion()}`,
+    shouldValidate,
     secrets,
-    true,
-    shouldValidate
+    true
   );
 }

--- a/packages/airnode-node/src/workers/local-handlers.ts
+++ b/packages/airnode-node/src/workers/local-handlers.ts
@@ -18,7 +18,8 @@ export interface CallApiArgs {
 function loadConfig() {
   const { config, shouldSkipValidation, validationOutput } = parseConfig(
     path.resolve(`${__dirname}/../../config/config.json`),
-    process.env
+    process.env,
+    true
   );
 
   // TODO: Log debug that validation is skipped

--- a/packages/airnode-validator/src/validator.test.ts
+++ b/packages/airnode-validator/src/validator.test.ts
@@ -268,6 +268,12 @@ describe('validator', () => {
       valid: true,
       messages: [],
     });
+    expect(
+      validator.validateJson(JSON.parse(validEndpointSpec), endpointsTemplate, undefined, undefined, undefined, false)
+    ).toEqual({
+      valid: true,
+      messages: [],
+    });
 
     const invalidEndpointSpec = `[
       {
@@ -343,6 +349,12 @@ describe('validator', () => {
         extraFieldMessage(['[1]', 'extra']),
       ],
     });
+    expect(
+      validator.validateJson(JSON.parse(invalidEndpointSpec), endpointsTemplate, undefined, undefined, undefined, false)
+    ).toEqual({
+      valid: true,
+      messages: [],
+    });
   });
 
   it('ois specs', () => {
@@ -367,6 +379,19 @@ describe('validator', () => {
           'Properties of parameter "myParameter" from endpoints.[1].parameters.[0], must match it\'s properties in apiSpecifications.paths'
         ),
       ],
+    });
+    expect(
+      validator.validateJson(
+        JSON.parse(invalidOISSpecification),
+        oisTemplate,
+        'templates/1.0/',
+        undefined,
+        undefined,
+        false
+      )
+    ).toEqual({
+      valid: true,
+      messages: [],
     });
   });
 

--- a/packages/airnode-validator/src/validator.ts
+++ b/packages/airnode-validator/src/validator.ts
@@ -11,12 +11,14 @@ import { keywords } from './utils/globals';
  * @param templateName - name of the template (ois, config...)
  * @param interpolate - list of env variables that will be interpolated with specification
  * @param returnJson - parsed JSON specification will be returned
+ * @param shouldValidate - if the validator should run the validation
  */
 export function validateJsonWithTemplate(
   specs: object,
   templateName: string | undefined,
   interpolate?: Record<string, string | undefined>,
-  returnJson = false
+  returnJson = false,
+  shouldValidate = true
 ): Result {
   if (!templateName) {
     return { valid: false, messages: [logger.error('Specification and template file must be provided')] };
@@ -51,7 +53,8 @@ export function validateJsonWithTemplate(
     template,
     split.slice(0, split.length - 1).join(path.sep) + path.sep,
     interpolate,
-    returnJson
+    returnJson,
+    shouldValidate
   );
 }
 
@@ -142,7 +145,8 @@ export function validateJson(
   template: object,
   templatePath = '',
   interpolate?: Record<string, string | undefined>,
-  returnJson = false
+  returnJson = false,
+  shouldValidate = true
 ): Result {
   const messages: Log[] = [];
   let interpolated: object | undefined = specs;
@@ -154,6 +158,14 @@ export function validateJson(
   }
 
   const nonRedundant = template[keywords.arrayItem as keyof typeof template] ? [] : {};
+  if (!shouldValidate) {
+    return {
+      valid: true,
+      messages: [],
+      specs: returnJson ? interpolated : undefined,
+    };
+  }
+
   const result = processSpecs(
     interpolated,
     template,

--- a/packages/airnode-validator/src/validator.ts
+++ b/packages/airnode-validator/src/validator.ts
@@ -16,9 +16,9 @@ import { keywords } from './utils/globals';
 export function validateJsonWithTemplate(
   specs: object,
   templateName: string | undefined,
+  shouldValidate: boolean,
   interpolate?: Record<string, string | undefined>,
-  returnJson = false,
-  shouldValidate = true
+  returnJson = false
 ): Result {
   if (!templateName) {
     return { valid: false, messages: [logger.error('Specification and template file must be provided')] };
@@ -88,7 +88,7 @@ export function validateWithTemplate(
     }
   }
 
-  return validateJsonWithTemplate(specs, templateName, env, returnJson);
+  return validateJsonWithTemplate(specs, templateName, true, env, returnJson);
 }
 
 /**
@@ -97,13 +97,15 @@ export function validateWithTemplate(
  * @param templatePath - template json file
  * @param interpolatePath - path to env file that will be interpolated with specification file
  * @param returnJson - parsed JSON specification will be returned
+ * @param shouldValidate - should the config be validated
  * @returns array of error and warning messages
  */
 export function validate(
   specsPath: string | undefined,
   templatePath: string | undefined,
   interpolatePath?: string,
-  returnJson = false
+  returnJson = false,
+  shouldValidate = true
 ): Result {
   if (!specsPath || !templatePath) {
     return { valid: false, messages: [logger.error('Specification and template file must be provided')] };
@@ -128,7 +130,14 @@ export function validate(
 
   const split = templatePath.split(path.sep);
 
-  return validateJson(specs, template, split.slice(0, split.length - 1).join(path.sep) + path.sep, env, returnJson);
+  return validateJson(
+    specs,
+    template,
+    split.slice(0, split.length - 1).join(path.sep) + path.sep,
+    env,
+    returnJson,
+    shouldValidate
+  );
 }
 
 /**
@@ -138,6 +147,7 @@ export function validate(
  * @param templatePath - path to current validator template file
  * @param interpolate - list of env variables that will be interpolated with specification
  * @param returnJson - parsed JSON specification will be returned
+ * @param shouldValidate - should the config be validated
  * @returns array of error and warning messages
  */
 export function validateJson(


### PR DESCRIPTION
Cam reported that`callApi` was timing out on AWS for the Amberdata deployment. I investigated and found that the size of the config file had surfaced severe inefficiencies in the `config.json` validator. This appears to only be an issue on cold-start of each handler (`parsedConfig` appears to effectively be memo’ised), but the inefficiency resulted in a start-up delay of 14-16 seconds, enough to prevent callApi from ever running.

After some investigation I found that the validator was largely responsible for this delay; disabling the validator in cloud environments reduces total execution time to the point that `callApi` no longer times out before the config has been parsed and memo'ised.

This PR implements disabling the validator in cloud environments.