### PR TITLE
Fix heartbeat API key location & name

### DIFF
--- a/.changeset/eight-roses-shave.md
+++ b/.changeset/eight-roses-shave.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': patch
+---
+
+Move heartbeat API key to a request header

--- a/packages/airnode-node/src/reporting/heartbeat.test.ts
+++ b/packages/airnode-node/src/reporting/heartbeat.test.ts
@@ -47,10 +47,11 @@ describe('reportHeartbeat', () => {
     expect(executeMock).toHaveBeenCalledWith({
       url: 'https://example.com',
       method: 'post',
+      headers: {
+        'airnode-heartbeat-api-key': '3a7af83f-6450-46d3-9937-5f9773ce2849',
+      },
       data: {
-        api_key: '3a7af83f-6450-46d3-9937-5f9773ce2849',
         deployment_id: '2d14a39a-9f6f-41af-9905-99abf0e5e1f0',
-        payload: {},
       },
       timeout: 5_000,
     });
@@ -69,10 +70,11 @@ describe('reportHeartbeat', () => {
     expect(executeMock).toHaveBeenCalledWith({
       url: 'https://example.com',
       method: 'post',
+      headers: {
+        'airnode-heartbeat-api-key': '3a7af83f-6450-46d3-9937-5f9773ce2849',
+      },
       data: {
-        api_key: '3a7af83f-6450-46d3-9937-5f9773ce2849',
         deployment_id: '2d14a39a-9f6f-41af-9905-99abf0e5e1f0',
-        payload: {},
       },
       timeout: 5_000,
     });

--- a/packages/airnode-node/src/reporting/heartbeat.ts
+++ b/packages/airnode-node/src/reporting/heartbeat.ts
@@ -20,17 +20,15 @@ export async function reportHeartbeat(state: CoordinatorState): Promise<PendingL
 
   const httpGatewayUrl = getEnvValue('HTTP_GATEWAY_URL');
 
-  // TODO: add statistics here
-  const payload = {};
-
   const request = {
     url,
     method: 'post' as const,
+    headers: {
+      'airnode-heartbeat-api-key': apiKey,
+    },
     data: {
-      api_key: apiKey,
       deployment_id: id,
       ...(httpGatewayUrl ? {} : { http_gateway_url: httpGatewayUrl }),
-      payload,
     },
     timeout: 5_000,
   };


### PR DESCRIPTION
Based on [slack discussion](https://api3workspace.slack.com/archives/C02AYRX8D89/p1635066629013200).
I tested it with the deployment created on staging and it became `Active` :slightly_smiling_face: 