### PR TITLE
Add relay security schemes example integration

### DIFF
--- a/.changeset/famous-pigs-bathe.md
+++ b/.changeset/famous-pigs-bathe.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-examples': patch
+'@api3/airnode-validator': patch
+---
+
+Add relay security schemes example integration and fix missing relaySponsorAddress and relaySponsorWalletAddress in validator

--- a/packages/airnode-examples/README.md
+++ b/packages/airnode-examples/README.md
@@ -41,6 +41,8 @@ authenticated requests encoding multiple reserved parameters. The following list
 - [OpenWeather](https://github.com/api3dao/airnode/tree/master/packages/airnode-examples/integrations/weather-multi-value) -
   authenticated weather request encoding multiple parameters including the transaction timestamp, time of sunset,
   temperature, and a description of the weather.
+- [Relay security schemes](https://github.com/api3dao/airnode/tree/master/packages/airnode-examples/integrations/relay-security-schemes) -
+  demonstration of how to relay multiple request metadata like chain ID and sponsor address to the API endpoint.
 
 ## Setup
 

--- a/packages/airnode-examples/contracts/relay-security-schemes/Requester.sol
+++ b/packages/airnode-examples/contracts/relay-security-schemes/Requester.sol
@@ -1,0 +1,50 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequester.sol";
+
+// An example requester which expects the response from Airnode consists of multiple values.
+contract Requester is RrpRequester {
+    mapping(bytes32 => bool) public incomingFulfillments;
+    mapping(bytes32 => address) public requesterAddress;
+    mapping(bytes32 => address) public sponsorAddress;
+    mapping(bytes32 => address) public sponsorWalletAddress;
+    mapping(bytes32 => uint256) public chainId;
+    mapping(bytes32 => bytes32) public chainType;
+
+    constructor(address airnodeAddress) RrpRequester(airnodeAddress) {}
+
+    function makeRequest(
+        address airnode,
+        bytes32 endpointId,
+        address sponsor,
+        address sponsorWallet,
+        bytes calldata parameters
+    ) external {
+        bytes32 requestId = airnodeRrp.makeFullRequest(
+            airnode,
+            endpointId,
+            sponsor,
+            sponsorWallet,
+            address(this),
+            this.fulfill.selector,
+            parameters
+        );
+        incomingFulfillments[requestId] = true;
+    }
+
+    function fulfill(bytes32 requestId, bytes calldata data)
+        external
+        onlyAirnodeRrp
+    {
+        require(incomingFulfillments[requestId], "No such request made");
+        delete incomingFulfillments[requestId];
+        (address v1, address v2, address v3, uint256 v4, bytes32 v5) = abi
+            .decode(data, (address, address, address, uint256, bytes32));
+        requesterAddress[requestId] = v1;
+        sponsorAddress[requestId] = v2;
+        sponsorWalletAddress[requestId] = v3;
+        chainId[requestId] = v4;
+        chainType[requestId] = v5;
+    }
+}

--- a/packages/airnode-examples/integrations/relay-security-schemes/README.md
+++ b/packages/airnode-examples/integrations/relay-security-schemes/README.md
@@ -2,9 +2,9 @@
 
 This example highlights how Airnode can relay request metadata, like the chain ID or sponsor address, to the API
 endpoint via security schemes. In order to demonstrate this functionality in a realistic way, the API endpoint used is
-httpbin.org, which simply responds with request headers and query parameters in JSON format. This behavior allows
-request metadata returned in the API response to be fulfilled by Airnode on-chain as proof that the metadata is being
-relayed as expected.
+[httpbin.org](https://httpbin.org/), which simply responds with request headers and query parameters in JSON format.
+This behavior allows request metadata returned in the API response to be fulfilled by Airnode on-chain as proof that the
+metadata is being relayed as expected.
 
 The following security scheme types illustrate the request metadata being relayed:
 

--- a/packages/airnode-examples/integrations/relay-security-schemes/README.md
+++ b/packages/airnode-examples/integrations/relay-security-schemes/README.md
@@ -1,0 +1,18 @@
+# Relay security schemes example integration
+
+This example highlights how Airnode can relay request metadata, like the chain ID or sponsor address, to the API
+endpoint via security schemes. In order to demonstrate this functionality in a realistic way, the API endpoint used is
+httpbin.org, which simply responds with request headers and query parameters in JSON format. This behavior allows
+request metadata returned in the API response to be fulfilled by Airnode on-chain as proof that the metadata is being
+relayed as expected.
+
+The following security scheme types illustrate the request metadata being relayed:
+
+- relayRequesterAddress
+- relaySponsorAddress
+- relaySponsorWalletAddress
+- relayChainId
+- relayChainType
+
+For more information on supported security schemes, refer to the
+[docs](https://docs.api3.org/airnode/latest/grp-providers/guides/build-an-airnode/api-security.html).

--- a/packages/airnode-examples/integrations/relay-security-schemes/README.md
+++ b/packages/airnode-examples/integrations/relay-security-schemes/README.md
@@ -6,7 +6,8 @@ endpoint via security schemes. In order to demonstrate this functionality in a r
 This behavior allows request metadata returned in the API response to be fulfilled by Airnode on-chain as proof that the
 metadata is being relayed as expected.
 
-The following security scheme types illustrate the request metadata being relayed:
+The following security scheme types illustrate the request metadata being relayed and, as shown in `config.json`,
+demonstrate how the value can be sent via `query`, `header`, and `cookie`:
 
 - relayRequesterAddress
 - relaySponsorAddress

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -90,7 +90,7 @@
               "name": "chainId"
             },
             "relayChainType": {
-              "in": "query",
+              "in": "cookie",
               "type": "relayChainType",
               "name": "chainType"
             }
@@ -119,7 +119,7 @@
             },
             {
               "name": "_path",
-              "fixed": "headers.Requesteraddress,args.sponsorAddress,args.sponsorWalletAddress,args.chainId,args.chainType"
+              "fixed": "headers.Requesteraddress,args.sponsorAddress,args.sponsorWalletAddress,args.chainId,headers.Cookie"
             },
             {
               "name": "_times",

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -1,0 +1,135 @@
+{
+  "chains": [
+    {
+      "maxConcurrency": 100,
+      "authorizers": [],
+      "contracts": {
+        "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+      },
+      "id": "31337",
+      "providers": {
+        "exampleProvider": {
+          "url": "${PROVIDER_URL}"
+        }
+      },
+      "type": "evm",
+      "options": {
+        "txType": "eip1559",
+        "baseFeeMultiplier": "2",
+        "priorityFee": {
+          "value": "3.12",
+          "unit": "gwei"
+        }
+      }
+    }
+  ],
+  "nodeSettings": {
+    "cloudProvider": {
+      "type": "local"
+    },
+    "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
+    "heartbeat": {
+      "enabled": false
+    },
+    "httpGateway": {
+      "enabled": false
+    },
+    "logFormat": "plain",
+    "logLevel": "INFO",
+    "nodeVersion": "0.4.0",
+    "stage": "dev",
+    "skipValidation": true
+  },
+  "triggers": {
+    "rrp": [
+      {
+        "endpointId": "0x825a9b8e4e78772cd07cc4307de6737b67cf6d624fff2fa56f71318e479f624b",
+        "oisTitle": "Relay Security Schemes via httpbin",
+        "endpointName": "httpbinRelaySecuritySchemes"
+      }
+    ]
+  },
+  "ois": [
+    {
+      "oisFormat": "1.0.0",
+      "title": "Relay Security Schemes via httpbin",
+      "version": "1.0.0",
+      "apiSpecifications": {
+        "servers": [
+          {
+            "url": "https://httpbin.org"
+          }
+        ],
+        "paths": {
+          "/get": {
+            "get": {
+              "parameters": []
+            }
+          }
+        },
+        "components": {
+          "securitySchemes": {
+            "relayRequesterAddress": {
+              "in": "header",
+              "type": "relayRequesterAddress",
+              "name": "requesterAddress"
+            },
+            "relaySponsorAddress": {
+              "in": "query",
+              "type": "relaySponsorAddress",
+              "name": "sponsorAddress"
+            },
+            "relaySponsorWalletAddress": {
+              "in": "query",
+              "type": "relaySponsorWalletAddress",
+              "name": "sponsorWalletAddress"
+            },
+            "relayChainId": {
+              "in": "query",
+              "type": "relayChainId",
+              "name": "chainId"
+            },
+            "relayChainType": {
+              "in": "query",
+              "type": "relayChainType",
+              "name": "chainType"
+            }
+          }
+        },
+        "security": {
+          "relayChainId": [],
+          "relayChainType": [],
+          "relayRequesterAddress": [],
+          "relaySponsorAddress": [],
+          "relaySponsorWalletAddress": []
+        }
+      },
+      "endpoints": [
+        {
+          "name": "httpbinRelaySecuritySchemes",
+          "operation": {
+            "method": "get",
+            "path": "/get"
+          },
+          "fixedOperationParameters": [],
+          "reservedParameters": [
+            {
+              "name": "_type",
+              "fixed": "address,address,address,uint256,string32"
+            },
+            {
+              "name": "_path",
+              "fixed": "headers.Requesteraddress,args.sponsorAddress,args.sponsorWalletAddress,args.chainId,args.chainType"
+            },
+            {
+              "name": "_times",
+              "fixed": ""
+            }
+          ],
+          "parameters": []
+        }
+      ]
+    }
+  ],
+  "apiCredentials": []
+}

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -123,7 +123,7 @@
             },
             {
               "name": "_times",
-              "fixed": ""
+              "fixed": ",,,,"
             }
           ],
           "parameters": []

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -131,7 +131,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
             },
             {
               name: '_times',
-              fixed: '',
+              fixed: ',,,,',
             },
           ],
           parameters: [],

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -97,7 +97,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
               name: 'chainId',
             },
             relayChainType: {
-              in: 'query',
+              in: 'cookie',
               type: 'relayChainType',
               name: 'chainType',
             },
