### PR TITLE
Add SelfServeRrpBeaconServerWhitelister Contract

### DIFF
--- a/packages/airnode-protocol/contracts/utils/SelfServeRrpBeaconServerWhitelister.sol
+++ b/packages/airnode-protocol/contracts/utils/SelfServeRrpBeaconServerWhitelister.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../rrp/requesters/RrpBeaconServer.sol";
+import "./interfaces/ISelfServeRrpBeaconServerWhitelister.sol";
+
+/// @title Contract that allows to whitlist readers on the RrpBeaconServer
+/// @dev The SelfServerRrpBeaconServerWhitelister contract has the WhitelistExpirationSetterRole
+/// and the IndefiniteWhitelisterRole of the RrpBeaconServer contract. The deployer of this contract
+/// can specify the beaconIds for which readers can whitelist themselves. The deployer(also the owner)
+/// can also add new beaconIds later for readers to self whitelist themselves.
+contract SelfServeRrpBeaconServerWhitelister is
+    Ownable,
+    ISelfServeRrpBeaconServerWhitelister
+{
+    address public rrpBeaconServer;
+
+    mapping(bytes32 => uint64) public beaconIdToExpirationTimestamp;
+    mapping(bytes32 => bool) public beaconIdToIndefiniteWhitelistStatus;
+
+    /// @param _rrpBeaconServer The RrpBeaconServer contract to whitelist readers on
+    /// @param _beaconIdsExpirationTimestamp Array of beaconIds that have an associated expiration timestamp
+    /// @param _expirationTimestamps Array of expiration timestamps that correspond to the beaconIds
+    /// @param _beaconIdsIndefiniteWhitelistStatus Array of beaconIds that have an associated indefinite whitelist status
+    /// @param _indefiniteWhitelistStatuses Array of indefinite whitelist status that correspond to the beaconIds
+    constructor(
+        address _rrpBeaconServer,
+        bytes32[] memory _beaconIdsExpirationTimestamp,
+        uint64[] memory _expirationTimestamps,
+        bytes32[] memory _beaconIdsIndefiniteWhitelistStatus,
+        bool[] memory _indefiniteWhitelistStatuses
+    ) {
+        require(_rrpBeaconServer != address(0), "RrpBeaconServer address zero");
+        rrpBeaconServer = _rrpBeaconServer;
+        for (
+            uint256 ind = 0;
+            ind < _beaconIdsExpirationTimestamp.length;
+            ind++
+        ) {
+            beaconIdToExpirationTimestamp[
+                _beaconIdsExpirationTimestamp[ind]
+            ] = _expirationTimestamps[ind];
+        }
+        for (
+            uint256 ind = 0;
+            ind < _beaconIdsIndefiniteWhitelistStatus.length;
+            ind++
+        ) {
+            beaconIdToIndefiniteWhitelistStatus[
+                _beaconIdsIndefiniteWhitelistStatus[ind]
+            ] = _indefiniteWhitelistStatuses[ind];
+        }
+    }
+
+    /// @notice Adds a new beaconId with an expiration timestamp
+    /// that can be whitelisted by readers
+    /// @param _beaconId The beaconId to set an expiration timestamp for
+    /// @param _expirationTimestamp The expiration timestamp for the beaconId
+    function setBeaconIdWithExpirationTimestamp(
+        bytes32 _beaconId,
+        uint64 _expirationTimestamp
+    ) external override onlyOwner {
+        beaconIdToExpirationTimestamp[_beaconId] = _expirationTimestamp;
+        emit SetBeaconIdWithExpirationTimestamp(
+            _beaconId,
+            _expirationTimestamp
+        );
+    }
+
+    /// @notice Adds a new beaconId with an indefinite whitelist status
+    /// that can be whitelisted by readers indefinetly
+    /// @param _beaconId The beaconId to set an indefinite whitelist status for
+    /// @param _indefiniteWhitelistStatus The indefinite whitelist status for the beaconId
+    function setBeaconIdWithIndefiniteWhitelistStatus(
+        bytes32 _beaconId,
+        bool _indefiniteWhitelistStatus
+    ) external override onlyOwner {
+        beaconIdToIndefiniteWhitelistStatus[
+            _beaconId
+        ] = _indefiniteWhitelistStatus;
+        emit SetBeaconIdWithIndefiniteWhitelistStatus(
+            _beaconId,
+            _indefiniteWhitelistStatus
+        );
+    }
+
+    /// @notice Whitelists a reader on the RrpBeaconServer with an expiration timestamp
+    /// @param _beaconId The beaconId to whitelist
+    /// @param _reader The reader to whitelist on the beaconId
+    function whitelistReaderWithExpiration(bytes32 _beaconId, address _reader)
+        external
+        override
+    {
+        uint64 expirationTimestamp = beaconIdToExpirationTimestamp[_beaconId];
+        require(
+            expirationTimestamp > block.timestamp,
+            "Cannot whitelist for beacon"
+        );
+        IRrpBeaconServer(rrpBeaconServer).setWhitelistExpiration(
+            _beaconId,
+            _reader,
+            expirationTimestamp
+        );
+        emit WhitelistedReaderWithExpiration(_beaconId, _reader);
+    }
+
+    /// @notice Whitelists a reader on the RrpBeaconServer with an indefinite whitelist status
+    /// @param _beaconId The beaconId to whitelist
+    /// @param _reader The reader to whitelist on the beaconId
+    function whitelistReaderIndefinitely(bytes32 _beaconId, address _reader)
+        external
+        override
+    {
+        require(
+            beaconIdToIndefiniteWhitelistStatus[_beaconId],
+            "Cannot whitelist indefinitely for beacon"
+        );
+        IRrpBeaconServer(rrpBeaconServer).setIndefiniteWhitelistStatus(
+            _beaconId,
+            _reader,
+            true
+        );
+        emit WhitelistedReaderIndefinitely(_beaconId, _reader);
+    }
+}

