### PR TITLE
Use standard packing for subscription ID derivation

### DIFF
--- a/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
@@ -267,7 +267,7 @@ contract DapiServer is
         require(relayer != address(0), "Relayer address zero");
         require(sponsor != address(0), "Sponsor address zero");
         subscriptionId = keccak256(
-            abi.encodePacked(
+            abi.encode(
                 block.chainid,
                 airnode,
                 templateId,

--- a/packages/airnode-protocol-v1/contracts/protocol/StorageUtils.sol
+++ b/packages/airnode-protocol-v1/contracts/protocol/StorageUtils.sol
@@ -133,7 +133,7 @@ contract StorageUtils is IStorageUtils {
         require(requester != address(0), "Requester address zero");
         require(fulfillFunctionId != bytes4(0), "Fulfill function ID zero");
         subscriptionId = keccak256(
-            abi.encodePacked(
+            abi.encode(
                 chainId,
                 airnode,
                 templateId,

--- a/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
+++ b/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
@@ -152,7 +152,7 @@ async function setUpBeacon() {
   );
   // Register the Beacon update subscription
   beaconUpdateSubscriptionId = hre.ethers.utils.keccak256(
-    hre.ethers.utils.solidityPack(
+    hre.ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
       [
         (await hre.ethers.provider.getNetwork()).chainId,
@@ -178,7 +178,7 @@ async function setUpBeacon() {
     );
   // Register the relayed Beacon update subscription
   beaconUpdateSubscriptionRelayedId = hre.ethers.utils.keccak256(
-    hre.ethers.utils.solidityPack(
+    hre.ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
       [
         (await hre.ethers.provider.getNetwork()).chainId,
@@ -239,7 +239,7 @@ async function setUpDapi() {
   // Calculate the dAPI update subscription ID
   const dapiUpdateParameters = hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]);
   dapiUpdateSubscriptionId = hre.ethers.utils.keccak256(
-    hre.ethers.utils.solidityPack(
+    hre.ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
       [
         (await hre.ethers.provider.getNetwork()).chainId,
@@ -255,7 +255,7 @@ async function setUpDapi() {
     )
   );
   dapiUpdateSubscriptionRelayedId = hre.ethers.utils.keccak256(
-    hre.ethers.utils.solidityPack(
+    hre.ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
       [
         (await hre.ethers.provider.getNetwork()).chainId,

--- a/packages/airnode-protocol-v1/test/protocol/StorageUtils.sol.js
+++ b/packages/airnode-protocol-v1/test/protocol/StorageUtils.sol.js
@@ -38,7 +38,7 @@ beforeEach(async () => {
   requester = testUtils.generateRandomAddress();
   fulfillFunctionId = '0x12345678';
   subscriptionId = hre.ethers.utils.keccak256(
-    hre.ethers.utils.solidityPack(
+    hre.ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
       [
         chainId,


### PR DESCRIPTION
The subscription struct has two dynamically sized fields, which makes the usage of `abi.encodePacked` inappropriate. It was replaced by `abi.encode` as a solution.

An alternative to this is to always use `abi.encode` as done in the pre-alpha contracts. Since we never store the encoded bytes, we don't need to care about its length.