### PR TITLE
Enforce changesets

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,9 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone airnode
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Check hyperlinks
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
@@ -41,6 +43,8 @@ jobs:
     steps:
       - name: Clone airnode
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Clone airnode
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Check hyperlinks
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
@@ -44,6 +42,7 @@ jobs:
       - name: Clone airnode
         uses: actions/checkout@v2
         with:
+          # Required for changesets check. See: https://github.com/changesets/changesets/issues/517#issuecomment-813282523
           fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -138,10 +138,29 @@ jobs:
           type: ${{ job.status }}
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  require-changeset:
+    name: Require a changeset
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.17.1'
+      - name: Require a changeset
+        # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#responding-to-events
+        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+        run: yarn changeset:check
+
   build-complete:
     name: All tests passed
     runs-on: ubuntu-latest
-    needs: [unit-tests, e2e-tests]
+    needs: [unit-tests, e2e-tests, require-changeset]
     steps:
       - run: exit 0
       - name: Slack Notification

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+yarn changeset:check

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ We use [changesets](https://github.com/atlassian/changesets) to manage the chang
 contributors is that you need to add a changeset by running `yarn changeset` which contains what packages should be
 bumped, their associated semver bump types and some markdown which will be inserted into changelogs.
 
-Changeset is required to merge a PR if it changes one of the monorepo packages. If you really do not want to include a
-changeset, you have to generate an empty one by running `yarn changeset:empty`. Note, that changeset is not required for
-dependabot PRs.
+A changeset is required to merge a PR if it changes one of the monorepo packages. If you really do not want to include a
+changeset, you have to generate an empty one by running `yarn changeset:empty`. Note that a changeset is not required
+for dependabot PRs.
 
 > Tip: Add `export EDITOR="code --wait"` to `.bashrc` to make it possible to write changelog description in VS Code (you
 > can adapt the configuration for other editor similarly).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ We use [changesets](https://github.com/atlassian/changesets) to manage the chang
 contributors is that you need to add a changeset by running `yarn changeset` which contains what packages should be
 bumped, their associated semver bump types and some markdown which will be inserted into changelogs.
 
+Changeset is required to merge a PR if it changes one of the monorepo packages. If you really do not want to include a
+changeset, you have to generate an empty one by running `yarn changeset:empty`. Note, that changeset is not required for
+dependabot PRs.
+
 > Tip: Add `export EDITOR="code --wait"` to `.bashrc` to make it possible to write changelog description in VS Code (you
 > can adapt the configuration for other editor similarly).
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:protocol": "(cd packages/airnode-protocol && yarn run build)",
     "build:validator": "(cd packages/airnode-validator && yarn run build)",
     "changeset": "changeset",
-    "changeset:check": "changeset status --since=master",
+    "changeset:check": "changeset status --since=origin/master",
     "changeset:empty": "changeset --empty",
     "clean": "lerna run clean --stream",
     "cli:deployer": "lerna run --scope @api3/airnode-deployer cli -- --",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "build:protocol": "(cd packages/airnode-protocol && yarn run build)",
     "build:validator": "(cd packages/airnode-validator && yarn run build)",
     "changeset": "changeset",
+    "changeset:check": "changeset status --since=master",
+    "changeset:empty": "changeset --empty",
     "clean": "lerna run clean --stream",
     "cli:deployer": "lerna run --scope @api3/airnode-deployer cli -- --",
     "dev:api": "(cd packages/airnode-operation && yarn run dev:api)",


### PR DESCRIPTION
https://api3dao.atlassian.net/browse/AN-495

When this is merged, the changeset bot can be turned off (maybe @andreogle can do this).

You can see the code working on [my Airnode forked](https://github.com/Siegrift/airnode) with similar PR to this merged. You can see two PRs - one with empty changeset that is passing the CI and one that doesn't have any changeset and fails. (Check details, since both PRs actually fail on CI because of some static analyzer check)