### PR TITLE
Revert In-lined Gas Price Call

### DIFF
--- a/packages/airnode-node/src/evm/gas-prices.ts
+++ b/packages/airnode-node/src/evm/gas-prices.ts
@@ -14,7 +14,7 @@ export const parsePriorityFee = ({ value, unit }: PriorityFee) => ethers.utils.p
 const getLegacyGasPrice = async (options: FetchOptions): Promise<LogsData<GasTarget | null>> => {
   const { provider } = options;
 
-  const [err, gasPrice] = await go(provider.getGasPrice, { retries: 1, timeoutMs: DEFAULT_RETRY_TIMEOUT_MS });
+  const [err, gasPrice] = await go(() => provider.getGasPrice(), { retries: 1, timeoutMs: DEFAULT_RETRY_TIMEOUT_MS });
   if (err || !gasPrice) {
     const log = logger.pend('ERROR', 'All attempts to get legacy gasPrice from provider failed');
     return [[log], null];


### PR DESCRIPTION
This adds a function wrapper around the gas pricing call, without this the underlying code references the wrong context.

Subject to testing by @jgcogsystematictrading

Fixes #798 