### PR TITLE
Fix EIP-1559 string->number config type switch

### DIFF
--- a/.changeset/cuddly-goats-tap.md
+++ b/.changeset/cuddly-goats-tap.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': patch
+---
+
+Fix EIP-1559 string->number config type switch

--- a/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
+++ b/packages/airnode-examples/test/e2e/coingecko-local.feature.ts
@@ -30,6 +30,9 @@ describe('Coingecko integration with containerized Airnode and hardhat', () => {
     runCommand('yarn rebuild-artifacts-container');
     runCommand('yarn rebuild-airnode-container');
     const airnodeDocker = runCommandInBackground('yarn run-airnode-locally');
+    airnodeDocker.stdout.on('data', (data) => {
+      logger.log(`Local Airnode stdout: ${data.toString()}`);
+    });
 
     // Try running rest of the commands, but make sure to kill the Airnode running in backround process gracefully.
     // We need to do this otherwise Airnode will be running in background forever

--- a/packages/airnode-node/src/evm/gas-prices.ts
+++ b/packages/airnode-node/src/evm/gas-prices.ts
@@ -9,8 +9,7 @@ export interface FetchOptions {
   readonly chainOptions: ChainOptions;
 }
 
-export const parsePriorityFee = ({ value, unit }: PriorityFee) =>
-  ethers.utils.parseUnits(value.toString(), unit ?? 'wei');
+export const parsePriorityFee = ({ value, unit }: PriorityFee) => ethers.utils.parseUnits(`${value}`, unit ?? 'wei');
 
 const getLegacyGasPrice = async (options: FetchOptions): Promise<LogsData<GasTarget | null>> => {
   const { provider } = options;


### PR DESCRIPTION
Relating to PR #890 unfortunately this PR introduced a bug which caused one of the tests to fail.

Two bugs from different PRs both caused failures in the same test.
I solved one failure, but the tests continued failing. This and various other factors lead me to believe it was a docker caching issue but it now appears, after I added additional logging, that the most recent issue related to the `priorityFee` type being passed to `parsePriorityFee`.

This PR hopefully fixes the issue and also adds additional logging around the e2e examples test airnode client container for easier future debugging.

I will assign a reviewer once I know this works (it works locally).