### PR TITLE
Fix windows build by conforming line endings to Unix

### DIFF
--- a/.changeset/tame-oranges-clap.md
+++ b/.changeset/tame-oranges-clap.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': patch
+---
+
+Conform line endings in the deployer's entrypoint.sh file to fix builds on Windows

--- a/.changeset/tame-oranges-clap.md
+++ b/.changeset/tame-oranges-clap.md
@@ -2,4 +2,4 @@
 '@api3/airnode-deployer': patch
 ---
 
-Conform line endings in the deployer's entrypoint.sh file to fix builds on Windows
+Support building Airnode deployer image on windows

--- a/packages/airnode-deployer/docker/Dockerfile
+++ b/packages/airnode-deployer/docker/Dockerfile
@@ -25,6 +25,9 @@ RUN ARCH=`[ $(arch) == "x86_64" ] && echo "amd64" || echo "arm64" ` && \
     ln -s ${appDir}/bin/deployer.js ${appBin} && \
     chmod +x ${appBin}
 
+# Git swaps out LF with CRLF on Windows but only in the working directory
+RUN sed -i $'s/\r$//' /entrypoint.sh
+
 # Default placement for GCP credentials
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/gcp.json
 

--- a/packages/airnode-deployer/docker/Dockerfile
+++ b/packages/airnode-deployer/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY packages/airnode-deployer/docker/entrypoint.sh /entrypoint.sh
 
     # Install external dependencies
 RUN ARCH=`[ $(arch) == "x86_64" ] && echo "amd64" || echo "arm64" ` && \
-    apk add --update --no-cache su-exec git && \
+    apk add --update --no-cache su-exec git dos2unix && \
     # Download Terraform binary
     wget ${baseTerraformURL}${ARCH}.zip && \
     unzip *.zip -d /bin && \
@@ -26,7 +26,8 @@ RUN ARCH=`[ $(arch) == "x86_64" ] && echo "amd64" || echo "arm64" ` && \
     chmod +x ${appBin}
 
 # Git swaps out LF with CRLF on Windows but only in the working directory
-RUN sed -i $'s/\r$//' /entrypoint.sh
+RUN dos2unix /entrypoint.sh
+RUN find ${appDir}/terraform -type f -exec dos2unix -q {} {} \;
 
 # Default placement for GCP credentials
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/gcp.json

--- a/packages/airnode-examples/scripts/create-airnode-secrets.ts
+++ b/packages/airnode-examples/scripts/create-airnode-secrets.ts
@@ -1,9 +1,6 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import isWsl from 'is-wsl';
-import { readIntegrationInfo, runAndHandleErrors } from '../src';
-
-const isMacOrWindows = () => process.platform === 'win32' || process.platform === 'darwin' || isWsl;
+import { isMacOrWindows, readIntegrationInfo, runAndHandleErrors } from '../src';
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();

