### PR TITLE
Allow Airnode to opt back in

### DIFF
--- a/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerWhitelisterWithToken.sol
+++ b/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerWhitelisterWithToken.sol
@@ -235,9 +235,8 @@ contract RequesterAuthorizerWhitelisterWithToken is
     ) external override onlyNonZeroAirnode(airnode) {
         if (msg.sender == airnode) {
             require(
-                airnodeParticipationStatus ==
-                    AirnodeParticipationStatus.OptedOut,
-                "Airnode can only opt out"
+                airnodeParticipationStatus != AirnodeParticipationStatus.Active,
+                "Airnode cannot activate itself"
             );
         } else {
             require(

--- a/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenDeposit.sol.js
+++ b/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenDeposit.sol.js
@@ -407,7 +407,7 @@ describe('setPriceCoefficient', function () {
 describe('setAirnodeParticipationStatus', function () {
   context('Airnode address is not zero', function () {
     context('Sender is Airnode', function () {
-      context('Status is OptedOut', function () {
+      context('Status is not Active', function () {
         it('sets Airnode participation status', async function () {
           await expect(
             requesterAuthorizerWhitelisterWithTokenDeposit
@@ -419,20 +419,25 @@ describe('setAirnodeParticipationStatus', function () {
           expect(
             await requesterAuthorizerWhitelisterWithTokenDeposit.airnodeToParticipationStatus(roles.airnode.address)
           ).to.equal(AirnodeParticipationStatus.OptedOut);
+          await expect(
+            requesterAuthorizerWhitelisterWithTokenDeposit
+              .connect(roles.airnode)
+              .setAirnodeParticipationStatus(roles.airnode.address, AirnodeParticipationStatus.Inactive)
+          )
+            .to.emit(requesterAuthorizerWhitelisterWithTokenDeposit, 'SetAirnodeParticipationStatus')
+            .withArgs(roles.airnode.address, AirnodeParticipationStatus.Inactive, roles.airnode.address);
+          expect(
+            await requesterAuthorizerWhitelisterWithTokenDeposit.airnodeToParticipationStatus(roles.airnode.address)
+          ).to.equal(AirnodeParticipationStatus.Inactive);
         });
       });
-      context('Status is not OptedOut', function () {
+      context('Status is Active', function () {
         it('reverts', async function () {
           await expect(
             requesterAuthorizerWhitelisterWithTokenDeposit
               .connect(roles.airnode)
               .setAirnodeParticipationStatus(roles.airnode.address, AirnodeParticipationStatus.Active)
-          ).to.be.revertedWith('Airnode can only opt out');
-          await expect(
-            requesterAuthorizerWhitelisterWithTokenDeposit
-              .connect(roles.airnode)
-              .setAirnodeParticipationStatus(roles.airnode.address, AirnodeParticipationStatus.Inactive)
-          ).to.be.revertedWith('Airnode can only opt out');
+          ).to.be.revertedWith('Airnode cannot activate itself');
         });
       });
     });

--- a/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenPayment.sol.js
+++ b/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenPayment.sol.js
@@ -446,7 +446,7 @@ describe('setPriceCoefficient', function () {
 describe('setAirnodeParticipationStatus', function () {
   context('Airnode address is not zero', function () {
     context('Sender is Airnode', function () {
-      context('Status is OptedOut', function () {
+      context('Status is not Active', function () {
         it('sets Airnode participation status', async function () {
           await expect(
             requesterAuthorizerWhitelisterWithTokenPayment
@@ -458,20 +458,25 @@ describe('setAirnodeParticipationStatus', function () {
           expect(
             await requesterAuthorizerWhitelisterWithTokenPayment.airnodeToParticipationStatus(roles.airnode.address)
           ).to.equal(AirnodeParticipationStatus.OptedOut);
+          await expect(
+            requesterAuthorizerWhitelisterWithTokenPayment
+              .connect(roles.airnode)
+              .setAirnodeParticipationStatus(roles.airnode.address, AirnodeParticipationStatus.Inactive)
+          )
+            .to.emit(requesterAuthorizerWhitelisterWithTokenPayment, 'SetAirnodeParticipationStatus')
+            .withArgs(roles.airnode.address, AirnodeParticipationStatus.Inactive, roles.airnode.address);
+          expect(
+            await requesterAuthorizerWhitelisterWithTokenPayment.airnodeToParticipationStatus(roles.airnode.address)
+          ).to.equal(AirnodeParticipationStatus.Inactive);
         });
       });
-      context('Status is not OptedOut', function () {
+      context('Status is Active', function () {
         it('reverts', async function () {
           await expect(
             requesterAuthorizerWhitelisterWithTokenPayment
               .connect(roles.airnode)
               .setAirnodeParticipationStatus(roles.airnode.address, AirnodeParticipationStatus.Active)
-          ).to.be.revertedWith('Airnode can only opt out');
-          await expect(
-            requesterAuthorizerWhitelisterWithTokenPayment
-              .connect(roles.airnode)
-              .setAirnodeParticipationStatus(roles.airnode.address, AirnodeParticipationStatus.Inactive)
-          ).to.be.revertedWith('Airnode can only opt out');
+          ).to.be.revertedWith('Airnode cannot activate itself');
         });
       });
     });


### PR DESCRIPTION
My initial plan for behavior was to only allow
```
(Any status) => OptedOut
```
or
```
OptedOut => Inactive
```
if the caller was `airnode` (but apparently I forgot to implement the second part). This felt a bit like unnecessarily complex, so I decided to allow the following instead
```
(Any status) => Inactive
```
or
```
(Any status) => OptedOut
```
This means that differently from the first version, `airnode` can set change its status as `Active => Inactive`, which is not really an issue (because `airnode` could already do that by opting out and opting back in). This made the implementation a lot simpler.