### PR TITLE
Remove non existent flag from deployer in airnode examples

### DIFF
--- a/packages/airnode-examples/scripts/deploy-airnode.ts
+++ b/packages/airnode-examples/scripts/deploy-airnode.ts
@@ -17,7 +17,7 @@ const main = async () => {
     integrationInfo.airnodeType === 'gcp' && `-v "\${HOME}/.config/gcloud:/app/gcloud"`,
     `-v ${integrationPath}:/app/config`,
     `-v ${integrationPath}:/app/output`,
-    `api3/airnode-deployer:latest deploy --skip-version-check`,
+    `api3/airnode-deployer:latest deploy`,
   ]
     .filter(Boolean)
     .join(' ');


### PR DESCRIPTION
I forgot to remove this one from examples when finishing https://github.com/api3dao/airnode/pull/749