### PR TITLE
Fix airnode-examples for windows

### DIFF
--- a/.changeset/thin-parents-wash.md
+++ b/.changeset/thin-parents-wash.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-examples': patch
+---
+
+Fix airnode examples for Windows

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,9 +55,6 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install Dependencies
         run: yarn run bootstrap
-      - name: Prepare config
-        run: |
-          cp packages/airnode-deployer/config/config.json.example packages/airnode-deployer/config/config.json
       - name: Build
         run: yarn run build
       - name: Lint code

--- a/packages/airnode-examples/README.md
+++ b/packages/airnode-examples/README.md
@@ -152,7 +152,9 @@ yarn create-airnode-secrets
 > If you are using docker for Windows/WSL or docker for mac and you want to connect to your local hardhat network, you
 > will need to modify the generated `secrets.env` file found in `integrations/<integration-name>/` by replacing the
 > provider URL with the following: `PROVIDER_URL=http://host.docker.internal:8545`. This is a docker limitation. See:
-> https://stackoverflow.com/a/24326540
+> https://stackoverflow.com/a/24326540.
+>
+> The `create-airnode-secrets` script will handle this for you.
 
 Refer to the
 [documentation](https://docs.api3.org/airnode/latest/grp-providers/guides/build-an-airnode/configuring-airnode.html) for

--- a/packages/airnode-examples/package.json
+++ b/packages/airnode-examples/package.json
@@ -30,12 +30,13 @@
     "test:e2e": "jest --selectProjects e2e"
   },
   "dependencies": {
-    "@api3/airnode-admin": "^0.4.0",
     "@api3/airnode-abi": "^0.4.0",
+    "@api3/airnode-admin": "^0.4.0",
     "@api3/airnode-deployer": "^0.4.0",
     "@api3/airnode-node": "^0.4.0",
     "@api3/airnode-protocol": "^0.4.0",
-    "ethers": "^5.4.4"
+    "ethers": "^5.4.4",
+    "is-wsl": "^2.2.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/packages/airnode-examples/scripts/create-airnode-secrets.ts
+++ b/packages/airnode-examples/scripts/create-airnode-secrets.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import isWsl from 'is-wsl';
-import { cliPrint, readIntegrationInfo, runAndHandleErrors } from '../src';
+import { readIntegrationInfo, runAndHandleErrors } from '../src';
 
 const isMacOrWindows = () => process.platform === 'win32' || process.platform === 'darwin' || isWsl;
 
@@ -20,14 +20,6 @@ const main = async () => {
     writeFileSync(
       secretsPath,
       rawSecrets.replace('PROVIDER_URL=http://127.0.0.1:8545/', 'PROVIDER_URL=http://host.docker.internal:8545')
-    );
-
-    cliPrint.warning(
-      [
-        '',
-        `We have detected that you are on Windows/WSL or MacOS platform and have set the PROVIDER_URL to http://host.docker.internal:8545.`,
-        `See: https://stackoverflow.com/a/24326540 for more information.`,
-      ].join('\n')
     );
   }
 };

--- a/packages/airnode-examples/scripts/create-airnode-secrets.ts
+++ b/packages/airnode-examples/scripts/create-airnode-secrets.ts
@@ -1,4 +1,9 @@
-import { readIntegrationInfo, runAndHandleErrors } from '../src';
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import isWsl from 'is-wsl';
+import { cliPrint, readIntegrationInfo, runAndHandleErrors } from '../src';
+
+const isMacOrWindows = () => process.platform === 'win32' || process.platform === 'darwin' || isWsl;
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
@@ -6,6 +11,25 @@ const main = async () => {
   // details.
   const createSecrets = await import(`../integrations/${integrationInfo.integration}/create-secrets.ts`);
   await createSecrets.default();
+
+  // Windows and MacOS docker users need to change the provider URL if running airnode client on localhost network. See:
+  // https://stackoverflow.com/a/24326540 for more information.
+  if (integrationInfo.network === 'localhost' && integrationInfo.airnodeType === 'local' && isMacOrWindows()) {
+    const secretsPath = join(__dirname, `../integrations/`, integrationInfo.integration, `secrets.env`);
+    const rawSecrets = readFileSync(secretsPath).toString();
+    writeFileSync(
+      secretsPath,
+      rawSecrets.replace('PROVIDER_URL=http://127.0.0.1:8545/', 'PROVIDER_URL=http://host.docker.internal:8545')
+    );
+
+    cliPrint.warning(
+      [
+        '',
+        `We have detected that you are on Windows/WSL or MacOS platform and have set the PROVIDER_URL to http://host.docker.internal:8545.`,
+        `See: https://stackoverflow.com/a/24326540 for more information.`,
+      ].join('\n')
+    );
+  }
 };
 
 runAndHandleErrors(main);