@@ -127,7 +127,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
             {
               name: '_path',
               fixed:
-                'headers.Requesteraddress,args.sponsorAddress,args.sponsorWalletAddress,args.chainId,args.chainType',
+                'headers.Requesteraddress,args.sponsorAddress,args.sponsorWalletAddress,args.chainId,headers.Cookie',
             },
             {
               name: '_times',

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -1,0 +1,150 @@
+import { Config } from '@api3/airnode-node';
+import {
+  createCloudProviderConfiguration,
+  createNodeVersion,
+  generateConfigFile,
+  getAirnodeRrpAddress,
+  getChainId,
+} from '../config-utils';
+
+const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
+  chains: [
+    {
+      maxConcurrency: 100,
+      authorizers: [],
+      contracts: {
+        AirnodeRrp: await getAirnodeRrpAddress(generateExampleFile),
+      },
+      id: await getChainId(generateExampleFile),
+      providers: {
+        exampleProvider: {
+          url: '${PROVIDER_URL}',
+        },
+      },
+      type: 'evm',
+      options: {
+        txType: 'eip1559',
+        baseFeeMultiplier: '2',
+        priorityFee: {
+          value: '3.12',
+          unit: 'gwei',
+        },
+      },
+    },
+  ],
+  nodeSettings: {
+    cloudProvider: createCloudProviderConfiguration(generateExampleFile),
+    airnodeWalletMnemonic: '${AIRNODE_WALLET_MNEMONIC}',
+    heartbeat: {
+      enabled: false,
+    },
+    httpGateway: {
+      enabled: false,
+    },
+    logFormat: 'plain',
+    logLevel: 'INFO',
+    nodeVersion: createNodeVersion(),
+    stage: 'dev',
+    skipValidation: true,
+  },
+  triggers: {
+    rrp: [
+      {
+        endpointId: '0x825a9b8e4e78772cd07cc4307de6737b67cf6d624fff2fa56f71318e479f624b',
+        oisTitle: 'Relay Security Schemes via httpbin',
+        endpointName: 'httpbinRelaySecuritySchemes',
+      },
+    ],
+  },
+  ois: [
+    {
+      oisFormat: '1.0.0',
+      title: 'Relay Security Schemes via httpbin',
+      version: '1.0.0',
+      apiSpecifications: {
+        servers: [
+          {
+            url: 'https://httpbin.org',
+          },
+        ],
+        paths: {
+          '/get': {
+            get: {
+              parameters: [],
+            },
+          },
+        },
+        components: {
+          securitySchemes: {
+            relayRequesterAddress: {
+              in: 'header',
+              type: 'relayRequesterAddress',
+              name: 'requesterAddress',
+            },
+            relaySponsorAddress: {
+              in: 'query',
+              type: 'relaySponsorAddress',
+              name: 'sponsorAddress',
+            },
+            relaySponsorWalletAddress: {
+              in: 'query',
+              type: 'relaySponsorWalletAddress',
+              name: 'sponsorWalletAddress',
+            },
+            relayChainId: {
+              in: 'query',
+              type: 'relayChainId',
+              name: 'chainId',
+            },
+            relayChainType: {
+              in: 'query',
+              type: 'relayChainType',
+              name: 'chainType',
+            },
+          },
+        },
+        security: {
+          relayChainId: [],
+          relayChainType: [],
+          relayRequesterAddress: [],
+          relaySponsorAddress: [],
+          relaySponsorWalletAddress: [],
+        },
+      },
+      endpoints: [
+        {
+          name: 'httpbinRelaySecuritySchemes',
+          operation: {
+            method: 'get',
+            path: '/get',
+          },
+          fixedOperationParameters: [],
+          reservedParameters: [
+            {
+              name: '_type',
+              fixed: 'address,address,address,uint256,string32',
+            },
+            {
+              name: '_path',
+              fixed:
+                'headers.Requesteraddress,args.sponsorAddress,args.sponsorWalletAddress,args.chainId,args.chainType',
+            },
+            {
+              name: '_times',
+              fixed: '',
+            },
+          ],
+          parameters: [],
+        },
+      ],
+    },
+  ],
+  apiCredentials: [],
+});
+
+const generateConfig = async (generateExampleFile = false) => {
+  const config = await createConfig(generateExampleFile);
+  generateConfigFile(__dirname, config, generateExampleFile);
+};
+
+export default generateConfig;

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-secrets.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-secrets.ts
@@ -1,0 +1,9 @@
+import { getCommonSecrets, writeSecrets } from '../secrets-utils';
+
+const createSecrets = async (generateExampleFile = false) => {
+  const secrets = await getCommonSecrets(generateExampleFile);
+
+  writeSecrets(__dirname, secrets, generateExampleFile);
+};
+
+export default createSecrets;

