### PR TITLE
Update GCP authentication process & API management

### DIFF
--- a/.changeset/violet-terms-unite.md
+++ b/.changeset/violet-terms-unite.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': minor
+---
+
+Update GCP authentication process & APIs management

--- a/packages/airnode-deployer/docker/Dockerfile
+++ b/packages/airnode-deployer/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN ARCH=`[ $(arch) == "x86_64" ] && echo "amd64" || echo "arm64" ` && \
     chmod +x ${appBin}
 
 # Default placement for GCP credentials
-ENV GOOGLE_APPLICATION_CREDENTIALS=/app/gcloud/application_default_credentials.json
+ENV GOOGLE_APPLICATION_CREDENTIALS=/app/gcp.json
 
 WORKDIR ${appDir}
 

--- a/packages/airnode-deployer/src/infrastructure/index.ts
+++ b/packages/airnode-deployer/src/infrastructure/index.ts
@@ -96,7 +96,7 @@ function awsAirnodeImportOptions(_cloudProvider: AwsCloudProvider): string[] {
 }
 
 function gcpAirnodeImportOptions(cloudProvider: GcpCloudProvider): string[] {
-  return ['module.startCoordinator.google_app_engine_application.app', cloudProvider.projectId!];
+  return ['module.startCoordinator.google_app_engine_application.app[0]', cloudProvider.projectId!];
 }
 
 const cloudProviderLib = {

--- a/packages/airnode-deployer/terraform/airnode/gcp/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/modules/function/main.tf
@@ -9,14 +9,6 @@ resource "random_string" "function_service_account_id" {
   number  = false
 }
 
-resource "random_string" "scheduler_service_account_id" {
-  length  = 20
-  lower   = true
-  upper   = false
-  special = false
-  number  = false
-}
-
 resource "null_resource" "fetch_function_files" {
   provisioner "local-exec" {
     command = <<EOC
@@ -85,7 +77,16 @@ resource "google_cloudfunctions_function" "function" {
   timeout               = var.timeout
   max_instances         = var.max_instances
   environment_variables = merge(merge(var.environment_variables, fileexists(var.secrets_file) ? jsondecode(file(var.secrets_file)) : {}), { AIRNODE_CLOUD_PROVIDER = "gcp" })
+}
 
+resource "random_string" "scheduler_service_account_id" {
+  count = var.schedule_interval == 0 ? 0 : 1
+
+  length  = 20
+  lower   = true
+  upper   = false
+  special = false
+  number  = false
 }
 
 resource "google_app_engine_application" "app" {
@@ -98,7 +99,7 @@ resource "google_app_engine_application" "app" {
 resource "google_service_account" "scheduler_service_account" {
   count = var.schedule_interval == 0 ? 0 : 1
 
-  account_id   = random_string.scheduler_service_account_id.result
+  account_id   = random_string.scheduler_service_account_id[0].result
   display_name = "${var.name}-service-account"
 }
 

--- a/packages/airnode-examples/README.md
+++ b/packages/airnode-examples/README.md
@@ -119,11 +119,12 @@ yarn create-aws-secrets
 
 ### 6. (Only if deploying to GCP) Create GCP credentials
 
-If you intend to deploy Airnode on GCP, you will need to sign in using the GCP CLI tool. If you are not sure how to do
-this or how to create a GCP account, see
+If you intend to deploy Airnode on GCP, you will need to create a service account for your project and add and download
+an access key for this account. If you are not sure how to do this or how to create a GCP account, see
 [the following docs section](https://docs.api3.org/airnode/v0.3/grp-providers/docker/deployer-image.html#gcp).
 
-No credentials file is required - signing through the GCP CLI is all there is needed.
+Store the access key file as `gcp.json` into the integration directory - e.g. if you have choosen the `coingecko`
+integration, store the file as `integrations/coingecko/gcp.json`.
 
 ### 7. Create Airnode configuration
 

--- a/packages/airnode-examples/scripts/deploy-airnode.ts
+++ b/packages/airnode-examples/scripts/deploy-airnode.ts
@@ -14,7 +14,7 @@ const main = async () => {
     `docker run -it --rm`,
     `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
     integrationInfo.airnodeType === 'aws' && `--env-file ${secretsFilePath}`,
-    integrationInfo.airnodeType === 'gcp' && `-v "\${HOME}/.config/gcloud:/app/gcloud"`,
+    integrationInfo.airnodeType === 'gcp' && `-v "${integrationPath}/gcp.json:/app/gcp.json"`,
     `-v ${integrationPath}:/app/config`,
     `-v ${integrationPath}:/app/output`,
     `api3/airnode-deployer:latest deploy`,

--- a/packages/airnode-examples/scripts/remove-airnode.ts
+++ b/packages/airnode-examples/scripts/remove-airnode.ts
@@ -14,7 +14,7 @@ const main = async () => {
     `docker run -it --rm`,
     `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
     integrationInfo.airnodeType === 'aws' && `--env-file ${secretsFilePath}`,
-    integrationInfo.airnodeType === 'gcp' && `-v "\${HOME}/.config/gcloud:/app/gcloud"`,
+    integrationInfo.airnodeType === 'gcp' && `-v "${integrationPath}/gcp.json:/app/gcp.json"`,
     `-v ${integrationPath}:/app/output`,
     `api3/airnode-deployer:latest remove -r output/receipt.json`,
   ]


### PR DESCRIPTION
[Issue AN-464](https://api3dao.atlassian.net/browse/AN-464)

Users will now need to enable just one API in GCP console and create a service account with the access key that can be downloaded as a JSON file to use for authentication. No need to install `gcloud` tools.

Docs update and further explanation of the new flow in [PR #532](https://github.com/api3dao/api3-docs/pull/532)