### PR TITLE
Miscellaneous ToB audit fixes

### DIFF
--- a/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistry.sol
+++ b/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistry.sol
@@ -32,7 +32,7 @@ contract AccessControlRegistry is
         require(manager != address(0), "Manager address zero");
         bytes32 rootRole = deriveRootRole(manager);
         if (!hasRole(rootRole, manager)) {
-            _setupRole(rootRole, manager);
+            _grantRole(rootRole, manager);
             emit InitializedManager(rootRole, manager);
         }
     }

--- a/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistryAdminned.sol
+++ b/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistryAdminned.sol
@@ -5,8 +5,8 @@ import "./RoleDeriver.sol";
 import "./AccessControlRegistryUser.sol";
 import "./interfaces/IAccessControlRegistryAdminned.sol";
 
-/// @title Contract that should be inherited by contracts whose adminship
-/// functionality will be implemented using AccessControlRegistry
+/// @title Contract to be inherited by contracts whose adminship functionality
+/// will be implemented using AccessControlRegistry
 contract AccessControlRegistryAdminned is
     RoleDeriver,
     AccessControlRegistryUser,

--- a/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistryAdminnedWithManager.sol
+++ b/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistryAdminnedWithManager.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "./AccessControlRegistryAdminned.sol";
 import "./interfaces/IAccessControlRegistryAdminnedWithManager.sol";
 
-/// @title Contract that should be inherited by contracts with manager whose
-/// adminship functionality will be implemented using AccessControlRegistry
+/// @title Contract to be inherited by contracts with manager whose adminship
+/// functionality will be implemented using AccessControlRegistry
 /// @notice The manager address here is expected to belong to an
 /// AccessControlRegistry user that is a multisig/DAO
 contract AccessControlRegistryAdminnedWithManager is

--- a/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistryUser.sol
+++ b/packages/airnode-protocol-v1/contracts/access-control-registry/AccessControlRegistryUser.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "./interfaces/IAccessControlRegistry.sol";
 import "./interfaces/IAccessControlRegistryUser.sol";
 