--- a/packages/airnode-protocol/contracts/utils/SelfServeRrpBeaconServerWhitelister.sol
+++ b/packages/airnode-protocol/contracts/utils/SelfServeRrpBeaconServerWhitelister.sol
@@ -6,9 +6,9 @@ import "../rrp/requesters/RrpBeaconServer.sol";
 import "./interfaces/ISelfServeRrpBeaconServerWhitelister.sol";
 
 /// @title Contract that allows to whitlist readers on the RrpBeaconServer
-/// @dev The SelfServerRrpBeaconServerWhitelister contract has the WhitelistExpirationSetterRole
+/// @dev The SelfServeRrpBeaconServerWhitelister contract has the WhitelistExpirationSetterRole
 /// and the IndefiniteWhitelisterRole of the RrpBeaconServer contract. The deployer of this contract
-/// can specify the beaconIds for which readers can whitelist themselves. The deployer(also the owner)
+/// can specify the beaconIds for which readers can whitelist themselves. The deployer (also the owner)
 /// can also add new beaconIds later for readers to self whitelist themselves.
 contract SelfServeRrpBeaconServerWhitelister is
     Ownable,
@@ -19,108 +19,105 @@ contract SelfServeRrpBeaconServerWhitelister is
     mapping(bytes32 => uint64) public beaconIdToExpirationTimestamp;
     mapping(bytes32 => bool) public beaconIdToIndefiniteWhitelistStatus;
 
-    /// @param _rrpBeaconServer The RrpBeaconServer contract to whitelist readers on
-    /// @param _beaconIdsExpirationTimestamp Array of beaconIds that have an associated expiration timestamp
-    /// @param _expirationTimestamps Array of expiration timestamps that correspond to the beaconIds
-    /// @param _beaconIdsIndefiniteWhitelistStatus Array of beaconIds that have an associated indefinite whitelist status
-    /// @param _indefiniteWhitelistStatuses Array of indefinite whitelist status that correspond to the beaconIds
+    /// @param rrpBeaconServerAddress The RrpBeaconServer contract to whitelist readers
+    /// @param beaconIdsExpirationTimestamp Array of beaconIds that have an associated expiration timestamp
+    /// @param expirationTimestamps Array of expiration timestamps that correspond to the beaconIds
+    /// @param beaconIdsIndefiniteWhitelistStatus Array of beaconIds that have an associated indefinite whitelist status
+    /// @param indefiniteWhitelistStatuses Array of indefinite whitelist status that correspond to the beaconIds
     constructor(
-        address _rrpBeaconServer,
-        bytes32[] memory _beaconIdsExpirationTimestamp,
-        uint64[] memory _expirationTimestamps,
-        bytes32[] memory _beaconIdsIndefiniteWhitelistStatus,
-        bool[] memory _indefiniteWhitelistStatuses
+        address rrpBeaconServerAddress,
+        bytes32[] memory beaconIdsExpirationTimestamp,
+        uint64[] memory expirationTimestamps,
+        bytes32[] memory beaconIdsIndefiniteWhitelistStatus,
+        bool[] memory indefiniteWhitelistStatuses
     ) {
-        require(_rrpBeaconServer != address(0), "RrpBeaconServer address zero");
-        rrpBeaconServer = _rrpBeaconServer;
+        require(
+            rrpBeaconServerAddress != address(0),
+            "RrpBeaconServer address zero"
+        );
+        rrpBeaconServer = rrpBeaconServerAddress;
         for (
             uint256 ind = 0;
-            ind < _beaconIdsExpirationTimestamp.length;
+            ind < beaconIdsExpirationTimestamp.length;
             ind++
         ) {
             beaconIdToExpirationTimestamp[
-                _beaconIdsExpirationTimestamp[ind]
-            ] = _expirationTimestamps[ind];
+                beaconIdsExpirationTimestamp[ind]
+            ] = expirationTimestamps[ind];
         }
         for (
             uint256 ind = 0;
-            ind < _beaconIdsIndefiniteWhitelistStatus.length;
+            ind < beaconIdsIndefiniteWhitelistStatus.length;
             ind++
         ) {
             beaconIdToIndefiniteWhitelistStatus[
-                _beaconIdsIndefiniteWhitelistStatus[ind]
-            ] = _indefiniteWhitelistStatuses[ind];
+                beaconIdsIndefiniteWhitelistStatus[ind]
+            ] = indefiniteWhitelistStatuses[ind];
         }
     }
 
     /// @notice Adds a new beaconId with an expiration timestamp
     /// that can be whitelisted by readers
-    /// @param _beaconId The beaconId to set an expiration timestamp for
-    /// @param _expirationTimestamp The expiration timestamp for the beaconId
+    /// @param beaconId The beaconId to set an expiration timestamp for
+    /// @param expirationTimestamp The expiration timestamp for the beaconId
     function setBeaconIdWithExpirationTimestamp(
-        bytes32 _beaconId,
-        uint64 _expirationTimestamp
+        bytes32 beaconId,
+        uint64 expirationTimestamp
     ) external override onlyOwner {
-        beaconIdToExpirationTimestamp[_beaconId] = _expirationTimestamp;
-        emit SetBeaconIdWithExpirationTimestamp(
-            _beaconId,
-            _expirationTimestamp
-        );
+        beaconIdToExpirationTimestamp[beaconId] = expirationTimestamp;
+        emit SetBeaconIdWithExpirationTimestamp(beaconId, expirationTimestamp);
     }
 
     /// @notice Adds a new beaconId with an indefinite whitelist status
     /// that can be whitelisted by readers indefinetly
