### PR TITLE
Avoid CI running 2X for push within an internal PR

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
   documentation:
     name: Check documentation
     runs-on: ubuntu-latest
-    # don't run twice for a push within an internal PR
+    # Don't run twice for a push within an internal PR
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone airnode

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
   build:
     name: Build and lint Airnode
     runs-on: ubuntu-latest
-    # don't run twice for a push within an internal PR
+    # Don't run twice for a push within an internal PR
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone airnode

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,8 @@ jobs:
   documentation:
     name: Check documentation
     runs-on: ubuntu-latest
+    # don't run twice for a push within an internal PR
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone airnode
         uses: actions/checkout@master
@@ -34,6 +36,8 @@ jobs:
   build:
     name: Build and lint Airnode
     runs-on: ubuntu-latest
+    # don't run twice for a push within an internal PR
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone airnode
         uses: actions/checkout@v2


### PR DESCRIPTION
The idea, which is to run skip the Action run for an internal PR since it's already covered by `push`  (hence why the tests currently run twice), originated from a comment [within this thread](https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/5) and is currently being used [here](https://github.com/Dart-Code/Dart-Code/blob/master/.github/workflows/build-and-test.yml). 

Closes #295.

Update: you can see it worked in the "All checks have passed" section below where all of the `(pull_request)` steps are skipped, and all of the `push` steps were successful.