-/// @title Contract that should be inherited by contracts that will interact
-/// with AccessControlRegistry
+/// @title Contract to be inherited by contracts that will interact with
+/// AccessControlRegistry
 contract AccessControlRegistryUser is IAccessControlRegistryUser {
     /// @notice AccessControlRegistry contract address
     address public immutable override accessControlRegistry;

--- a/packages/airnode-protocol-v1/contracts/access-control-registry/RoleDeriver.sol
+++ b/packages/airnode-protocol-v1/contracts/access-control-registry/RoleDeriver.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
-/// @title Contract that implements the AccessControlRegistry role derivation
-/// logic
+/// @title Contract to be inherited by contracts that will derive
+/// AccessControlRegistry roles
 /// @notice If a contract interfaces with AccessControlRegistry and needs to
 /// derive roles, it should inherit this contract instead of re-implementing
 /// the logic

--- a/packages/airnode-protocol-v1/contracts/allocators/Allocator.sol
+++ b/packages/airnode-protocol-v1/contracts/allocators/Allocator.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/utils/Multicall.sol";
 import "./interfaces/IAllocator.sol";
 
-/// @title Abstract contract that is inherited by contracts that temporarily
-/// allocate subscription slots for Airnodes/relayers
+/// @title Abstract contract to be inherited by Allocator contracts that
+/// temporarily allocate subscription slots for Airnodes/relayers
 /// @dev An Airnode/relayer calls a number of Allocators to retrieve a number
 /// of slots to serve the respective subscriptions. What these Allocators and
 /// slot numbers are expected to be communicated off-chain. The Airnode/relayer

--- a/packages/airnode-protocol-v1/contracts/authorizers/RequesterAuthorizer.sol
+++ b/packages/airnode-protocol-v1/contracts/authorizers/RequesterAuthorizer.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/utils/Multicall.sol";
 import "../whitelist/Whitelist.sol";
 import "./interfaces/IRequesterAuthorizer.sol";
 
-/// @title Abstract contract that can be used to build Airnode authorizers that
+/// @title Abstract contract to be inherited by Authorizer contracts that
 /// temporarily or permanently whitelist requesters for Airnode–endpoint pairs
 abstract contract RequesterAuthorizer is
     Multicall,

--- a/packages/airnode-protocol-v1/contracts/dapis/DapiReader.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/DapiReader.sol
@@ -3,7 +3,8 @@ pragma solidity 0.8.9;
 
 import "./interfaces/IDapiReader.sol";
 
-/// @title Contract to be inherited to read from a DapiServer contract
+/// @title Contract to be inherited by contracts that will read from a
+/// DapiServer contract
 contract DapiReader is IDapiReader {
     /// @notice DapiServer contract address
     address public override dapiServer;

--- a/packages/airnode-protocol-v1/contracts/dapis/Median.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/Median.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.9;
 import "./Sort.sol";
 import "./QuickSelect.sol";
 
-/// @title Contract that calculates the median of an array
+/// @title Contract to be inherited by contracts that will calculate the median
+/// of an array
 /// @notice The operation will be in-place, i.e., the array provided as the
 /// argument will be modified.
 contract Median is Sort, Quickselect {

--- a/packages/airnode-protocol-v1/contracts/dapis/QuickSelect.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/QuickSelect.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
-/// @title Contract that calculates the index of the k-th and optionally
-/// (k+1)-th largest elements in the array
+/// @title Contract to be inherited by contracts that will calculate the index
+/// of the k-th and optionally (k+1)-th largest elements in the array
 /// @notice Uses quickselect, which operates in-place, i.e., the array provided
 /// as the argument will be modified.
 contract Quickselect {

--- a/packages/airnode-protocol-v1/contracts/dapis/Sort.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/Sort.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
-/// @title Contract that sorts an array using an unrolled implementation
+/// @title Contract to be inherited by contracts that will sort an array using
+/// an unrolled implementation
 /// @notice The operation will be in-place, i.e., the array provided as the
 /// argument will be modified.
 contract Sort {

--- a/packages/airnode-protocol-v1/contracts/monetization/AirnodeEndpointPriceRegistry.sol
+++ b/packages/airnode-protocol-v1/contracts/monetization/AirnodeEndpointPriceRegistry.sol
@@ -60,11 +60,7 @@ contract AirnodeEndpointPriceRegistry is
     /// @notice Called by registrars or the manager to register the
     /// default price
     /// @param price 30 day price in USD (times 10^18)
-    function registerDefaultPrice(uint256 price)
-        external
-        override
-        onlyRegistrarOrManager
-    {
+    function registerDefaultPrice(uint256 price) external override {
         _registerUint256(DEFAULT_PRICE_ID, price);
         emit RegisterDefaultPrice(price, msg.sender);
     }
@@ -76,7 +72,6 @@ contract AirnodeEndpointPriceRegistry is
     function registerDefaultChainPrice(uint256 chainId, uint256 price)
         external
         override
-        onlyRegistrarOrManager
         onlyNonZeroChainId(chainId)
     {
         _registerUint256(
@@ -93,7 +88,6 @@ contract AirnodeEndpointPriceRegistry is
     function registerAirnodePrice(address airnode, uint256 price)
         external
         override
-        onlyRegistrarOrManager
         onlyNonZeroAirnode(airnode)
     {
         _registerUint256(keccak256(abi.encodePacked(airnode)), price);
@@ -112,7 +106,6 @@ contract AirnodeEndpointPriceRegistry is
     )
         external
         override
-        onlyRegistrarOrManager
         onlyNonZeroAirnode(airnode)
         onlyNonZeroChainId(chainId)
     {
@@ -132,7 +125,7 @@ contract AirnodeEndpointPriceRegistry is
         address airnode,
         bytes32 endpointId,
         uint256 price
-    ) external override onlyRegistrarOrManager onlyNonZeroAirnode(airnode) {
+    ) external override onlyNonZeroAirnode(airnode) {
         _registerUint256(
             keccak256(abi.encodePacked(SALT, airnode, endpointId)),
             price
@@ -159,7 +152,6 @@ contract AirnodeEndpointPriceRegistry is
     )
         external
         override
-        onlyRegistrarOrManager
         onlyNonZeroAirnode(airnode)
         onlyNonZeroChainId(chainId)
     {

--- a/packages/airnode-protocol-v1/contracts/monetization/AirnodeEndpointPriceRegistryUser.sol
+++ b/packages/airnode-protocol-v1/contracts/monetization/AirnodeEndpointPriceRegistryUser.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "./interfaces/IAirnodeEndpointPriceRegistry.sol";
 import "./interfaces/IAirnodeEndpointPriceRegistryUser.sol";
 
-/// @title Contract that should be inherited by contracts that will interact
-/// with AirnodeEndpointPriceRegistry
+/// @title Contract to be inherited by contracts that will interact with
+/// AirnodeEndpointPriceRegistry
 contract AirnodeEndpointPriceRegistryUser is IAirnodeEndpointPriceRegistryUser {
     /// @notice AirnodeEndpointPriceRegistry contract address
     address public immutable override airnodeEndpointPriceRegistry;

--- a/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerRegistry.sol
+++ b/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerRegistry.sol
@@ -29,7 +29,7 @@ contract RequesterAuthorizerRegistry is
     function registerChainRequesterAuthorizer(
         uint256 chainId,
         address requesterAuthorizer
-    ) external override onlyRegistrarOrManager {
+    ) external override {
         require(chainId != 0, "Chain ID zero");
         (bool success, ) = tryReadChainRequesterAuthorizer(chainId);
         require(!success, "Chain Authorizer already set");

--- a/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerRegistryUser.sol
+++ b/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerRegistryUser.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "./interfaces/IRequesterAuthorizerRegistry.sol";
 import "./interfaces/IRequesterAuthorizerRegistryUser.sol";
 
-/// @title Contract that should be inherited by contracts that will interact
-/// with RequesterAuthorizerRegistry
+/// @title Contract to be inherited by contracts that will interact with
+/// RequesterAuthorizerRegistry
 contract RequesterAuthorizerRegistryUser is IRequesterAuthorizerRegistryUser {
     /// @notice RequesterAuthorizerRegistry contract address
     address public immutable override requesterAuthorizerRegistry;

--- a/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerWhitelisterWithToken.sol
+++ b/packages/airnode-protocol-v1/contracts/monetization/RequesterAuthorizerWhitelisterWithToken.sol
@@ -10,8 +10,8 @@ import "./RequesterAuthorizerRegistryUser.sol";
 import "./interfaces/IRequesterAuthorizerWhitelisterWithToken.sol";
 import "../authorizers/interfaces/IRequesterAuthorizer.sol";
 
-/// @title Base contract for RequesterAuthorizer whitelister contracts that
-/// will whitelist based on token interaction
+/// @title Contract to be inherited by RequesterAuthorizer contracts that will
+/// whitelist based on token interaction
 contract RequesterAuthorizerWhitelisterWithToken is
     Multicall,
     AccessControlRegistryAdminnedWithManager,

--- a/packages/airnode-protocol-v1/contracts/protocol/AirnodeProtocol.sol
+++ b/packages/airnode-protocol-v1/contracts/protocol/AirnodeProtocol.sol
@@ -36,8 +36,6 @@ contract AirnodeProtocol is
     mapping(bytes32 => bytes32) private requestIdToFulfillmentParameters;
 
     /// @notice Called by the requester to make a request
-    /// @dev If the `templateId` is zero, the fulfillment will be made with
-    /// `parameters` being used as fulfillment data
     /// @param templateId Template ID
     /// @param parameters Parameters provided by the requester in addition to
     /// the parameters in the template

--- a/packages/airnode-protocol-v1/contracts/protocol/AirnodeRequester.sol
+++ b/packages/airnode-protocol-v1/contracts/protocol/AirnodeRequester.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "./interfaces/IAirnodeProtocol.sol";
 import "./interfaces/IAirnodeRequester.sol";
 
-/// @title Contract to be inherited to make Airnode requests and receive
-/// fulfillments
+/// @title Contract to be inherited by contracts that will make Airnode
+/// requests and receive fulfillments
 contract AirnodeRequester is IAirnodeRequester {
     /// @notice AirnodeProtocol contract address
     address public immutable override airnodeProtocol;

--- a/packages/airnode-protocol-v1/contracts/utils/AddressRegistry.sol
+++ b/packages/airnode-protocol-v1/contracts/utils/AddressRegistry.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.9;
 import "./RegistryRolesWithManager.sol";
 import "./interfaces/IAddressRegistry.sol";
 
-/// @title Registry with manager that maps IDs to addresses
+/// @title Contract to be inherited by contracts that need a registry wit
+/// manager that maps IDs to addresses
 contract AddressRegistry is RegistryRolesWithManager, IAddressRegistry {
     mapping(bytes32 => address) private idToAddress;
 

--- a/packages/airnode-protocol-v1/contracts/utils/RegistryRolesWithManager.sol
+++ b/packages/airnode-protocol-v1/contracts/utils/RegistryRolesWithManager.sol
@@ -14,7 +14,7 @@ contract RegistryRolesWithManager is
     string public constant override REGISTRAR_ROLE_DESCRIPTION = "Registrar";
 
     /// @notice Registrar role
-    bytes32 public registrarRole;
+    bytes32 public immutable registrarRole;
 
     /// @dev Reverts if the sender is not the manager and does not have the
     /// registrar role

--- a/packages/airnode-protocol-v1/contracts/utils/RegistryRolesWithManager.sol
+++ b/packages/airnode-protocol-v1/contracts/utils/RegistryRolesWithManager.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "../access-control-registry/AccessControlRegistryAdminnedWithManager.sol";
 import "./interfaces/IRegistryRolesWithManager.sol";
 
-/// @title Contract that implements generic AccessControlRegistry roles for a
-/// registry contract
+/// @title Contract to be inherited by registry contracts that will use generic
+/// AccessControlRegistry roles
 contract RegistryRolesWithManager is
     AccessControlRegistryAdminnedWithManager,
     IRegistryRolesWithManager

--- a/packages/airnode-protocol-v1/contracts/utils/Uint256Registry.sol
+++ b/packages/airnode-protocol-v1/contracts/utils/Uint256Registry.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.9;
 import "./RegistryRolesWithManager.sol";
 import "./interfaces/IUint256Registry.sol";
 
-/// @title Registry with manager that maps IDs to unsigned integers
+/// @title Contract to be inherited by contracts that need a registry with
+/// manager that maps IDs to unsigned integers
 /// @dev Does not allow zero to be registered as a number
 contract Uint256Registry is RegistryRolesWithManager, IUint256Registry {
     mapping(bytes32 => uint256) private idToUint256;

--- a/packages/airnode-protocol-v1/contracts/whitelist/Whitelist.sol
+++ b/packages/airnode-protocol-v1/contracts/whitelist/Whitelist.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
-/// @title Contract that implements temporary and permanent whitelists for
-/// multiple services identified with a hash
+/// @title Contract to be inherited by contracts that need temporary and
+/// permanent whitelists for services identified by hashes
 /// @notice This contract implements two kinds of whitelisting:
 ///   (1) Temporary, ends when the expiration timestamp is in the past
 ///   (2) Indefinite, ends when the indefinite whitelist count is zero

--- a/packages/airnode-protocol-v1/contracts/whitelist/WhitelistRoles.sol
+++ b/packages/airnode-protocol-v1/contracts/whitelist/WhitelistRoles.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.9;
 
 import "./interfaces/IWhitelistRoles.sol";
 
-/// @title Contract that implements generic AccessControlRegistry roles for a
-/// whitelist contract
+/// @title Contract to be inherited by Whitelist contracts that will use
+/// generic AccessControlRegistry roles
 contract WhitelistRoles is IWhitelistRoles {
     // There are four roles implemented in this contract:
     // Root

--- a/packages/airnode-protocol-v1/contracts/whitelist/WhitelistRolesWithAirnode.sol
+++ b/packages/airnode-protocol-v1/contracts/whitelist/WhitelistRolesWithAirnode.sol
@@ -6,8 +6,8 @@ import "../access-control-registry/AccessControlRegistryAdminned.sol";
 import "./interfaces/IWhitelistRolesWithAirnode.sol";
 import "../access-control-registry/interfaces/IAccessControlRegistry.sol";
 
-/// @title Contract that implements AccessControlRegistry roles for a whitelist
-/// contract where each individual Airnode address is its own manager
+/// @title Contract to be inherited by Whitelist contracts that will use
+/// roles where each individual Airnode address is its own manager
 contract WhitelistRolesWithAirnode is
     WhitelistRoles,
     AccessControlRegistryAdminned,

--- a/packages/airnode-protocol-v1/contracts/whitelist/WhitelistRolesWithManager.sol
+++ b/packages/airnode-protocol-v1/contracts/whitelist/WhitelistRolesWithManager.sol
@@ -6,8 +6,8 @@ import "../access-control-registry/AccessControlRegistryAdminnedWithManager.sol"
 import "./interfaces/IWhitelistRolesWithManager.sol";
 import "../access-control-registry/interfaces/IAccessControlRegistry.sol";
 
-/// @title Contract that implements AccessControlRegistry roles for a whitelist
-/// contract controlled by a manager
+/// @title Contract to be inherited by Whitelist contracts that will use
+/// roles where there is a single manager
 contract WhitelistRolesWithManager is
     WhitelistRoles,
     AccessControlRegistryAdminnedWithManager,

--- a/packages/airnode-protocol-v1/contracts/whitelist/WhitelistWithManager.sol
+++ b/packages/airnode-protocol-v1/contracts/whitelist/WhitelistWithManager.sol
@@ -5,7 +5,8 @@ import "./Whitelist.sol";
 import "./WhitelistRolesWithManager.sol";
 import "./interfaces/IWhitelistWithManager.sol";
 
-/// @title Whitelist contract that is controlled by a manager
+/// @title Contract to be inherited by Whitelist contracts that are controlled
+/// by a manager
 contract WhitelistWithManager is
     Whitelist,
     WhitelistRolesWithManager,

--- a/packages/airnode-protocol-v1/package.json
+++ b/packages/airnode-protocol-v1/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "^4.3.2",
+    "@openzeppelin/contracts": "^4.4.2",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "hardhat": "^2.6.0",

--- a/packages/airnode-protocol-v1/test/monetization/AirnodeEndpointFeeRegistry.sol.js
+++ b/packages/airnode-protocol-v1/test/monetization/AirnodeEndpointFeeRegistry.sol.js
@@ -193,8 +193,8 @@ describe('registerDefaultChainPrice', function () {
 });
 
 describe('registerAirnodePrice', function () {
-  context('Sender has the registrar role', function () {
-    context('Airnode address is not zero', function () {
+  context('Airnode address is not zero', function () {
+    context('Sender has the registrar role', function () {
       context('Price is not zero', function () {
         it('sets Airnode price', async function () {
           const airnodeAddress = testUtils.generateRandomAddress();
@@ -222,18 +222,7 @@ describe('registerAirnodePrice', function () {
         });
       });
     });
-    context('Airnode address is zero', function () {
-      it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
-        const price = 123;
-        await expect(
-          airnodeEndpointPriceRegistry.connect(roles.registrar).registerAirnodePrice(airnodeAddress, price)
-        ).to.be.revertedWith('Airnode address zero');
-      });
-    });
-  });
-  context('Sender is the manager', function () {
-    context('Airnode address is not zero', function () {
+    context('Sender is the manager', function () {
       context('Price is not zero', function () {
         it('sets Airnode price', async function () {
           const airnodeAddress = testUtils.generateRandomAddress();
@@ -259,31 +248,31 @@ describe('registerAirnodePrice', function () {
         });
       });
     });
-    context('Airnode address is zero', function () {
+    context('Sender does not have the registrar role and is not the manager', function () {
       it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
+        const airnodeAddress = testUtils.generateRandomAddress();
         const price = 123;
         await expect(
-          airnodeEndpointPriceRegistry.connect(roles.manager).registerAirnodePrice(airnodeAddress, price)
-        ).to.be.revertedWith('Airnode address zero');
+          airnodeEndpointPriceRegistry.connect(roles.randomPerson).registerAirnodePrice(airnodeAddress, price)
+        ).to.be.revertedWith('Sender cannot register');
       });
     });
   });
-  context('Sender does not have the registrar role and is not the manager', function () {
+  context('Airnode address is zero', function () {
     it('reverts', async function () {
-      const airnodeAddress = testUtils.generateRandomAddress();
+      const airnodeAddress = hre.ethers.constants.AddressZero;
       const price = 123;
       await expect(
         airnodeEndpointPriceRegistry.connect(roles.randomPerson).registerAirnodePrice(airnodeAddress, price)
-      ).to.be.revertedWith('Sender cannot register');
+      ).to.be.revertedWith('Airnode address zero');
     });
   });
 });
 
 describe('registerAirnodeChainPrice', function () {
-  context('Sender has the registrar role', function () {
-    context('Airnode address is not zero', function () {
-      context('Chain ID is not zero', function () {
+  context('Airnode address is not zero', function () {
+    context('Chain ID is not zero', function () {
+      context('Sender has the registrar role', function () {
         context('Price is not zero', function () {
           it('sets Airnode, chain price', async function () {
             const airnodeAddress = testUtils.generateRandomAddress();
@@ -320,35 +309,7 @@ describe('registerAirnodeChainPrice', function () {
           });
         });
       });
-      context('Chain ID is zero', function () {
-        it('reverts', async function () {
-          const airnodeAddress = testUtils.generateRandomAddress();
-          const chainId = 0;
-          const price = 123;
-          await expect(
-            airnodeEndpointPriceRegistry
-              .connect(roles.registrar)
-              .registerAirnodeChainPrice(airnodeAddress, chainId, price)
-          ).to.be.revertedWith('Chain ID zero');
-        });
-      });
-    });
-    context('Airnode address is zero', function () {
-      it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
-        const chainId = 3;
-        const price = 123;
-        await expect(
-          airnodeEndpointPriceRegistry
-            .connect(roles.registrar)
-            .registerAirnodeChainPrice(airnodeAddress, chainId, price)
-        ).to.be.revertedWith('Airnode address zero');
-      });
-    });
-  });
-  context('Sender is the manager', function () {
-    context('Airnode address is not zero', function () {
-      context('Chain ID is not zero', function () {
+      context('Sender is the manager', function () {
         context('Price is not zero', function () {
           it('sets Airnode, chain price', async function () {
             const airnodeAddress = testUtils.generateRandomAddress();
@@ -385,47 +346,49 @@ describe('registerAirnodeChainPrice', function () {
           });
         });
       });
-      context('Chain ID is zero', function () {
+      context('Sender does not have the registrar role and is not the manager', function () {
         it('reverts', async function () {
           const airnodeAddress = testUtils.generateRandomAddress();
-          const chainId = 0;
+          const chainId = 3;
           const price = 123;
           await expect(
             airnodeEndpointPriceRegistry
-              .connect(roles.manager)
+              .connect(roles.randomPerson)
               .registerAirnodeChainPrice(airnodeAddress, chainId, price)
-          ).to.be.revertedWith('Chain ID zero');
+          ).to.be.revertedWith('Sender cannot register');
         });
       });
     });
-    context('Airnode address is zero', function () {
+    context('Chain ID is zero', function () {
       it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
-        const chainId = 3;
+        const airnodeAddress = testUtils.generateRandomAddress();
+        const chainId = 0;
         const price = 123;
         await expect(
-          airnodeEndpointPriceRegistry.connect(roles.manager).registerAirnodeChainPrice(airnodeAddress, chainId, price)
-        ).to.be.revertedWith('Airnode address zero');
+          airnodeEndpointPriceRegistry
+            .connect(roles.randomPerson)
+            .registerAirnodeChainPrice(airnodeAddress, chainId, price)
+        ).to.be.revertedWith('Chain ID zero');
       });
     });
   });
-  context('Sender does not have the registrar role and is not the manager', function () {
+  context('Airnode address is zero', function () {
     it('reverts', async function () {
-      const airnodeAddress = testUtils.generateRandomAddress();
+      const airnodeAddress = hre.ethers.constants.AddressZero;
       const chainId = 3;
       const price = 123;
       await expect(
         airnodeEndpointPriceRegistry
           .connect(roles.randomPerson)
           .registerAirnodeChainPrice(airnodeAddress, chainId, price)
-      ).to.be.revertedWith('Sender cannot register');
+      ).to.be.revertedWith('Airnode address zero');
     });
   });
 });
 
 describe('registerAirnodeEndpointPrice', function () {
-  context('Sender has the registrar role', function () {
-    context('Airnode address is not zero', function () {
+  context('Airnode address is not zero', function () {
+    context('Sender has the registrar role', function () {
       context('Price is not zero', function () {
         it('sets Airnode, endpoint price', async function () {
           const airnodeAddress = testUtils.generateRandomAddress();
@@ -465,21 +428,7 @@ describe('registerAirnodeEndpointPrice', function () {
         });
       });
     });
-    context('Airnode address is zero', function () {
-      it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
-        const endpointId = testUtils.generateRandomBytes32();
-        const price = 123;
-        await expect(
-          airnodeEndpointPriceRegistry
-            .connect(roles.registrar)
-            .registerAirnodeEndpointPrice(airnodeAddress, endpointId, price)
-        ).to.be.revertedWith('Airnode address zero');
-      });
-    });
-  });
-  context('Sender is the manager', function () {
-    context('Airnode address is not zero', function () {
+    context('Sender is the manager', function () {
       context('Price is not zero', function () {
         it('sets Airnode, endpoint price', async function () {
           const airnodeAddress = testUtils.generateRandomAddress();
@@ -519,37 +468,37 @@ describe('registerAirnodeEndpointPrice', function () {
         });
       });
     });
-    context('Airnode address is zero', function () {
+    context('Sender does not have the registrar role and is not the manager', function () {
       it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
+        const airnodeAddress = testUtils.generateRandomAddress();
         const endpointId = testUtils.generateRandomBytes32();
         const price = 123;
         await expect(
           airnodeEndpointPriceRegistry
-            .connect(roles.manager)
+            .connect(roles.randomPerson)
             .registerAirnodeEndpointPrice(airnodeAddress, endpointId, price)
-        ).to.be.revertedWith('Airnode address zero');
+        ).to.be.revertedWith('Sender cannot register');
       });
     });
   });
-  context('Sender does not have the registrar role and is not the manager', function () {
+  context('Airnode address is zero', function () {
     it('reverts', async function () {
-      const airnodeAddress = testUtils.generateRandomAddress();
+      const airnodeAddress = hre.ethers.constants.AddressZero;
       const endpointId = testUtils.generateRandomBytes32();
       const price = 123;
       await expect(
         airnodeEndpointPriceRegistry
           .connect(roles.randomPerson)
           .registerAirnodeEndpointPrice(airnodeAddress, endpointId, price)
-      ).to.be.revertedWith('Sender cannot register');
+      ).to.be.revertedWith('Airnode address zero');
     });
   });
 });
 
 describe('registerAirnodeChainEndpointPrice', function () {
-  context('Sender has the registrar role', function () {
-    context('Airnode address is not zero', function () {
-      context('Chain ID is not zero', function () {
+  context('Airnode address is not zero', function () {
+    context('Chain ID is not zero', function () {
+      context('Sender has the registrar role', function () {
         context('Price is not zero', function () {
           it('sets Airnode, chain, endpoint price', async function () {
             const airnodeAddress = testUtils.generateRandomAddress();
@@ -593,37 +542,7 @@ describe('registerAirnodeChainEndpointPrice', function () {
           });
         });
       });
-      context('Chain ID is zero', function () {
-        it('reverts', async function () {
-          const airnodeAddress = testUtils.generateRandomAddress();
-          const chainId = 0;
-          const endpointId = testUtils.generateRandomBytes32();
-          const price = 123;
-          await expect(
-            airnodeEndpointPriceRegistry
-              .connect(roles.registrar)
-              .registerAirnodeChainEndpointPrice(airnodeAddress, chainId, endpointId, price)
-          ).to.be.revertedWith('Chain ID zero');
-        });
-      });
-    });
-    context('Airnode address is zero', function () {
-      it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
-        const chainId = 3;
-        const endpointId = testUtils.generateRandomBytes32();
-        const price = 123;
-        await expect(
-          airnodeEndpointPriceRegistry
-            .connect(roles.registrar)
-            .registerAirnodeChainEndpointPrice(airnodeAddress, chainId, endpointId, price)
-        ).to.be.revertedWith('Airnode address zero');
-      });
-    });
-  });
-  context('Sender is the manager', function () {
-    context('Airnode address is not zero', function () {
-      context('Chain ID is not zero', function () {
+      context('Sender is the manager', function () {
         context('Price is not zero', function () {
           it('sets Airnode, chain, endpoint price', async function () {
             const airnodeAddress = testUtils.generateRandomAddress();
@@ -667,37 +586,37 @@ describe('registerAirnodeChainEndpointPrice', function () {
           });
         });
       });
-      context('Chain ID is zero', function () {
+      context('Sender does not have the registrar role and is not the manager', function () {
         it('reverts', async function () {
           const airnodeAddress = testUtils.generateRandomAddress();
-          const chainId = 0;
+          const chainId = 3;
           const endpointId = testUtils.generateRandomBytes32();
           const price = 123;
           await expect(
             airnodeEndpointPriceRegistry
-              .connect(roles.manager)
+              .connect(roles.randomPerson)
               .registerAirnodeChainEndpointPrice(airnodeAddress, chainId, endpointId, price)
-          ).to.be.revertedWith('Chain ID zero');
+          ).to.be.revertedWith('Sender cannot register');
         });
       });
     });
-    context('Airnode address is zero', function () {
+    context('Chain ID is zero', function () {
       it('reverts', async function () {
-        const airnodeAddress = hre.ethers.constants.AddressZero;
-        const chainId = 3;
+        const airnodeAddress = testUtils.generateRandomAddress();
+        const chainId = 0;
         const endpointId = testUtils.generateRandomBytes32();
         const price = 123;
         await expect(
           airnodeEndpointPriceRegistry
-            .connect(roles.manager)
+            .connect(roles.randomPerson)
             .registerAirnodeChainEndpointPrice(airnodeAddress, chainId, endpointId, price)
-        ).to.be.revertedWith('Airnode address zero');
+        ).to.be.revertedWith('Chain ID zero');
       });
     });
   });
-  context('Sender does not have the registrar role and is not the manager', function () {
+  context('Airnode address is zero', function () {
     it('reverts', async function () {
-      const airnodeAddress = testUtils.generateRandomAddress();
+      const airnodeAddress = hre.ethers.constants.AddressZero;
       const chainId = 3;
       const endpointId = testUtils.generateRandomBytes32();
       const price = 123;
@@ -705,7 +624,7 @@ describe('registerAirnodeChainEndpointPrice', function () {
         airnodeEndpointPriceRegistry
           .connect(roles.randomPerson)
           .registerAirnodeChainEndpointPrice(airnodeAddress, chainId, endpointId, price)
-      ).to.be.revertedWith('Sender cannot register');
+      ).to.be.revertedWith('Airnode address zero');
     });
   });
 });

--- a/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerRegistry.sol.js
+++ b/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerRegistry.sol.js
@@ -40,8 +40,8 @@ beforeEach(async () => {
 });
 
 describe('registerChainRequesterAuthorizer', function () {
-  context('Sender has the registrar role', function () {
-    context('Chain ID is not zero', function () {
+  context('Chain ID is not zero', function () {
+    context('Sender has the registrar role', function () {
       context('RequesterAuthorizer has not been set before', function () {
         context('RequesterAuthorizer address is not zero', function () {
           it('sets RequesterAuthorizer address for the chain', async function () {
@@ -94,20 +94,7 @@ describe('registerChainRequesterAuthorizer', function () {
         });
       });
     });
-    context('Chain ID is zero', function () {
-      it('reverts', async function () {
-        const chainId = 0;
-        const requesterAuthorizerAddress = testUtils.generateRandomAddress();
-        await expect(
-          requesterAuthorizerRegistry
-            .connect(roles.registrar)
-            .registerChainRequesterAuthorizer(chainId, requesterAuthorizerAddress)
-        ).to.be.revertedWith('Chain ID zero');
-      });
-    });
-  });
-  context('Sender is the manager', function () {
-    context('Chain ID is not zero', function () {
+    context('Sender is the manager', function () {
       context('RequesterAuthorizer address is not zero', function () {
         it('sets default price', async function () {
           const chainId = 3;
@@ -142,27 +129,27 @@ describe('registerChainRequesterAuthorizer', function () {
         });
       });
     });
-    context('Chain ID is zero', function () {
+    context('Sender does not have the registrar role and is not the manager', function () {
       it('reverts', async function () {
-        const chainId = 0;
+        const chainId = 3;
         const requesterAuthorizerAddress = testUtils.generateRandomAddress();
         await expect(
           requesterAuthorizerRegistry
-            .connect(roles.manager)
+            .connect(roles.randomPerson)
             .registerChainRequesterAuthorizer(chainId, requesterAuthorizerAddress)
-        ).to.be.revertedWith('Chain ID zero');
+        ).to.be.revertedWith('Sender cannot register');
       });
     });
   });
-  context('Sender does not have the registrar role and is not the manager', function () {
+  context('Chain ID is zero', function () {
     it('reverts', async function () {
-      const chainId = 3;
+      const chainId = 0;
       const requesterAuthorizerAddress = testUtils.generateRandomAddress();
       await expect(
         requesterAuthorizerRegistry
           .connect(roles.randomPerson)
           .registerChainRequesterAuthorizer(chainId, requesterAuthorizerAddress)
-      ).to.be.revertedWith('Sender cannot register');
+      ).to.be.revertedWith('Chain ID zero');
     });
   });
 });

--- a/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenDeposit.sol.js
+++ b/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenDeposit.sol.js
@@ -1063,7 +1063,7 @@ describe('depositTokens', function () {
                   requesterAuthorizerWhitelisterWithTokenDeposit
                     .connect(roles.depositor)
                     .depositTokens(roles.airnode.address, chainId, endpointId, requester)
-                ).to.be.revertedWith('ERC20: transfer amount exceeds allowance');
+                ).to.be.revertedWith('ERC20: insufficient allowance');
               });
             });
           });

--- a/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenPayment.sol.js
+++ b/packages/airnode-protocol-v1/test/monetization/RequesterAuthorizerWhitelisterWithTokenPayment.sol.js
@@ -1147,7 +1147,7 @@ describe('payTokens', function () {
                   requesterAuthorizerWhitelisterWithTokenPayment
                     .connect(roles.payer)
                     .payTokens(roles.airnode.address, chainId, endpointId, requester, whitelistExtension)
-                ).to.be.revertedWith('ERC20: transfer amount exceeds allowance');
+                ).to.be.revertedWith('ERC20: insufficient allowance');
               });
             });
           });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,6 +2662,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.3.tgz#ff6ee919fc2a1abaf72b22814bfb72ed129ec137"
   integrity sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g==
 
+"@openzeppelin/contracts@^4.4.2":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
+  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+
 "@pm2/agent@~2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@pm2/agent/-/agent-2.0.1.tgz#0edffc54cd8ee2b12f90136264e7880f3f78c79d"


### PR DESCRIPTION
> To reduce gas costs, make variables immutable wherever possible

Addressed in https://github.com/api3dao/airnode/commit/53f2a33594f53bad819a10bde01d4a20ae107564

> To improve readability make contracts abstract if they should not be deployed

If a contract doesn't implement the whole interface the compiler errors. Using `abstract` as described above disables this check, so `abstract` shouldn't be used unless the contract actually doesn't implement the whole interface. As a compromise, the title strings of such contracts are edited to all start with `"Contract to be inherited..."` (some contracts that are not planned to deployed in standalone fashion but potentially could have been are omitted) https://github.com/api3dao/airnode/commit/a0df928212111d7f49ffa443d736f32819dd3435

> Improve the NatSpec comments

Addressed in https://github.com/api3dao/airnode/commit/69174d9ff0f1832a4e6c779f98c3019cd52b9805

> Remove the onlyRegistrarOrManager modifier from _registerAddress

It didn't feel right for `_registerAddress()` to not check if the sender is allowed to register an address. Therefore, I removed the `onlyRegistrarOrManager` from the exposed function instead https://github.com/api3dao/airnode/commit/3ed253e99c6f5a211f8a15c3ee6ea28ff9c55dab

> Replace the deprecated _setupRole with _grantRole

The audited contracts use OpenZeppelin contracts 4.3.2 where _setupRole isn't deprecated yet and _grantRole is private so this suggestion doesn't work. Updated the OpenZeppelin contracts to 4.4.2 anyway and implemented this https://github.com/api3dao/airnode/commit/c954ad6883989f7982ca2f3ba21b9f5968e5e919

> Remove the require(...) check

The redundant check was added on purpose so that Sort.sol doesn't get reused overseeing this requirement, so leaving this in.