-    /// @param _beaconId The beaconId to set an indefinite whitelist status for
-    /// @param _indefiniteWhitelistStatus The indefinite whitelist status for the beaconId
+    /// @param beaconId The beaconId to set an indefinite whitelist status for
+    /// @param indefiniteWhitelistStatus The indefinite whitelist status for the beaconId
     function setBeaconIdWithIndefiniteWhitelistStatus(
-        bytes32 _beaconId,
-        bool _indefiniteWhitelistStatus
+        bytes32 beaconId,
+        bool indefiniteWhitelistStatus
     ) external override onlyOwner {
         beaconIdToIndefiniteWhitelistStatus[
-            _beaconId
-        ] = _indefiniteWhitelistStatus;
+            beaconId
+        ] = indefiniteWhitelistStatus;
         emit SetBeaconIdWithIndefiniteWhitelistStatus(
-            _beaconId,
-            _indefiniteWhitelistStatus
+            beaconId,
+            indefiniteWhitelistStatus
         );
     }
 
     /// @notice Whitelists a reader on the RrpBeaconServer with an expiration timestamp
-    /// @param _beaconId The beaconId to whitelist
-    /// @param _reader The reader to whitelist on the beaconId
-    function whitelistReaderWithExpiration(bytes32 _beaconId, address _reader)
+    /// @param beaconId The beaconId to whitelist
+    /// @param reader The reader to whitelist on the beaconId
+    function whitelistReaderWithExpiration(bytes32 beaconId, address reader)
         external
         override
     {
-        uint64 expirationTimestamp = beaconIdToExpirationTimestamp[_beaconId];
-        require(
-            expirationTimestamp > block.timestamp,
-            "Cannot whitelist for beacon"
-        );
+        uint64 expirationTimestamp = beaconIdToExpirationTimestamp[beaconId];
+        require(expirationTimestamp > block.timestamp, "Cannot whitelist");
         IRrpBeaconServer(rrpBeaconServer).setWhitelistExpiration(
-            _beaconId,
-            _reader,
+            beaconId,
+            reader,
             expirationTimestamp
         );
-        emit WhitelistedReaderWithExpiration(_beaconId, _reader);
+        emit WhitelistedReaderWithExpiration(beaconId, reader);
     }
 
     /// @notice Whitelists a reader on the RrpBeaconServer with an indefinite whitelist status
-    /// @param _beaconId The beaconId to whitelist
-    /// @param _reader The reader to whitelist on the beaconId
-    function whitelistReaderIndefinitely(bytes32 _beaconId, address _reader)
+    /// @param beaconId The beaconId to whitelist
+    /// @param reader The reader to whitelist on the beaconId
+    function whitelistReaderIndefinitely(bytes32 beaconId, address reader)
         external
         override
     {
         require(
-            beaconIdToIndefiniteWhitelistStatus[_beaconId],
-            "Cannot whitelist indefinitely for beacon"
+            beaconIdToIndefiniteWhitelistStatus[beaconId],
+            "Cannot whitelist indefinitely"
         );
         IRrpBeaconServer(rrpBeaconServer).setIndefiniteWhitelistStatus(
-            _beaconId,
-            _reader,
+            beaconId,
+            reader,
             true
         );
-        emit WhitelistedReaderIndefinitely(_beaconId, _reader);
+        emit WhitelistedReaderIndefinitely(beaconId, reader);
     }
 }

--- a/packages/airnode-protocol/contracts/utils/SelfServeRrpBeaconServerWhitelister.sol
+++ b/packages/airnode-protocol/contracts/utils/SelfServeRrpBeaconServerWhitelister.sol
@@ -20,66 +20,38 @@ contract SelfServeRrpBeaconServerWhitelister is
     mapping(bytes32 => bool) public beaconIdToIndefiniteWhitelistStatus;
 
     /// @param rrpBeaconServerAddress The RrpBeaconServer contract to whitelist readers