--- a/packages/airnode-examples/scripts/deploy-airnode.ts
+++ b/packages/airnode-examples/scripts/deploy-airnode.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { cliPrint, isMacOrWindows, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
+import { cliPrint, isWindows, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
@@ -12,7 +12,7 @@ const main = async () => {
   const secretsFilePath = join(__dirname, '../aws.env');
   const deployCommand = [
     `docker run -it --rm`,
-    isMacOrWindows() ? '' : `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
+    isWindows() ? '' : `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
     integrationInfo.airnodeType === 'aws' && `--env-file ${secretsFilePath}`,
     integrationInfo.airnodeType === 'gcp' && `-v "${integrationPath}/gcp.json:/app/gcp.json"`,
     `-v ${integrationPath}:/app/config`,

--- a/packages/airnode-examples/scripts/deploy-airnode.ts
+++ b/packages/airnode-examples/scripts/deploy-airnode.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { cliPrint, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
+import { cliPrint, isMacOrWindows, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
@@ -12,7 +12,7 @@ const main = async () => {
   const secretsFilePath = join(__dirname, '../aws.env');
   const deployCommand = [
     `docker run -it --rm`,
-    `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
+    isMacOrWindows() ? '' : `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
     integrationInfo.airnodeType === 'aws' && `--env-file ${secretsFilePath}`,
     integrationInfo.airnodeType === 'gcp' && `-v "${integrationPath}/gcp.json:/app/gcp.json"`,
     `-v ${integrationPath}:/app/config`,

--- a/packages/airnode-examples/scripts/remove-airnode.ts
+++ b/packages/airnode-examples/scripts/remove-airnode.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { cliPrint, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
+import { cliPrint, isMacOrWindows, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
@@ -12,7 +12,7 @@ const main = async () => {
   const secretsFilePath = join(__dirname, '../aws.env');
   const deployCommand = [
     `docker run -it --rm`,
-    `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
+    isMacOrWindows() ? '' : `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
     integrationInfo.airnodeType === 'aws' && `--env-file ${secretsFilePath}`,
     integrationInfo.airnodeType === 'gcp' && `-v "${integrationPath}/gcp.json:/app/gcp.json"`,
     `-v ${integrationPath}:/app/output`,

--- a/packages/airnode-examples/scripts/remove-airnode.ts
+++ b/packages/airnode-examples/scripts/remove-airnode.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { cliPrint, isMacOrWindows, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
+import { cliPrint, isWindows, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
@@ -12,7 +12,7 @@ const main = async () => {
   const secretsFilePath = join(__dirname, '../aws.env');
   const deployCommand = [
     `docker run -it --rm`,
-    isMacOrWindows() ? '' : `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
+    isWindows() ? '' : `-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)`,
     integrationInfo.airnodeType === 'aws' && `--env-file ${secretsFilePath}`,
     integrationInfo.airnodeType === 'gcp' && `-v "${integrationPath}/gcp.json:/app/gcp.json"`,
     `-v ${integrationPath}:/app/output`,

--- a/packages/airnode-examples/src/utils.ts
+++ b/packages/airnode-examples/src/utils.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { parse as parseEnvFile } from 'dotenv';
 import prompts, { PromptObject } from 'prompts';
+import isWsl from 'is-wsl';
 
 export interface IntegrationInfo {
   integration: string;
@@ -13,6 +14,11 @@ export interface IntegrationInfo {
   providerUrl: string;
   gcpProjectId?: string;
 }
+
+/**
+ * @returns true if this platform is MacOS, Windows or WSL
+ */
+export const isMacOrWindows = () => process.platform === 'win32' || process.platform === 'darwin' || isWsl;
 
 /**
  * @returns The contents of the "integration-info.json" file (throws if it doesn't exist)

--- a/packages/airnode-examples/src/utils.ts
+++ b/packages/airnode-examples/src/utils.ts
@@ -21,6 +21,11 @@ export interface IntegrationInfo {
 export const isMacOrWindows = () => process.platform === 'win32' || process.platform === 'darwin' || isWsl;
 
 /**
+ * @returns true if platform is Windows or WSL
+ */
+export const isWindows = () => process.platform === 'win32' || isWsl;
+
+/**
  * @returns The contents of the "integration-info.json" file (throws if it doesn't exist)
  */
 export const readIntegrationInfo = (): IntegrationInfo =>


### PR DESCRIPTION
This fixes the `airnode-deployer` build on Windows.

The problem was that Git on Windows, by default, swaps Unix end-of-line bytes with Windows _EOL_ bytes (LF vs CRLF), which makes `/entrypoint.sh` not executable (it breaks the shebang).

Ideally one would want to configure git to not do this, which is possible, but the process is inconsistent depending on which Git you're using (Git for Windows, Github Desktop, etc.) and seemingly has to be applied in the Dockerfile too. Using `sed`, a utility the Alpine image comes bundled with, to do the character removal, seems like an elegant one-line solution that doesn't noticeably increase the docker image size.

Git automatically converts files back to Unix when a Windows user does a commit and push.