--- a/packages/airnode-examples/integrations/relay-security-schemes/request-utils.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/request-utils.ts
@@ -13,7 +13,11 @@ export const printResponse = async (requestId: string) => {
   const sponsorAddress = await requester.sponsorAddress(requestId);
   const sponsorWalletAddress = await requester.sponsorWalletAddress(requestId);
   const chainId = await requester.chainId(requestId);
-  const chainType = ethers.utils.parseBytes32String(await requester.chainType(requestId));
+  // decode and extract chain from API response `chainType=evm;`
+  const chainType = ethers.utils
+    .parseBytes32String(await requester.chainType(requestId))
+    .split('=')[1]
+    .split(';')[0];
 
   cliPrint.info(`The following was successfully relayed:
     requesterAddress: ${requesterAddress}

--- a/packages/airnode-examples/integrations/relay-security-schemes/request-utils.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/request-utils.ts
@@ -1,0 +1,24 @@
+import { ethers } from 'ethers';
+import { cliPrint, getDeployedContract, readIntegrationInfo } from '../../src';
+
+export const getEncodedParameters = () => {
+  return '0x';
+};
+
+export const printResponse = async (requestId: string) => {
+  const integrationInfo = readIntegrationInfo();
+  const requester = await getDeployedContract(`contracts/${integrationInfo.integration}/Requester.sol`);
+
+  const requesterAddress = await requester.requesterAddress(requestId);
+  const sponsorAddress = await requester.sponsorAddress(requestId);
+  const sponsorWalletAddress = await requester.sponsorWalletAddress(requestId);
+  const chainId = await requester.chainId(requestId);
+  const chainType = ethers.utils.parseBytes32String(await requester.chainType(requestId));
+
+  cliPrint.info(`The following was successfully relayed:
+    requesterAddress: ${requesterAddress}
+    sponsorAddress: ${sponsorAddress}
+    sponsorWalletAddress: ${sponsorWalletAddress}
+    chainId: ${chainId}
+    chainType: ${chainType}`);
+};

--- a/packages/airnode-examples/integrations/relay-security-schemes/secrets.example.env
+++ b/packages/airnode-examples/integrations/relay-security-schemes/secrets.example.env
@@ -1,0 +1,2 @@
+AIRNODE_WALLET_MNEMONIC=tube spin artefact salad slab lumber foot bitter wash reward vote cook
+PROVIDER_URL=http://127.0.0.1:8545/

--- a/packages/airnode-validator/src/validators/validators.test.ts
+++ b/packages/airnode-validator/src/validators/validators.test.ts
@@ -531,7 +531,7 @@ describe('validators integration test', () => {
       valid: false,
       messages: [
         error(
-          'components.securitySchemes.mySecurityScheme.type: Allowed values are "apiKey", "http", "relayChainId", "relayChainType" or "relayRequesterAddress"'
+          'components.securitySchemes.mySecurityScheme.type: Allowed values are "apiKey", "http", "relayChainId", "relayChainType", "relayRequesterAddress", "relaySponsorAddress", or "relaySponsorWalletAddress"'
         ),
         error(
           'components.securitySchemes.mySecurityScheme2 must contain "name" and "in" since value of "type" is "apiKey"'

--- a/packages/airnode-validator/templates/1.0/apiSpecifications.json
+++ b/packages/airnode-validator/templates/1.0/apiSpecifications.json
@@ -68,15 +68,15 @@
     "securitySchemes": {
       "__objectItem": {
         "type": {
-          "__regexp": "^(apiKey|http|relayChainId|relayChainType|relayRequesterAddress)$",
+          "__regexp": "^(apiKey|http|relayChainId|relayChainType|relayRequesterAddress|relaySponsorAddress|relaySponsorWalletAddress)$",
           "__catch": {
-            "__message": "__fullPath: Allowed values are \"apiKey\", \"http\", \"relayChainId\", \"relayChainType\" or \"relayRequesterAddress\""
+            "__message": "__fullPath: Allowed values are \"apiKey\", \"http\", \"relayChainId\", \"relayChainType\", \"relayRequesterAddress\", \"relaySponsorAddress\", or \"relaySponsorWalletAddress\""
           }
         },
         "__conditions": [
           {
             "__if": {
-              "type": "^(apiKey|relayChainId|relayChainType|relayRequesterAddress)$"
+              "type": "^(apiKey|relayChainId|relayChainType|relayRequesterAddress|relaySponsorAddress|relaySponsorWalletAddress)$"
             },
             "__then": {
               "name": {},
@@ -120,7 +120,7 @@
             },
             "__then": {
               "type": {
-                "__regexp": "^(apiKey|relayChainId|relayChainType|relayRequesterAddress)$",
+                "__regexp": "^(apiKey|relayChainId|relayChainType|relayRequesterAddress|relaySponsorAddress|relaySponsorWalletAddress)$",
                 "__catch": {
                   "__level": "error"
                 }
@@ -137,7 +137,7 @@
             },
             "__then": {
               "type": {
-                "__regexp": "^(apiKey|relayChainId|relayChainType|relayRequesterAddress)$",
+                "__regexp": "^(apiKey|relayChainId|relayChainType|relayRequesterAddress|relaySponsorAddress|relaySponsorWalletAddress)$",
                 "__catch": {
                   "__level": "error"
                 }


### PR DESCRIPTION
[AN-511](https://api3dao.atlassian.net/browse/AN-511)

Note the name `relay-security-schemes` was chosen as this is the nomenclature [used in the docs](https://docs.api3.org/airnode/v0.4/grp-providers/guides/build-an-airnode/api-security.html#supported-security-schemes).

Ignore the failing docs link check in CI- this will pass once merged.

Here is how the output looks:

```
> yarn make-request
yarn run v1.22.11
$ ts-node scripts/make-request.ts
Making request...
Waiting for fulfillment...
Request fulfilled
The following was successfully relayed:
    requesterAddress: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
    sponsorAddress: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
    sponsorWalletAddress: 0x68F7F1197a9FD5f2EC79B4eBff2879A1dc1fe78f
    chainId: 31337
    chainType: evm
Done in 20.31s.
```