### PR TITLE
Add back yarn pack to fix docker build process

### DIFF
--- a/.changeset/fresh-teachers-compete.md
+++ b/.changeset/fresh-teachers-compete.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-utilities': patch
+---
+
+Add back yarn pack to fix docker build process

--- a/packages/airnode-utilities/package.json
+++ b/packages/airnode-utilities/package.json
@@ -11,7 +11,8 @@
     "build": "yarn run clean && yarn run compile",
     "clean": "rimraf -rf ./dist *.tgz",
     "compile": "tsc -p tsconfig.build.json",
-    "test": "SILENCE_LOGGER=true jest --selectProjects unit"
+    "test": "SILENCE_LOGGER=true jest --selectProjects unit",
+    "pack": "yarn pack"
   },
   "types": "dist/index",
   "main": "dist/index.js",


### PR DESCRIPTION
`yarn pack` is an important command because it is used by the artifacts build process.
The lack of this command meant that `airnode-utilities` didn't make its way into the airnode-client image and hence e2e tests started failing.