-    /// @param beaconIdsExpirationTimestamp Array of beaconIds that have an associated expiration timestamp
-    /// @param expirationTimestamps Array of expiration timestamps that correspond to the beaconIds
-    /// @param beaconIdsIndefiniteWhitelistStatus Array of beaconIds that have an associated indefinite whitelist status
-    /// @param indefiniteWhitelistStatuses Array of indefinite whitelist status that correspond to the beaconIds
-    constructor(
-        address rrpBeaconServerAddress,
-        bytes32[] memory beaconIdsExpirationTimestamp,
-        uint64[] memory expirationTimestamps,
-        bytes32[] memory beaconIdsIndefiniteWhitelistStatus,
-        bool[] memory indefiniteWhitelistStatuses
-    ) {
+    constructor(address rrpBeaconServerAddress) {
         require(
             rrpBeaconServerAddress != address(0),
             "RrpBeaconServer address zero"
         );
         rrpBeaconServer = rrpBeaconServerAddress;
-        for (
-            uint256 ind = 0;
-            ind < beaconIdsExpirationTimestamp.length;
-            ind++
-        ) {
-            beaconIdToExpirationTimestamp[
-                beaconIdsExpirationTimestamp[ind]
-            ] = expirationTimestamps[ind];
-        }
-        for (
-            uint256 ind = 0;
-            ind < beaconIdsIndefiniteWhitelistStatus.length;
-            ind++
-        ) {
-            beaconIdToIndefiniteWhitelistStatus[
-                beaconIdsIndefiniteWhitelistStatus[ind]
-            ] = indefiniteWhitelistStatuses[ind];
-        }
     }
 
     /// @notice Adds a new beaconId with an expiration timestamp
     /// that can be whitelisted by readers
     /// @param beaconId The beaconId to set an expiration timestamp for
     /// @param expirationTimestamp The expiration timestamp for the beaconId
-    function setBeaconIdWithExpirationTimestamp(
+    function setBeaconIdToExpirationTimestamp(
         bytes32 beaconId,
         uint64 expirationTimestamp
     ) external override onlyOwner {
         beaconIdToExpirationTimestamp[beaconId] = expirationTimestamp;
-        emit SetBeaconIdWithExpirationTimestamp(beaconId, expirationTimestamp);
+        emit SetBeaconIdToExpirationTimestamp(beaconId, expirationTimestamp);
     }
 
     /// @notice Adds a new beaconId with an indefinite whitelist status
     /// that can be whitelisted by readers indefinetly
     /// @param beaconId The beaconId to set an indefinite whitelist status for
     /// @param indefiniteWhitelistStatus The indefinite whitelist status for the beaconId
-    function setBeaconIdWithIndefiniteWhitelistStatus(
+    function setBeaconIdToIndefiniteWhitelistStatus(
         bytes32 beaconId,
         bool indefiniteWhitelistStatus
     ) external override onlyOwner {
         beaconIdToIndefiniteWhitelistStatus[
             beaconId
         ] = indefiniteWhitelistStatus;
-        emit SetBeaconIdWithIndefiniteWhitelistStatus(
+        emit SetBeaconIdToIndefiniteWhitelistStatus(
             beaconId,
             indefiniteWhitelistStatus
         );
@@ -88,36 +60,33 @@ contract SelfServeRrpBeaconServerWhitelister is
     /// @notice Whitelists a reader on the RrpBeaconServer with an expiration timestamp
     /// @param beaconId The beaconId to whitelist
     /// @param reader The reader to whitelist on the beaconId
-    function whitelistReaderWithExpiration(bytes32 beaconId, address reader)
+    function whitelistReader(bytes32 beaconId, address reader)
         external
         override
     {
         uint64 expirationTimestamp = beaconIdToExpirationTimestamp[beaconId];
-        require(expirationTimestamp > block.timestamp, "Cannot whitelist");
+        bool indefiniteWhitelistStatus = beaconIdToIndefiniteWhitelistStatus[
+            beaconId
+        ];
+        require(
+            expirationTimestamp > block.timestamp || indefiniteWhitelistStatus,
+            "Cannot whitelist"
+        );
         IRrpBeaconServer(rrpBeaconServer).setWhitelistExpiration(
             beaconId,
             reader,
             expirationTimestamp
         );
-        emit WhitelistedReaderWithExpiration(beaconId, reader);
-    }
-
-    /// @notice Whitelists a reader on the RrpBeaconServer with an indefinite whitelist status
-    /// @param beaconId The beaconId to whitelist
-    /// @param reader The reader to whitelist on the beaconId
-    function whitelistReaderIndefinitely(bytes32 beaconId, address reader)
-        external
-        override
-    {
-        require(
-            beaconIdToIndefiniteWhitelistStatus[beaconId],
-            "Cannot whitelist indefinitely"
-        );
         IRrpBeaconServer(rrpBeaconServer).setIndefiniteWhitelistStatus(
             beaconId,
             reader,
-            true
+            indefiniteWhitelistStatus
         );
-        emit WhitelistedReaderIndefinitely(beaconId, reader);
+        emit WhitelistedReader(
+            beaconId,
+            reader,
+            expirationTimestamp,
+            indefiniteWhitelistStatus
+        );
     }
 }

--- a/packages/airnode-protocol/contracts/utils/interfaces/ISelfServeRrpBeaconServerWhitelister.sol
+++ b/packages/airnode-protocol/contracts/utils/interfaces/ISelfServeRrpBeaconServerWhitelister.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+interface ISelfServeRrpBeaconServerWhitelister {
+    event SetBeaconIdWithExpirationTimestamp(
+        bytes32 indexed beaconId,
+        uint64 expirationTimestamp
+    );
+    event SetBeaconIdWithIndefiniteWhitelistStatus(
+        bytes32 indexed beaconId,
+        bool indefiniteWhitelistStatus
+    );
+    event WhitelistedReaderWithExpiration(
+        bytes32 indexed beaconId,
+        address indexed reader
+    );
+    event WhitelistedReaderIndefinitely(
+        bytes32 indexed beaconId,
+        address indexed reader
+    );
+
+    function setBeaconIdWithExpirationTimestamp(
+        bytes32 _beaconId,
+        uint64 _expirationTimestamp
+    ) external;
+
+    function setBeaconIdWithIndefiniteWhitelistStatus(
+        bytes32 _beaconId,
+        bool _indefiniteWhitelistStatus
+    ) external;
+
+    function whitelistReaderWithExpiration(bytes32 _beaconId, address _reader)
+        external;
+
+    function whitelistReaderIndefinitely(bytes32 _beaconId, address _reader)
+        external;
+}

--- a/packages/airnode-protocol/contracts/utils/interfaces/ISelfServeRrpBeaconServerWhitelister.sol
+++ b/packages/airnode-protocol/contracts/utils/interfaces/ISelfServeRrpBeaconServerWhitelister.sol
@@ -2,36 +2,40 @@
 pragma solidity 0.8.9;
 
 interface ISelfServeRrpBeaconServerWhitelister {
-    event SetBeaconIdWithExpirationTimestamp(
+    event SetBeaconIdToExpirationTimestamp(
         bytes32 indexed beaconId,
         uint64 expirationTimestamp
     );
-    event SetBeaconIdWithIndefiniteWhitelistStatus(
+    event SetBeaconIdToIndefiniteWhitelistStatus(
         bytes32 indexed beaconId,
         bool indefiniteWhitelistStatus
     );
-    event WhitelistedReaderWithExpiration(
+    event WhitelistedReader(
         bytes32 indexed beaconId,
-        address indexed reader
-    );
-    event WhitelistedReaderIndefinitely(
-        bytes32 indexed beaconId,
-        address indexed reader
+        address indexed reader,
+        uint64 expirationTimestamp,
+        bool indefiniteWhitelistStatus
     );
 
-    function setBeaconIdWithExpirationTimestamp(
+    function setBeaconIdToExpirationTimestamp(
         bytes32 _beaconId,
         uint64 _expirationTimestamp
     ) external;
 
-    function setBeaconIdWithIndefiniteWhitelistStatus(
+    function setBeaconIdToIndefiniteWhitelistStatus(
         bytes32 _beaconId,
         bool _indefiniteWhitelistStatus
     ) external;
 
-    function whitelistReaderWithExpiration(bytes32 _beaconId, address _reader)
-        external;
+    function whitelistReader(bytes32 _beaconId, address _reader) external;
 
-    function whitelistReaderIndefinitely(bytes32 _beaconId, address _reader)
-        external;
+    function beaconIdToExpirationTimestamp(bytes32 _beaconId)
+        external
+        view
+        returns (uint64);
+
+    function beaconIdToIndefiniteWhitelistStatus(bytes32 _beaconId)
+        external
+        view
+        returns (bool);
 }

--- a/packages/airnode-protocol/test/utils/SelfServeRrpBeaconServerWhitelister.sol.js
+++ b/packages/airnode-protocol/test/utils/SelfServeRrpBeaconServerWhitelister.sol.js
@@ -320,7 +320,7 @@ describe('whitelistReaderWithExpiration', function () {
       const randomBeaconId = hre.ethers.utils.randomBytes(32);
       await expect(
         selfServeRrpBeaconServerWhitelister.whitelistReaderWithExpiration(randomBeaconId, roles.beaconReader.address)
-      ).to.be.revertedWith('Cannot whitelist for beacon');
+      ).to.be.revertedWith('Cannot whitelist');
     });
   });
 });
@@ -357,7 +357,7 @@ describe('whitelistReaderIndefinitely', function () {
       const randomBeaconId = hre.ethers.utils.randomBytes(32);
       await expect(
         selfServeRrpBeaconServerWhitelister.whitelistReaderIndefinitely(randomBeaconId, roles.beaconReader.address)
-      ).to.be.revertedWith('Cannot whitelist indefinitely for beacon');
+      ).to.be.revertedWith('Cannot whitelist indefinitely');
     });
   });
 });

