### PR TITLE
Fix the order of commands in the examples package

### DIFF
--- a/packages/airnode-examples/README.md
+++ b/packages/airnode-examples/README.md
@@ -254,7 +254,16 @@ yarn make-request
 When there is an blockchain event received by Airnode, it will immediately perform the API call and submit the response
 back on chain. This command will wait for all of this to happen and you should see the final output in the CLI.
 
-### 18. (Only if deploying to a cloud provider) Remove Airnode from the cloud provider
+### 18. (Optional) Make a withdrawal request
+
+Withdrawal requests instruct the Airnode return the funds of particular sponsor wallet back to sponsor. This step is
+recommended when testing on public testnets. To do so run:
+
+```sh
+yarn make-withdrawal-request
+```
+
+### 19. (Only if deploying to a cloud provider) Remove Airnode from the cloud provider
 
 If you want to tear down the Airnode from the cloud provider run:
 
@@ -263,15 +272,6 @@ yarn remove-airnode
 ```
 
 This will use the deployer to remove the Airnode lambdas from the cloud provider.
-
-### 19. (Optional) Make a withdrawal request
-
-Withdrawal requests instruct the Airnode return the funds of particular sponsor wallet back to sponsor. This step is
-recommended when testing on public testnets. To do so run:
-
-```sh
-yarn make-withdrawal-request
-```
 
 ## For developers
 


### PR DESCRIPTION
While documenting https://github.com/api3dao/airnode/pull/764 I made a mistake and documented the withdrawal request after the Airnode is tear down. This of course will result in withdrawal request not processed. Kudos to Martin for testing and reporting this.

The order should be flipped.