### PR TITLE
Fix coingecko-signed-data integration command typo

### DIFF
--- a/.changeset/loud-clouds-lie.md
+++ b/.changeset/loud-clouds-lie.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-examples': patch
+---
+
+Fix minor coingecko-signed-data integration command typo

--- a/packages/airnode-examples/integrations/coingecko-signed-data/README.md
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/README.md
@@ -12,7 +12,7 @@ chain.
 You can trigger the API call with a POST request. For example, you can use `curl` in the terminal:
 
 ```sh
-curl -X POST -H 'x-api-key: <HTTP_SIGNED_DATA_GATEWAY_API_KEY>' -d '{"parameters": {"coinId": "bitcoin","\_templateId":"0x6365636b79000000000000000000000000000000000000000000000000000000"}}' '<HTTP_SIGNED_DATA_GATEWAY_URL>/<ENDPOINT_ID>'
+curl -X POST -H 'x-api-key: <HTTP_SIGNED_DATA_GATEWAY_API_KEY>' -d '{"parameters": {"coinId": "bitcoin","_templateId":"0x6365636b79000000000000000000000000000000000000000000000000000000"}}' '<HTTP_SIGNED_DATA_GATEWAY_URL>/<ENDPOINT_ID>'
 ```
 
 Before making the request, you need to replace the example values:


### PR DESCRIPTION
 Removes the `\`, which was causing the curl command to return an internal server error. 