--- a/packages/airnode-protocol/test/utils/SelfServeRrpBeaconServerWhitelister.sol.js
+++ b/packages/airnode-protocol/test/utils/SelfServeRrpBeaconServerWhitelister.sol.js
@@ -1,0 +1,363 @@
+/* globals context */
+const hre = require('hardhat');
+const { expect } = require('chai');
+const testUtils = require('../test-utils');
+
+let roles;
+let accessControlRegistry, airnodeRrp, rrpBeaconServer, selfServeRrpBeaconServerWhitelister;
+let rrpBeaconServerAdminRoleDescription = 'RrpBeaconServer admin';
+let adminRole;
+let airnodeAddress, airnodeMnemonic, airnodeXpub, airnodeWallet;
+let sponsorWalletAddress, sponsorWallet;
+let beaconIdExpirationTimeStamp, encodedTimestamp, encodedTimestamp2;
+let endpointId, endpointId2, templateParameters, templateId, templateId2, beaconParameters, beaconId, beaconId2;
+
+beforeEach(async () => {
+  const accounts = await hre.ethers.getSigners();
+  roles = {
+    deployer: accounts[0],
+    manager: accounts[1],
+    sponsor: accounts[6],
+    updateRequester: accounts[7],
+    beaconReader: accounts[8],
+    anotherBeaconReader: accounts[9],
+    randomPerson: accounts[10],
+  };
+  const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
+  accessControlRegistry = await accessControlRegistryFactory.deploy();
+  const airnodeRrpFactory = await hre.ethers.getContractFactory('AirnodeRrp', roles.deployer);
+  airnodeRrp = await airnodeRrpFactory.deploy();
+  const rrpBeaconServerFactory = await hre.ethers.getContractFactory('RrpBeaconServer', roles.deployer);
+  rrpBeaconServer = await rrpBeaconServerFactory.deploy(
+    accessControlRegistry.address,
+    rrpBeaconServerAdminRoleDescription,
+    roles.manager.address,
+    airnodeRrp.address
+  );
+  const selfServeRrpBeaconServerWhitelisterFactory = await hre.ethers.getContractFactory(
+    'SelfServeRrpBeaconServerWhitelister',
+    roles.manager
+  );
+
+  ({ airnodeAddress, airnodeMnemonic, airnodeXpub } = testUtils.generateRandomAirnodeWallet());
+  airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeMnemonic, "m/44'/60'/0'/0/0");
+  sponsorWalletAddress = testUtils.deriveSponsorWalletAddress(airnodeXpub, roles.sponsor.address);
+  await roles.deployer.sendTransaction({
+    to: sponsorWalletAddress,
+    value: hre.ethers.utils.parseEther('1'),
+  });
+  sponsorWallet = testUtils.deriveSponsorWallet(airnodeMnemonic, roles.sponsor.address).connect(hre.ethers.provider);
+  endpointId = testUtils.generateRandomBytes32();
+  endpointId2 = testUtils.generateRandomBytes32();
+  templateParameters = testUtils.generateRandomBytes();
+  await airnodeRrp.connect(roles.randomPerson).createTemplate(airnodeAddress, endpointId, templateParameters);
+  await airnodeRrp.connect(roles.randomPerson).createTemplate(airnodeAddress, endpointId2, templateParameters);
+  templateId = hre.ethers.utils.keccak256(
+    hre.ethers.utils.solidityPack(['address', 'bytes32', 'bytes'], [airnodeAddress, endpointId, templateParameters])
+  );
+  templateId2 = hre.ethers.utils.keccak256(
+    hre.ethers.utils.solidityPack(['address', 'bytes32', 'bytes'], [airnodeAddress, endpointId2, templateParameters])
+  );
+
+  beaconParameters = testUtils.generateRandomBytes();
+  beaconId = hre.ethers.utils.keccak256(
+    hre.ethers.utils.solidityPack(['bytes32', 'bytes'], [templateId, beaconParameters])
+  );
+  beaconId2 = hre.ethers.utils.keccak256(
+    hre.ethers.utils.solidityPack(['bytes32', 'bytes'], [templateId2, beaconParameters])
+  );
+
+  await airnodeRrp.connect(roles.sponsor).setSponsorshipStatus(rrpBeaconServer.address, true);
+  await rrpBeaconServer.connect(roles.sponsor).setUpdatePermissionStatus(roles.updateRequester.address, true);
+
+  // Compute the expected request ID
+  const requestId = hre.ethers.utils.keccak256(
+    hre.ethers.utils.solidityPack(
+      ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+      [
+        (await hre.ethers.provider.getNetwork()).chainId,
+        airnodeRrp.address,
+        rrpBeaconServer.address,
+        await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
+        templateId,
+        roles.sponsor.address,
+        sponsorWalletAddress,
+        rrpBeaconServer.address,
+        rrpBeaconServer.interface.getSighash('fulfill'),
+        beaconParameters,
+      ]
+    )
+  );
+  // Request the beacon update
+  await rrpBeaconServer
+    .connect(roles.updateRequester)
+    .requestBeaconUpdate(templateId, roles.sponsor.address, sponsorWalletAddress, beaconParameters);
+  // Fulfill
+  const now = (await hre.ethers.provider.getBlock(await hre.ethers.provider.getBlockNumber())).timestamp;
+  await hre.ethers.provider.send('evm_setNextBlockTimestamp', [now + 1]);
+  const encodedData = 123;
+  encodedTimestamp = now;
+  const data = hre.ethers.utils.defaultAbiCoder.encode(['int256', 'uint256'], [encodedData, encodedTimestamp]);
+  const signature = await airnodeWallet.signMessage(
+    hre.ethers.utils.arrayify(
+      hre.ethers.utils.keccak256(hre.ethers.utils.solidityPack(['bytes32', 'bytes'], [requestId, data]))
+    )
+  );
+  await airnodeRrp
+    .connect(sponsorWallet)
+    .fulfill(
+      requestId,
+      airnodeAddress,
+      rrpBeaconServer.address,
+      rrpBeaconServer.interface.getSighash('fulfill'),
+      data,
+      signature,
+      { gasLimit: 500000 }
+    );
+
+  // Setup another beaconId to read from
+
+  // Compute the expected request ID
+  const requestId2 = hre.ethers.utils.keccak256(
+    hre.ethers.utils.solidityPack(
+      ['uint256', 'address', 'address', 'uint256', 'bytes32', 'address', 'address', 'address', 'bytes4', 'bytes'],
+      [
+        (await hre.ethers.provider.getNetwork()).chainId,
+        airnodeRrp.address,
+        rrpBeaconServer.address,
+        await airnodeRrp.requesterToRequestCountPlusOne(rrpBeaconServer.address),
+        templateId2,
+        roles.sponsor.address,
+        sponsorWalletAddress,
+        rrpBeaconServer.address,
+        rrpBeaconServer.interface.getSighash('fulfill'),
+        beaconParameters,
+      ]
+    )
+  );
+
+  await rrpBeaconServer
+    .connect(roles.updateRequester)
+    .requestBeaconUpdate(templateId2, roles.sponsor.address, sponsorWalletAddress, beaconParameters);
+
+  const now2 = (await hre.ethers.provider.getBlock(await hre.ethers.provider.getBlockNumber())).timestamp;
+  beaconIdExpirationTimeStamp = now2 + 10;
+  await hre.ethers.provider.send('evm_setNextBlockTimestamp', [now2 + 1]);
+  const encodedData2 = 456;
+  encodedTimestamp2 = now2;
+  const data2 = hre.ethers.utils.defaultAbiCoder.encode(['int256', 'uint256'], [encodedData2, encodedTimestamp2]);
+  const signature2 = await airnodeWallet.signMessage(
+    hre.ethers.utils.arrayify(
+      hre.ethers.utils.keccak256(hre.ethers.utils.solidityPack(['bytes32', 'bytes'], [requestId2, data2]))
+    )
+  );
+  await airnodeRrp
+    .connect(sponsorWallet)
+    .fulfill(
+      requestId2,
+      airnodeAddress,
+      rrpBeaconServer.address,
+      rrpBeaconServer.interface.getSighash('fulfill'),
+      data2,
+      signature2,
+      { gasLimit: 500000 }
+    );
+
+  selfServeRrpBeaconServerWhitelister = await selfServeRrpBeaconServerWhitelisterFactory.deploy(
+    rrpBeaconServer.address,
+    [beaconId],
+    [beaconIdExpirationTimeStamp],
+    [beaconId2],
+    [true]
+  );
+
+  const managerRootRole = await accessControlRegistry.deriveRootRole(roles.manager.address);
+  adminRole = await rrpBeaconServer.adminRole();
+  await accessControlRegistry.connect(roles.manager).initializeAndGrantRoles(
+    [managerRootRole, adminRole, adminRole],
+    [
+      rrpBeaconServerAdminRoleDescription,
+      await rrpBeaconServer.WHITELIST_EXPIRATION_SETTER_ROLE_DESCRIPTION(),
+      await rrpBeaconServer.INDEFINITE_WHITELISTER_ROLE_DESCRIPTION(),
+    ],
+    [
+      roles.manager.address, // which will already have been granted the role
+      selfServeRrpBeaconServerWhitelister.address,
+      selfServeRrpBeaconServerWhitelister.address,
+    ]
+  );
+});
+
+describe('constructor', function () {
+  context('RrpBeaconServer address is not zero', function () {
+    it('constructs', async function () {
+      const selfServeRrpBeaconServerWhitelisterFactory = await hre.ethers.getContractFactory(
+        'SelfServeRrpBeaconServerWhitelister',
+        roles.deployer
+      );
+      const now = (await hre.ethers.provider.getBlock(await hre.ethers.provider.getBlockNumber())).timestamp;
+      const selfServeRrpBeaconServerWhitelister = await selfServeRrpBeaconServerWhitelisterFactory.deploy(
+        rrpBeaconServer.address,
+        [beaconId],
+        [now + 10],
+        [beaconId2],
+        [true]
+      );
+      expect(await selfServeRrpBeaconServerWhitelister.rrpBeaconServer()).to.equal(rrpBeaconServer.address);
+      expect(await selfServeRrpBeaconServerWhitelister.beaconIdToExpirationTimestamp(beaconId)).to.equal(now + 10);
+      expect(await selfServeRrpBeaconServerWhitelister.beaconIdToIndefiniteWhitelistStatus(beaconId2)).to.equal(true);
+    });
+  });
+  context('RrpBeaconServer address is zero', function () {
+    it('reverts', async function () {
+      const selfServeRrpBeaconServerWhitelisterFactory = await hre.ethers.getContractFactory(
+        'SelfServeRrpBeaconServerWhitelister',
+        roles.deployer
+      );
+      const now = (await hre.ethers.provider.getBlock(await hre.ethers.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfServeRrpBeaconServerWhitelisterFactory.deploy(
+          hre.ethers.constants.AddressZero,
+          [beaconId],
+          [now + 10],
+          [beaconId2],
+          [true]
+        )
+      ).to.be.revertedWith('RrpBeaconServer address zero');
+    });
+  });
+});
+
+describe('setBeaconIdWithExpirationTimestamp', function () {
+  context('caller is owner', function () {
+    it('sets the expiration timestamp for a beaconId', async function () {
+      const randomBeaconId = hre.ethers.utils.randomBytes(32);
+      expect(await selfServeRrpBeaconServerWhitelister.beaconIdToExpirationTimestamp(randomBeaconId)).to.equal(0);
+      const now = (await hre.ethers.provider.getBlock(await hre.ethers.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfServeRrpBeaconServerWhitelister
+          .connect(roles.manager)
+          .setBeaconIdWithExpirationTimestamp(randomBeaconId, now + 10)
+      ).to.emit(selfServeRrpBeaconServerWhitelister, 'SetBeaconIdWithExpirationTimestamp');
+
+      expect(await selfServeRrpBeaconServerWhitelister.beaconIdToExpirationTimestamp(randomBeaconId)).to.equal(
+        now + 10
+      );
+    });
+  });
+  context('caller is not owner', function () {
+    it('reverts', async function () {
+      const randomBeaconId = hre.ethers.utils.randomBytes(32);
+      const now = (await hre.ethers.provider.getBlock(await hre.ethers.provider.getBlockNumber())).timestamp;
+      await expect(
+        selfServeRrpBeaconServerWhitelister
+          .connect(roles.randomPerson)
+          .setBeaconIdWithExpirationTimestamp(randomBeaconId, now + 10)
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+  });
+});
+
+describe('setBeaconIdWithIndefiniteWhitelistStatus', function () {
+  context('caller is owner', function () {
+    it('sets the indefinite whitelist status for a beaconId', async function () {
+      const randomBeaconId = hre.ethers.utils.randomBytes(32);
+      expect(await selfServeRrpBeaconServerWhitelister.beaconIdToIndefiniteWhitelistStatus(randomBeaconId)).to.equal(
+        false
+      );
+      await expect(
+        selfServeRrpBeaconServerWhitelister
+          .connect(roles.manager)
+          .setBeaconIdWithIndefiniteWhitelistStatus(randomBeaconId, true)
+      ).to.emit(selfServeRrpBeaconServerWhitelister, 'SetBeaconIdWithIndefiniteWhitelistStatus');
+
+      expect(await selfServeRrpBeaconServerWhitelister.beaconIdToIndefiniteWhitelistStatus(randomBeaconId)).to.equal(
+        true
+      );
+    });
+  });
+  context('caller is not owner', function () {
+    it('reverts', async function () {
+      const randomBeaconId = hre.ethers.utils.randomBytes(32);
+      await expect(
+        selfServeRrpBeaconServerWhitelister
+          .connect(roles.randomPerson)
+          .setBeaconIdWithIndefiniteWhitelistStatus(randomBeaconId, true)
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+  });
+});
+
+describe('whitelistReaderWithExpiration', function () {
+  context('beaconId expirationTimestamp is valid', function () {
+    it('whitelists a reader', async function () {
+      await expect(rrpBeaconServer.connect(roles.beaconReader).readBeacon(beaconId)).to.be.revertedWith(
+        'Sender not whitelisted'
+      );
+
+      let whitelistStatus = await rrpBeaconServer.beaconIdToReaderToWhitelistStatus(
+        beaconId,
+        roles.beaconReader.address
+      );
+      expect(whitelistStatus.expirationTimestamp).to.equal(0);
+      expect(whitelistStatus.indefiniteWhitelistCount).to.equal(0);
+      await expect(
+        selfServeRrpBeaconServerWhitelister.whitelistReaderWithExpiration(beaconId, roles.beaconReader.address)
+      )
+        .to.emit(selfServeRrpBeaconServerWhitelister, 'WhitelistedReaderWithExpiration')
+        .withArgs(beaconId, roles.beaconReader.address);
+      whitelistStatus = await rrpBeaconServer.beaconIdToReaderToWhitelistStatus(beaconId, roles.beaconReader.address);
+      expect(whitelistStatus.expirationTimestamp).to.equal(beaconIdExpirationTimeStamp);
+      expect(whitelistStatus.indefiniteWhitelistCount).to.equal(0);
+
+      const beaconResponse = await rrpBeaconServer.connect(roles.beaconReader).readBeacon(beaconId);
+      expect(beaconResponse.value).to.equal(123);
+      expect(beaconResponse.timestamp).to.equal(encodedTimestamp);
+    });
+  });
+  context('beaconId expirationTimestamp is invalid', function () {
+    it('reverts', async function () {
+      const randomBeaconId = hre.ethers.utils.randomBytes(32);
+      await expect(
+        selfServeRrpBeaconServerWhitelister.whitelistReaderWithExpiration(randomBeaconId, roles.beaconReader.address)
+      ).to.be.revertedWith('Cannot whitelist for beacon');
+    });
+  });
+});
+
+describe('whitelistReaderIndefinitely', function () {
+  context('beaconId indefinite whitelist status is valid', function () {
+    it('whitelists a reader', async function () {
+      await expect(rrpBeaconServer.connect(roles.beaconReader).readBeacon(beaconId2)).to.be.revertedWith(
+        'Sender not whitelisted'
+      );
+
+      let whitelistStatus = await rrpBeaconServer.beaconIdToReaderToWhitelistStatus(
+        beaconId2,
+        roles.beaconReader.address
+      );
+      expect(whitelistStatus.expirationTimestamp).to.equal(0);
+      expect(whitelistStatus.indefiniteWhitelistCount).to.equal(0);
+      await expect(
+        selfServeRrpBeaconServerWhitelister.whitelistReaderIndefinitely(beaconId2, roles.beaconReader.address)
+      )
+        .to.emit(selfServeRrpBeaconServerWhitelister, 'WhitelistedReaderIndefinitely')
+        .withArgs(beaconId2, roles.beaconReader.address);
+      whitelistStatus = await rrpBeaconServer.beaconIdToReaderToWhitelistStatus(beaconId2, roles.beaconReader.address);
+      expect(whitelistStatus.expirationTimestamp).to.equal(0);
+      expect(whitelistStatus.indefiniteWhitelistCount).to.equal(1);
+
+      const beaconResponse = await rrpBeaconServer.connect(roles.beaconReader).readBeacon(beaconId2);
+      expect(beaconResponse.value).to.equal(456);
+      expect(beaconResponse.timestamp).to.equal(encodedTimestamp2);
+    });
+  });
+  context('beaconId indefinite whitelist status is invalid', function () {
+    it('reverts', async function () {
+      const randomBeaconId = hre.ethers.utils.randomBytes(32);
+      await expect(
+        selfServeRrpBeaconServerWhitelister.whitelistReaderIndefinitely(randomBeaconId, roles.beaconReader.address)
+      ).to.be.revertedWith('Cannot whitelist indefinitely for beacon');
+    });
+  });
+});


### PR DESCRIPTION
Main purpose of this contract is for readers to whitelist themselves. The contract is assumed to have the `indefiniteWhitelisterRole` and `WhitelistExpirationSetterRole`. 

There are two ways to whitelist:
1. With an expirationTimestamp
2. Indefinitely

A set of beaconIds are available for readers to be able to whitelist themselves for either 1 or 2 (different sets). The deployer(owner) can add/remove from the sets. 
 
I wasn't sure where to put the contracts, so I put it under `/utils`.