--- a/packages/airnode-examples/scripts/derive-and-fund-sponsor-wallet.ts
+++ b/packages/airnode-examples/scripts/derive-and-fund-sponsor-wallet.ts
@@ -7,11 +7,11 @@ const main = async () => {
   const airnodeWallet = getAirnodeWallet();
   const provider = getProvider();
   const sponsor = ethers.Wallet.fromMnemonic(integrationInfo.mnemonic).connect(provider);
-  // NOTE: When doing this manually, you can use the 'derive-airnode-xpub' from the admin CLI package
+  // NOTE: When doing this manually, you can use the 'derive-airnode-xpub' command from the admin CLI package
   const airnodeXpub = deriveAirnodeXpub(airnodeWallet.mnemonic.phrase);
 
   // Derive the sponsor wallet address programatically
-  // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' from the admin CLI package
+  // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' command from the admin CLI package
   const sponsorWalletAddress = await deriveSponsorWalletAddress(airnodeXpub, airnodeWallet.address, sponsor.address);
 
   // Fund the derived sponsor wallet using sponsor account

--- a/packages/airnode-examples/scripts/make-request.ts
+++ b/packages/airnode-examples/scripts/make-request.ts
@@ -40,8 +40,8 @@ const makeRequest = async (): Promise<string> => {
   const sponsor = ethers.Wallet.fromMnemonic(integrationInfo.mnemonic);
   // NOTE: The request is always made to the first endpoint listed in the "triggers.rrp" inside config.json
   const endpointId = readConfig().triggers.rrp[0].endpointId;
-  // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' and 'derive-airnode-xpub' from the
-  // admin CLI package
+  // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' and 'derive-airnode-xpub' commands
+  // from the admin CLI package
   const sponsorWalletAddress = await deriveSponsorWalletAddress(
     deriveAirnodeXpub(airnodeWallet.mnemonic.phrase),
     airnodeWallet.address,

--- a/packages/airnode-examples/scripts/make-withdrawal-request.ts
+++ b/packages/airnode-examples/scripts/make-withdrawal-request.ts
@@ -24,14 +24,14 @@ const makeWithdrawalRequest = async (): Promise<string> => {
   const airnodeWallet = getAirnodeWallet();
   const sponsor = ethers.Wallet.fromMnemonic(integrationInfo.mnemonic);
   const sponsorWalletAddress = await deriveSponsorWalletAddress(
-    // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' and 'derive-airnode-xpub' from
-    // the admin CLI package
+    // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' and 'derive-airnode-xpub'
+    // commands from the admin CLI package
     deriveAirnodeXpub(airnodeWallet.mnemonic.phrase),
     airnodeWallet.address,
     sponsor.address
   );
 
-  // NOTE: You can use 'request-withdrawal' from the admin CLI package
+  // NOTE: You can use 'request-withdrawal' command from the admin CLI package
   const withdrawalRequestId = await requestWithdrawal(
     useAirnodeRrp(airnodeRrp),
     airnodeWallet.address,
@@ -45,8 +45,8 @@ const printWalletBalances = async () => {
   const airnodeWallet = getAirnodeWallet();
   const sponsor = ethers.Wallet.fromMnemonic(integrationInfo.mnemonic);
   const sponsorWalletAddress = await deriveSponsorWalletAddress(
-    // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' and 'derive-airnode-xpub' from
-    // the admin CLI package
+    // NOTE: When doing this manually, you can use the 'derive-sponsor-wallet-address' and 'derive-airnode-xpub'
+    // commands from the admin CLI package
     deriveAirnodeXpub(airnodeWallet.mnemonic.phrase),
     airnodeWallet.address,
     sponsor.address

--- a/packages/airnode-examples/scripts/sponsor-requester.ts
+++ b/packages/airnode-examples/scripts/sponsor-requester.ts
@@ -1,18 +1,15 @@
-import { getDeployedContract, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
+import { sponsorRequester, useAirnodeRrp } from '@api3/airnode-admin';
+import { cliPrint, getDeployedContract, getUserWallet, readIntegrationInfo, runAndHandleErrors } from '../src';
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
   const airnodeRrp = await getDeployedContract('@api3/airnode-protocol/contracts/rrp/AirnodeRrp.sol');
   const requester = await getDeployedContract(`contracts/${integrationInfo.integration}/Requester.sol`);
+  const userWallet = getUserWallet();
 
-  const command = [
-    `yarn airnode-admin sponsor-requester`,
-    `--provider-url ${integrationInfo.providerUrl}`,
-    `--airnode-rrp-address ${airnodeRrp.address}`,
-    `--requester-address ${requester.address}`,
-    `--sponsor-mnemonic "${integrationInfo.mnemonic}"`,
-  ].join(' ');
-  runShellCommand(command);
+  // NOTE: When doing this manually, you can use the 'sponsor-requester' command from the admin CLI package
+  const requesterAddress = await sponsorRequester(useAirnodeRrp(airnodeRrp).connect(userWallet), requester.address);
+  cliPrint.info(`Requester address: ${requesterAddress} is now sponsored`);
 };
 
 runAndHandleErrors(main);

--- a/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
+++ b/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
@@ -30,23 +30,30 @@ describe('Coingecko integration with containerized Airnode and hardhat', () => {
     runCommand('yarn rebuild-airnode-container');
     const airnodeDocker = runCommandInBackground('yarn run-airnode-locally');
 
-    runCommand('yarn deploy-requester');
-    runCommand('yarn derive-and-fund-sponsor-wallet');
-    runCommand('yarn sponsor-requester');
-    const response = runCommand('yarn make-request');
+    // Try running rest of the commands, but make sure to kill the Airnode running in backround process gracefully.
+    // We need to do this otherwise Airnode will be running in background forever
+    try {
+      runCommand('yarn deploy-requester');
+      runCommand('yarn derive-and-fund-sponsor-wallet');
+      runCommand('yarn sponsor-requester');
+      const response = runCommand('yarn make-request');
 
-    killBackgroundProcess(airnodeDocker);
+      killBackgroundProcess(airnodeDocker);
 
-    const pathOfResponseText = 'Ethereum price is';
-    expect(response).toContain(pathOfResponseText);
+      const pathOfResponseText = 'Ethereum price is';
+      expect(response).toContain(pathOfResponseText);
 
-    const priceText = response.split(pathOfResponseText)[1];
-    expect(priceText).toContain('USD');
+      const priceText = response.split(pathOfResponseText)[1];
+      expect(priceText).toContain('USD');
 
-    const price = priceText.split('USD')[0].trim();
-    expect(Number(price)).toEqual(expect.any(Number));
-    expect(Number(price).toString()).toBe(price);
+      const price = priceText.split('USD')[0].trim();
+      expect(Number(price)).toEqual(expect.any(Number));
+      expect(Number(price).toString()).toBe(price);
 
-    console.log(`FYI: The Ethereum price is ${price} USD.`);
+      console.log(`FYI: The Ethereum price is ${price} USD.`);
+    } catch (e) {
+      killBackgroundProcess(airnodeDocker);
+      throw e;
+    }
   });
 });

--- a/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
+++ b/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
@@ -50,7 +50,7 @@ describe('Coingecko integration with containerized Airnode and hardhat', () => {
       expect(Number(price)).toEqual(expect.any(Number));
       expect(Number(price).toString()).toBe(price);
 
-      console.log(`FYI: The Ethereum price is ${price} USD.`);
+      console.log(`The Ethereum price is ${price} USD.`);
     } catch (e) {
       killBackgroundProcess(airnodeDocker);
       throw e;

--- a/packages/airnode-examples/test/utils.ts
+++ b/packages/airnode-examples/test/utils.ts
@@ -7,7 +7,7 @@ export const runCommand = (command: string) => {
   });
 
   if (result.status !== 0 || result.error) {
-    throw new Error(result.error?.message ?? 'Command failed with non-zero status code');
+    throw new Error(`Command failed with non-zero status code. Output:\n${result.stdout.toString()}`);
   }
 
   return result.stdout.toString();

--- a/packages/airnode-examples/test/utils.ts
+++ b/packages/airnode-examples/test/utils.ts
@@ -1,4 +1,5 @@
 import { spawnSync, spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import { cliPrint } from '../src';
 
 export const runCommand = (command: string) => {
   console.log(`Running command:\n${command}`);
@@ -10,7 +11,13 @@ export const runCommand = (command: string) => {
     throw new Error(`Command failed with non-zero status code. Output:\n${result.stdout.toString()}`);
   }
 
-  return result.stdout.toString();
+  const stderr = result.stderr.toString();
+  if (stderr) {
+    cliPrint.warning(`Stderr output:\n${stderr}`);
+  }
+
+  const stdout = result.stdout.toString();
+  return stdout;
 };
 
 export const runCommandInBackground = (command: string) => {
@@ -22,9 +29,14 @@ export const runCommandInBackground = (command: string) => {
 };
 
 export const killBackgroundProcess = (processToKill: ChildProcessWithoutNullStreams) => {
-  // Only the following reliably kills the Airnode process. See:
-  // https://azimi.me/2014/12/31/kill-child_process-node-js.html
-  //
   // We need to gracefully kill the Airnode docker otherwise it remains running on background
-  process.kill(-processToKill.pid!);
+  //
+  // The following reliably kills the Airnode process for unix, but it throws for windows.
+  // See: https://azimi.me/2014/12/31/kill-child_process-node-js.html
+  try {
+    process.kill(-processToKill.pid!);
+  } catch (e) {
+    // See: https://stackoverflow.com/a/28163919
+    spawn('taskkill', ['/pid', processToKill.pid!.toString(), '/f', '/t']);
+  }
 };


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode/issues/812

Resolves these Jira issues:
* https://api3dao.atlassian.net/browse/AN-541
* https://api3dao.atlassian.net/browse/AN-542

I've also wanted to include a step of running airnode examples on CI, but this is unfortunately not possible, since you can't run linux containers on windows (see: https://github.community/t/github-actions-windows-runtime-linux-container-mode-docker/135874/4). This is compensated for windows and macOs users with the [Docker for desktop](https://www.docker.com/products/docker-desktop).