### PR TITLE
Update AWS Terraform provider version

### DIFF
--- a/packages/airnode-deployer/terraform/airnode/aws/providers.tf
+++ b/packages/airnode-deployer/terraform/airnode/aws/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.71"
     }
   }
 

--- a/packages/airnode-deployer/terraform/state/aws/providers.tf
+++ b/packages/airnode-deployer/terraform/state/aws/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.71"
     }
   }
 


### PR DESCRIPTION
[Issue AN-481](https://api3dao.atlassian.net/browse/AN-481)

I bumped the version but this was actually not an issue. The `~>` in version description means that the provider should be of major version `3` and the highest available minor version. And in our setup, the providers are downloaded during the deployment, not during the Docker image build. So, even the older Docker images will use the newest provider.