### PR TITLE
Remove Errored variant of RequestStatus enum

### DIFF
--- a/.changeset/fifty-bottles-suffer.md
+++ b/.changeset/fifty-bottles-suffer.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': minor
+---
+
+Remove Errored variant of RequestStatus enum and drop errored requests

--- a/packages/airnode-node/src/coordinator/calls/aggregation.test.ts
+++ b/packages/airnode-node/src/coordinator/calls/aggregation.test.ts
@@ -4,10 +4,7 @@ import { RequestStatus } from '../../types';
 
 describe('aggregate (API calls)', () => {
   it('ignores requests that are not pending', () => {
-    const apiCalls = [
-      fixtures.requests.buildApiCall({ status: RequestStatus.Errored }),
-      fixtures.requests.buildApiCall({ status: RequestStatus.Blocked }),
-    ];
+    const apiCalls = [fixtures.requests.buildApiCall({ status: RequestStatus.Blocked })];
     const res = aggregation.aggregate(fixtures.buildConfig(), apiCalls);
     expect(res).toEqual({});
   });

--- a/packages/airnode-node/src/coordinator/calls/disaggregation.test.ts
+++ b/packages/airnode-node/src/coordinator/calls/disaggregation.test.ts
@@ -43,7 +43,7 @@ describe('disaggregate - Requests', () => {
     );
   });
 
-  it('does not update the request if the parameters are different', () => {
+  it('drops the request if the parameters are different', () => {
     const requests0: GroupedRequests = {
       apiCalls: [fixtures.requests.buildApiCall({ id: 'ethCall', parameters: { from: 'ETH' } })],
       withdrawals: [],
@@ -76,11 +76,7 @@ describe('disaggregate - Requests', () => {
     expect(logs).toEqual([
       { level: 'ERROR', message: 'Unable to find matching aggregated API calls for Request:ethCall' },
     ]);
-    expect(res[0].requests.apiCalls[0].responseValue).toEqual(undefined);
-    expect(res[0].requests.apiCalls[0].status).toEqual(RequestStatus.Blocked);
-    expect(res[0].requests.apiCalls[0].errorMessage).toEqual(
-      `${RequestErrorMessage.NoMatchingAggregatedApiCall}: ethCall`
-    );
+    expect(res[0].requests.apiCalls.length).toEqual(0);
     expect(res[1].requests.apiCalls[0].responseValue).toEqual('0x123');
     expect(res[1].requests.apiCalls[0].status).toEqual(RequestStatus.Pending);
     expect(res[1].requests.apiCalls[0].errorMessage).toEqual(undefined);
@@ -88,7 +84,7 @@ describe('disaggregate - Requests', () => {
 
   it('does not update API calls if the status is not pending', () => {
     const apiCall = fixtures.requests.buildApiCall({
-      status: RequestStatus.Errored,
+      status: RequestStatus.Blocked,
       errorMessage: RequestErrorMessage.Unauthorized,
     });
     const requests: GroupedRequests = { apiCalls: [apiCall], withdrawals: [] };
@@ -117,7 +113,7 @@ describe('disaggregate - Requests', () => {
     expect(res[0].requests.apiCalls).toEqual([apiCall]);
   });
 
-  it('applies the error code to each individual request', () => {
+  it('drops errored requests', () => {
     const apiCall = fixtures.requests.buildApiCall();
     const requests: GroupedRequests = { apiCalls: [apiCall], withdrawals: [] };
 
@@ -142,14 +138,8 @@ describe('disaggregate - Requests', () => {
 
     const [logs, res] = disaggregation.disaggregate(mutableState);
     expect(logs).toEqual([]);
-    expect(res[0].requests.apiCalls).toEqual([
-      { ...apiCall, errorMessage: RequestErrorMessage.ApiCallFailed, status: RequestStatus.Errored },
-    ]);
-    expect(res[1].requests.apiCalls).toEqual([
-      { ...apiCall, errorMessage: RequestErrorMessage.ApiCallFailed, status: RequestStatus.Errored },
-    ]);
-    expect(res[2].requests.apiCalls).toEqual([
-      { ...apiCall, errorMessage: RequestErrorMessage.ApiCallFailed, status: RequestStatus.Errored },
-    ]);
+    expect(res[0].requests.apiCalls).toEqual([{ ...apiCall, errorMessage: RequestErrorMessage.ApiCallFailed }]);
+    expect(res[1].requests.apiCalls).toEqual([{ ...apiCall, errorMessage: RequestErrorMessage.ApiCallFailed }]);
+    expect(res[2].requests.apiCalls).toEqual([{ ...apiCall, errorMessage: RequestErrorMessage.ApiCallFailed }]);
   });
 });

--- a/packages/airnode-node/src/coordinator/calls/disaggregation.ts
+++ b/packages/airnode-node/src/coordinator/calls/disaggregation.ts
@@ -12,7 +12,7 @@ import {
   UpdatedRequests,
 } from '../../types';
 
-function updateApiCallResponse(
+function updateApiCallResponses(
   apiCalls: Request<ApiCall>[],
   aggregatedApiCallsById: AggregatedApiCallsById
 ): LogsData<Request<ApiCall>[]> {
@@ -53,7 +53,7 @@ function mapEVMProviderState(
   state: ProviderState<EVMProviderState>,
   aggregatedApiCallsById: AggregatedApiCallsById
 ): LogsData<ProviderState<EVMProviderState>> {
-  const [logs, apiCalls] = updateApiCallResponse(state.requests.apiCalls, aggregatedApiCallsById);
+  const [logs, apiCalls] = updateApiCallResponses(state.requests.apiCalls, aggregatedApiCallsById);
   const requests = { ...state.requests, apiCalls };
 
   return [logs, { ...state, requests }];

--- a/packages/airnode-node/src/evm/authorization/authorization-application.ts
+++ b/packages/airnode-node/src/evm/authorization/authorization-application.ts
@@ -1,69 +1,68 @@
-import flatMap from 'lodash/flatMap';
 import isNil from 'lodash/isNil';
 import { logger } from '@api3/airnode-utilities';
-import { ApiCall, AuthorizationByRequestId, Request, LogsData, RequestErrorMessage, RequestStatus } from '../../types';
+import {
+  ApiCall,
+  AuthorizationByRequestId,
+  Request,
+  LogsData,
+  RequestErrorMessage,
+  RequestStatus,
+  UpdatedRequests,
+} from '../../types';
 
 function applyAuthorization(
-  apiCall: Request<ApiCall>,
+  apiCalls: Request<ApiCall>[],
   authorizationByRequestId: AuthorizationByRequestId
-): LogsData<Request<ApiCall>> {
-  // Don't overwrite any existing error codes or statuses
-  if (apiCall.errorMessage || apiCall.status !== RequestStatus.Pending) {
-    return [[], apiCall];
-  }
+): LogsData<Request<ApiCall>[]> {
+  const { logs, requests } = apiCalls.reduce(
+    (acc, apiCall) => {
+      // Don't overwrite any existing error codes or statuses
+      if (apiCall.errorMessage || apiCall.status !== RequestStatus.Pending) {
+        return { ...acc, requests: [...acc.requests, apiCall] };
+      }
 
-  // There should always be an endpointId at this point, but just in case, check again
-  // and drop the request if it is missing. If endpointId is missing, it means that the
-  // template was not loaded
-  if (!apiCall.endpointId) {
-    const log = logger.pend('ERROR', `No endpoint ID found for Request ID:${apiCall.id}`);
-    const updatedApiCall: Request<ApiCall> = {
-      ...apiCall,
-      status: RequestStatus.Blocked,
-      errorMessage: RequestErrorMessage.TemplateNotFound, // TODO: shouldn't this be UnknownEndpointId?
-    };
-    return [[log], updatedApiCall];
-  }
+      // There should always be an endpointId at this point, but just in case, check again
+      // and drop the request if it is missing. If endpointId is missing, it means that the
+      // template was not loaded
+      if (!apiCall.endpointId) {
+        const log = logger.pend('ERROR', `No endpoint ID found for Request ID:${apiCall.id}`);
+        return { ...acc, logs: [...acc.logs, log] };
+      }
 
-  const authorized = authorizationByRequestId[apiCall.id];
+      const authorized = authorizationByRequestId[apiCall.id];
 
-  // If we couldn't fetch the authorization status, block the request until the next run
-  if (isNil(authorized)) {
-    const log = logger.pend('WARN', `Authorization not found for Request ID:${apiCall.id}`);
-    const updatedApiCall: Request<ApiCall> = {
-      ...apiCall,
-      status: RequestStatus.Blocked,
-      errorMessage: RequestErrorMessage.AuthorizationNotFound,
-    };
-    return [[log], updatedApiCall];
-  }
+      // If we couldn't fetch the authorization status, block the request until the next run
+      if (isNil(authorized)) {
+        const log = logger.pend('WARN', `Authorization not found for Request ID:${apiCall.id}`);
+        const updatedApiCall: Request<ApiCall> = {
+          ...apiCall,
+          status: RequestStatus.Blocked,
+          errorMessage: RequestErrorMessage.AuthorizationNotFound,
+        };
+        return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, updatedApiCall] };
+      }
 
-  if (authorized) {
-    return [[], apiCall];
-  }
+      if (authorized) {
+        return { ...acc, requests: [...acc.requests, apiCall] };
+      }
 
-  const log = logger.pend(
-    'WARN',
-    `Requester:${apiCall.requesterAddress} is not authorized to access Endpoint ID:${apiCall.endpointId} for Request ID:${apiCall.id}`
+      // If the request is unauthorized, update drop the request
+      const log = logger.pend(
+        'WARN',
+        `Requester:${apiCall.requesterAddress} is not authorized to access Endpoint ID:${apiCall.endpointId} for Request ID:${apiCall.id}`
+      );
+      return { ...acc, logs: [...acc.logs, log] };
+    },
+    { logs: [], requests: [] } as UpdatedRequests<ApiCall>
   );
-  // If the request is unauthorized, update the status of the request
-  const updatedApiCall: Request<ApiCall> = {
-    ...apiCall,
-    status: RequestStatus.Errored,
-    errorMessage: `${RequestErrorMessage.Unauthorized}: ${apiCall.requesterAddress}`,
-  };
-  return [[log], updatedApiCall];
+  return [logs, requests];
 }
 
 export function mergeAuthorizations(
   apiCalls: Request<ApiCall>[],
   authorizationByRequestId: AuthorizationByRequestId
 ): LogsData<Request<ApiCall>[]> {
-  const logsWithApiCalls = apiCalls.map((apiCall) => {
-    return applyAuthorization(apiCall, authorizationByRequestId);
-  });
+  const [logs, authorizedApiCalls] = applyAuthorization(apiCalls, authorizationByRequestId);
 
-  const logs = flatMap(logsWithApiCalls, (a) => a[0]);
-  const authorizedApiCalls = flatMap(logsWithApiCalls, (a) => a[1]);
   return [logs, authorizedApiCalls];
 }

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.test.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.test.ts
@@ -219,7 +219,6 @@ describe('submitApiCall', () => {
         expect(data).toEqual({
           ...apiCall,
           fulfillment: { hash: '0xfailtransaction' },
-          status: RequestStatus.Errored,
           errorMessage: 'Fulfill transaction failed',
         });
         expect(staticFulfillMock).toHaveBeenCalledTimes(1);
@@ -276,7 +275,6 @@ describe('submitApiCall', () => {
         expect(data).toEqual({
           ...apiCall,
           fulfillment: { hash: '0xfailtransaction' },
-          status: RequestStatus.Errored,
           errorMessage: 'Fulfill transaction failed',
         });
         expect(staticFulfillMock).toHaveBeenCalledTimes(1);
@@ -416,7 +414,6 @@ describe('submitApiCall', () => {
         failMock.mockResolvedValueOnce({ hash: '0xfailtransaction' });
         const apiCall = fixtures.requests.buildApiCall({
           errorMessage: RequestErrorMessage.ApiCallFailed,
-          status: RequestStatus.Errored,
           nonce: 5,
         });
         const [logs, err, data] = await apiCalls.submitApiCall(createAirnodeRrpFake(), apiCall, {
@@ -460,7 +457,6 @@ describe('submitApiCall', () => {
         failMock.mockResolvedValueOnce({ hash: '0xfailtransaction' });
         const apiCall = fixtures.requests.buildApiCall({
           errorMessage: longError,
-          status: RequestStatus.Errored,
           nonce: 5,
         });
 
@@ -507,7 +503,6 @@ describe('submitApiCall', () => {
         const apiCall = fixtures.requests.buildApiCall({
           id: '0xb56b66dc089eab3dc98672ea5e852488730a8f76621fd9ea719504ea205980f8',
           errorMessage: `${RequestErrorMessage.ApiCallFailed} with error: Server did not respond`,
-          status: RequestStatus.Errored,
           nonce: 5,
         });
         const [logs, err, data] = await apiCalls.submitApiCall(createAirnodeRrpFake(), apiCall, {

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.ts
@@ -124,7 +124,6 @@ async function testAndSubmitFulfill(
   if (testErr || (testData && !testData.callSuccess)) {
     const updatedRequest: Request<ApiCall> = {
       ...request,
-      status: RequestStatus.Errored,
       errorMessage: testErr
         ? `${RequestErrorMessage.FulfillTransactionFailed} with error: ${testErr.message}`
         : RequestErrorMessage.FulfillTransactionFailed,
@@ -193,7 +192,7 @@ async function submitFail(
 // Main functions
 // =================================================================
 export const submitApiCall: SubmitRequest<ApiCall> = async (airnodeRrp, request, options) => {
-  if (request.status !== RequestStatus.Pending && request.status !== RequestStatus.Errored) {
+  if (request.status !== RequestStatus.Pending) {
     const log = logger.pend(
       'INFO',
       `API call for Request:${request.id} not actioned as it has status:${request.status}`

--- a/packages/airnode-node/src/evm/fulfillments/withdrawals.test.ts
+++ b/packages/airnode-node/src/evm/fulfillments/withdrawals.test.ts
@@ -84,20 +84,14 @@ describe('submitWithdrawal', () => {
   );
 
   test.each([gasTarget, gasTargetFallback])(
-    `does nothing if the request is blocked or errored - %#`,
+    `does nothing if the request is blocked - %#`,
     async (gasTarget: GasTarget) => {
       const provider = new ethers.providers.JsonRpcProvider();
       // NOTE: a withdrawal should not be able to become "errored" or "blocked", but this
       // is just in case that changes
       const blocked = fixtures.requests.buildWithdrawal({ status: RequestStatus.Blocked });
-      const errored = fixtures.requests.buildWithdrawal({ status: RequestStatus.Errored });
 
       const blockedRes = await withdrawals.submitWithdrawal(createAirnodeRrpFake(), blocked, {
-        gasTarget,
-        masterHDNode,
-        provider,
-      });
-      const erroredRes = await withdrawals.submitWithdrawal(createAirnodeRrpFake(), errored, {
         gasTarget,
         masterHDNode,
         provider,
@@ -111,14 +105,6 @@ describe('submitWithdrawal', () => {
       ]);
       expect(blockedRes[1]).toEqual(null);
       expect(blockedRes[2]).toEqual(null);
-      expect(erroredRes[0]).toEqual([
-        {
-          level: 'INFO',
-          message: `Withdrawal sponsor address:${errored.sponsorAddress} for Request:${errored.id} not actioned as it has status:${errored.status}`,
-        },
-      ]);
-      expect(erroredRes[1]).toEqual(null);
-      expect(erroredRes[2]).toEqual(null);
       expect(fulfillWithdrawalMock).not.toHaveBeenCalled();
     }
   );

--- a/packages/airnode-node/src/evm/requests/api-calls.ts
+++ b/packages/airnode-node/src/evm/requests/api-calls.ts
@@ -1,5 +1,4 @@
-import flatMap from 'lodash/flatMap';
-import { logger, PendingLog } from '@api3/airnode-utilities';
+import { logger } from '@api3/airnode-utilities';
 import * as events from './events';
 import * as encoding from '../abi-encoding';
 import { airnodeRrpTopics } from '../contracts';
@@ -11,8 +10,8 @@ import {
   EVMMadeRequestLog,
   EVMFulfilledRequestLog,
   LogsData,
-  RequestErrorMessage,
   RequestStatus,
+  UpdatedRequests,
 } from '../../types';
 
 function getApiCallType(topic: string): ApiCallType {
@@ -60,32 +59,35 @@ export function initialize(log: EVMMadeRequestLog): Request<ApiCall> {
   return request;
 }
 
-export function applyParameters(request: Request<ApiCall>): LogsData<Request<ApiCall>> {
-  if (!request.encodedParameters) {
-    return [[], request];
-  }
+export function applyParameters(apiCalls: Request<ApiCall>[]): LogsData<Request<ApiCall>[]> {
+  const { logs, requests } = apiCalls.reduce(
+    (acc, apiCall) => {
+      if (!apiCall.encodedParameters) {
+        return {
+          ...acc,
+          requests: [...acc.requests, apiCall],
+        };
+      }
 
-  const parameters = encoding.safeDecode(request.encodedParameters);
-  if (parameters === null) {
-    const { id, encodedParameters } = request;
+      const parameters = encoding.safeDecode(apiCall.encodedParameters);
+      if (parameters === null) {
+        // Drop request
+        const { id, encodedParameters } = apiCall;
+        const log = logger.pend('ERROR', `Request ID:${id} submitted with invalid parameters: ${encodedParameters}`);
+        return {
+          ...acc,
+          logs: [...acc.logs, log],
+        };
+      }
 
-    const log = logger.pend('ERROR', `Request ID:${id} submitted with invalid parameters: ${encodedParameters}`);
-
-    const updatedRequest: Request<ApiCall> = {
-      ...request,
-      status: RequestStatus.Errored,
-      errorMessage: `${RequestErrorMessage.RequestParameterDecodingFailed}: ${encodedParameters}`,
-    };
-
-    return [[log], updatedRequest];
-  }
-
-  return [[], { ...request, parameters }];
-}
-
-export interface UpdatedFulfilledRequests {
-  readonly logs: PendingLog[];
-  readonly requests: Request<ApiCall>[];
+      return {
+        ...acc,
+        requests: [...acc.requests, { ...apiCall, parameters }],
+      };
+    },
+    { logs: [], requests: [] } as UpdatedRequests<ApiCall>
+  );
+  return [logs, requests];
 }
 
 export function dropFulfilledRequests(
@@ -98,15 +100,12 @@ export function dropFulfilledRequests(
         // Drop request
         const log = logger.pend('DEBUG', `Request ID:${apiCall.id} (API call) has already been fulfilled`);
 
-        return {
-          ...acc,
-          logs: [...acc.logs, log],
-        };
+        return { ...acc, logs: [...acc.logs, log] };
       }
 
       return { ...acc, requests: [...acc.requests, apiCall] };
     },
-    { logs: [], requests: [] } as UpdatedFulfilledRequests
+    { logs: [], requests: [] } as UpdatedRequests<ApiCall>
   );
 
   return [logs, requests];
@@ -122,12 +121,10 @@ export function mapRequests(logsWithMetadata: EVMEventLog[]): LogsData<Request<A
   // Cast raw logs to typed API request objects
   const apiCallRequests = requestLogs.map(initialize);
 
-  // Decode and apply parameters for each API call
-  const parameterized = apiCallRequests.map(applyParameters);
-  const parameterLogs = flatMap(parameterized, (p) => p[0]);
-  const parameterizedRequests = flatMap(parameterized, (p) => p[1]);
+  // Decode and apply parameters for each API call or drop if error
+  const [parameterLogs, parameterizedRequests] = applyParameters(apiCallRequests);
 
-  // Update the status of requests that have already been fulfilled
+  // Drop requests that have already been fulfilled
   const fulfilledRequestIds = fulfillmentLogs.map((fl) => fl.parsedLog.args.requestId);
   const [fulfilledLogs, apiCallsWithFulfillments] = dropFulfilledRequests(parameterizedRequests, fulfilledRequestIds);
 

--- a/packages/airnode-node/src/evm/templates/template-application.test.ts
+++ b/packages/airnode-node/src/evm/templates/template-application.test.ts
@@ -1,6 +1,6 @@
 import * as application from './template-application';
 import * as fixtures from '../../../test/fixtures';
-import { ApiCallTemplate, RequestErrorMessage, RequestStatus } from '../../types';
+import { ApiCallTemplate } from '../../types';
 
 describe('mergeApiCallsWithTemplates', () => {
   it('returns API calls without a template ID', () => {
@@ -89,17 +89,16 @@ describe('mergeApiCallsWithTemplates', () => {
     expect(res[0].parameters).toEqual({ from: 'BTC', amount: '5000' });
   });
 
-  it('blocks API calls where the template cannot be found', () => {
+  it('drops API calls where the template cannot be found', () => {
     const apiCall = fixtures.requests.buildApiCall({ templateId: 'templateId-0' });
     const [logs, res] = application.mergeApiCallsWithTemplates([apiCall], {});
     expect(logs).toEqual([
       { level: 'ERROR', message: 'Unable to fetch template ID:templateId-0 for Request ID:apiCallId' },
     ]);
-    expect(res[0].status).toEqual(RequestStatus.Blocked);
-    expect(res[0].errorMessage).toEqual(`${RequestErrorMessage.TemplateNotFound}: templateId-0`);
+    expect(res.length).toEqual(0);
   });
 
-  it('invalidates API calls with invalid template parameters', () => {
+  it('drops API calls with invalid template parameters', () => {
     const apiCall = fixtures.requests.buildApiCall({ templateId: 'templateId-0' });
 
     const templatesById: { readonly [id: string]: ApiCallTemplate } = {
@@ -115,7 +114,6 @@ describe('mergeApiCallsWithTemplates', () => {
     expect(logs).toEqual([
       { level: 'ERROR', message: 'Template ID:templateId-0 contains invalid parameters: invalid-parameters' },
     ]);
-    expect(res[0].status).toEqual(RequestStatus.Errored);
-    expect(res[0].errorMessage).toEqual(`${RequestErrorMessage.TemplateParameterDecodingFailed}: invalid-parameters`);
+    expect(res.length).toEqual(0);
   });
 });

--- a/packages/airnode-node/src/evm/templates/template-application.ts
+++ b/packages/airnode-node/src/evm/templates/template-application.ts
@@ -34,7 +34,7 @@ function applyTemplate(
 }
 
 // TODO: This could also be done in call-api
-function updateApiCallWithTemplate(
+function updateApiCallsWithTemplate(
   apiCalls: Request<ApiCall>[],
   templatesById: ApiCallTemplatesById
 ): LogsData<Request<ApiCall>[]> {
@@ -88,7 +88,7 @@ export function mergeApiCallsWithTemplates(
   apiCalls: Request<ApiCall>[],
   templatesById: ApiCallTemplatesById
 ): LogsData<Request<ApiCall>[]> {
-  const [logs, templatedApiCalls] = updateApiCallWithTemplate(apiCalls, templatesById);
+  const [logs, templatedApiCalls] = updateApiCallsWithTemplate(apiCalls, templatesById);
 
   return [logs, templatedApiCalls];
 }

--- a/packages/airnode-node/src/evm/templates/template-application.ts
+++ b/packages/airnode-node/src/evm/templates/template-application.ts
@@ -1,4 +1,3 @@
-import flatMap from 'lodash/flatMap';
 import { logger } from '@api3/airnode-utilities';
 import * as evm from '..';
 import {
@@ -7,9 +6,9 @@ import {
   ApiCallTemplate,
   Request,
   LogsData,
-  RequestErrorMessage,
   RequestStatus,
   ApiCallTemplatesById,
+  UpdatedRequests,
 } from '../../types';
 
 function applyTemplate(
@@ -36,66 +35,60 @@ function applyTemplate(
 
 // TODO: This could also be done in call-api
 function updateApiCallWithTemplate(
-  apiCall: Request<ApiCall>,
+  apiCalls: Request<ApiCall>[],
   templatesById: ApiCallTemplatesById
-): LogsData<Request<ApiCall>> {
-  const { id, status, templateId } = apiCall;
+): LogsData<Request<ApiCall>[]> {
+  const { logs, requests } = apiCalls.reduce(
+    (acc, apiCall) => {
+      const { id, status, templateId } = apiCall;
 
-  // If the request does not have a template to apply, skip it
-  if (!templateId) {
-    const log = logger.pend('DEBUG', `Request:${id} is not linked to a template`);
-    return [[log], apiCall];
-  }
+      // If the request does not have a template to apply, skip it
+      if (!templateId) {
+        const log = logger.pend('DEBUG', `Request:${id} is not linked to a template`);
+        return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, apiCall] };
+      }
 
-  if (apiCall.status !== RequestStatus.Pending) {
-    const log = logger.pend('DEBUG', `Skipping template application for Request:${id} as it has status code:${status}`);
-    return [[log], apiCall];
-  }
+      if (apiCall.status !== RequestStatus.Pending) {
+        const log = logger.pend(
+          'DEBUG',
+          `Skipping template application for Request:${id} as it has status code:${status}`
+        );
+        return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, apiCall] };
+      }
 
-  const template = templatesById[templateId];
-  // If no template is found, then we aren't able to build the full request.
-  // Block the request for now and it will be retried on the next run
-  if (!template) {
-    const log = logger.pend('ERROR', `Unable to fetch template ID:${templateId} for Request ID:${id}`);
-    const updatedApiCall: Request<ApiCall> = {
-      ...apiCall,
-      status: RequestStatus.Blocked,
-      errorMessage: `${RequestErrorMessage.TemplateNotFound}: ${templateId}`,
-    };
-    return [[log], updatedApiCall];
-  }
+      const template = templatesById[templateId];
+      // Drop the request if no template is found
+      if (!template) {
+        const log = logger.pend('ERROR', `Unable to fetch template ID:${templateId} for Request ID:${id}`);
+        return { ...acc, logs: [...acc.logs, log] };
+      }
 
-  // Attempt to decode the template parameters
-  const templateParameters = evm.encoding.safeDecode(template.encodedParameters);
+      // Attempt to decode the template parameters
+      const templateParameters = evm.encoding.safeDecode(template.encodedParameters);
 
-  // If the template contains invalid parameters, then we can't use it to execute the request
-  if (templateParameters === null) {
-    const log = logger.pend(
-      'ERROR',
-      `Template ID:${template.id} contains invalid parameters: ${template.encodedParameters}`
-    );
-    const updatedApiCall: Request<ApiCall> = {
-      ...apiCall,
-      status: RequestStatus.Errored,
-      errorMessage: `${RequestErrorMessage.TemplateParameterDecodingFailed}: ${template.encodedParameters}`,
-    };
-    return [[log], updatedApiCall];
-  }
+      // Drop the request if the template contains invalid parameters
+      if (templateParameters === null) {
+        const log = logger.pend(
+          'ERROR',
+          `Template ID:${template.id} contains invalid parameters: ${template.encodedParameters}`
+        );
+        return { ...acc, logs: [...acc.logs, log] };
+      }
 
-  const updatedApiCall = applyTemplate(apiCall, template, templateParameters);
-  const log = logger.pend('DEBUG', `Template ID:${template.id} applied to Request:${apiCall.id}`);
-  return [[log], updatedApiCall];
+      const updatedApiCall = applyTemplate(apiCall, template, templateParameters);
+      const log = logger.pend('DEBUG', `Template ID:${template.id} applied to Request:${apiCall.id}`);
+      return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, updatedApiCall] };
+    },
+    { logs: [], requests: [] } as UpdatedRequests<ApiCall>
+  );
+  return [logs, requests];
 }
 
 export function mergeApiCallsWithTemplates(
   apiCalls: Request<ApiCall>[],
   templatesById: ApiCallTemplatesById
 ): LogsData<Request<ApiCall>[]> {
-  const logsWithApiCalls = apiCalls.map((apiCall) => {
-    return updateApiCallWithTemplate(apiCall, templatesById);
-  });
+  const [logs, templatedApiCalls] = updateApiCallWithTemplate(apiCalls, templatesById);
 
-  const logs = flatMap(logsWithApiCalls, (a) => a[0]);
-  const templatedApiCalls = flatMap(logsWithApiCalls, (a) => a[1]);
   return [logs, templatedApiCalls];
 }

--- a/packages/airnode-node/src/evm/verification/request-verification.test.ts
+++ b/packages/airnode-node/src/evm/verification/request-verification.test.ts
@@ -2,7 +2,7 @@ import * as verification from './request-verification';
 import * as requests from '../../requests';
 import * as wallet from '../wallet';
 import * as fixtures from '../../../test/fixtures';
-import { RequestErrorMessage, RequestStatus } from '../../types';
+import { RequestStatus } from '../../types';
 
 describe('verifySponsorWallets', () => {
   const config = fixtures.buildConfig();
@@ -141,7 +141,7 @@ describe('verifyTriggers', () => {
     }
   });
 
-  it('errors API calls that have an unknown endpointId', () => {
+  it('drops API calls that have an unknown endpointId', () => {
     const apiCall = fixtures.requests.buildApiCall({ endpointId: '0xinvalid' });
     const config = fixtures.buildConfig();
     const rrpTriggers = config.triggers.rrp;
@@ -152,15 +152,10 @@ describe('verifyTriggers', () => {
         message: `Request:${apiCall.id} has no matching endpointId:${apiCall.endpointId} in Airnode config`,
       },
     ]);
-    expect(res.length).toEqual(1);
-    expect(res[0]).toEqual({
-      ...apiCall,
-      status: RequestStatus.Errored,
-      errorMessage: `${RequestErrorMessage.UnknownEndpointId}: ${apiCall.endpointId}`,
-    });
+    expect(res.length).toEqual(0);
   });
 
-  it('errors API calls that are linked to a valid trigger but unknown OIS', () => {
+  it('drops API calls that are linked to a valid trigger but unknown OIS', () => {
     const rrpTrigger = fixtures.buildTrigger({ oisTitle: 'unknown' });
     const apiCall = fixtures.requests.buildApiCall({ endpointId: rrpTrigger.endpointId });
     const config = fixtures.buildConfig({ triggers: { rrp: [rrpTrigger], httpSignedData: [] } });
@@ -171,15 +166,10 @@ describe('verifyTriggers', () => {
         message: `Unknown OIS:unknown received for Request:${apiCall.id}`,
       },
     ]);
-    expect(res.length).toEqual(1);
-    expect(res[0]).toEqual({
-      ...apiCall,
-      status: RequestStatus.Errored,
-      errorMessage: `${RequestErrorMessage.UnknownOIS}: ${rrpTrigger.oisTitle}`,
-    });
+    expect(res.length).toEqual(0);
   });
 
-  it('errors API calls that are linked to a valid trigger but unknown endpoint', () => {
+  it('drops API calls that are linked to a valid trigger but unknown endpoint', () => {
     const rrpTrigger = fixtures.buildTrigger({ endpointName: 'unknown' });
     const apiCall = fixtures.requests.buildApiCall({ endpointId: rrpTrigger.endpointId });
     const config = fixtures.buildConfig({ triggers: { rrp: [rrpTrigger], httpSignedData: [] } });
@@ -190,12 +180,7 @@ describe('verifyTriggers', () => {
         message: `Unknown Endpoint:unknown for OIS:${rrpTrigger.oisTitle} received for Request:${apiCall.id}`,
       },
     ]);
-    expect(res.length).toEqual(1);
-    expect(res[0]).toEqual({
-      ...apiCall,
-      status: RequestStatus.Errored,
-      errorMessage: `${RequestErrorMessage.UnknownEndpointName}: ${rrpTrigger.endpointName} for OIS ${rrpTrigger.oisTitle}`,
-    });
+    expect(res.length).toEqual(0);
   });
 
   it('does nothing is the API call is linked to a valid trigger and OIS endpoint', () => {

--- a/packages/airnode-node/src/evm/verification/request-verification.ts
+++ b/packages/airnode-node/src/evm/verification/request-verification.ts
@@ -1,9 +1,8 @@
 import { ethers } from 'ethers';
-import flatMap from 'lodash/flatMap';
 import { OIS } from '@api3/airnode-ois';
-import { logger, PendingLog } from '@api3/airnode-utilities';
+import { logger } from '@api3/airnode-utilities';
 import * as wallet from '../wallet';
-import { ApiCall, Request, LogsData, RequestErrorMessage, RequestStatus } from '../../types';
+import { ApiCall, Request, LogsData, RequestStatus, UpdatedRequests } from '../../types';
 import { Trigger } from '../../config/types';
 
 export const isValidSponsorWallet = (hdNode: ethers.utils.HDNode, sponsor: string, sponsorWallet: string) => {
@@ -13,34 +12,31 @@ export const isValidSponsorWallet = (hdNode: ethers.utils.HDNode, sponsor: strin
 
 // TODO: Remove this once https://api3dao.atlassian.net/browse/AN-400 is done
 export function verifySponsorWallets<T>(
-  requests: Request<T>[],
+  unverifiedRequests: Request<T>[],
   masterHDNode: ethers.utils.HDNode
 ): LogsData<Request<T>[]> {
-  const logs: PendingLog[] = [];
+  const { logs, requests } = unverifiedRequests.reduce(
+    (acc, request) => {
+      if (request.status !== RequestStatus.Pending) {
+        const message = `Sponsor wallet verification skipped for Request:${request.id} as it has status:${request.status}`;
+        const log = logger.pend('DEBUG', message);
+        return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, request] };
+      }
 
-  const verifiedRequests = requests.filter((request) => {
-    if (request.status !== RequestStatus.Pending) {
-      const message = `Sponsor wallet verification skipped for Request:${request.id} as it has status:${request.status}`;
+      const expectedSponsorWalletAddress = wallet.deriveSponsorWallet(masterHDNode, request.sponsorAddress).address;
+      if (request.sponsorWalletAddress !== expectedSponsorWalletAddress) {
+        const message = `Invalid sponsor wallet:${request.sponsorWalletAddress} for Request:${request.id}. Expected:${expectedSponsorWalletAddress}`;
+        const log = logger.pend('ERROR', message);
+        return { ...acc, logs: [...acc.logs, log] };
+      }
+
+      const message = `Request ID:${request.id} is linked to a valid sponsor wallet:${request.sponsorWalletAddress}`;
       const log = logger.pend('DEBUG', message);
-      logs.push(log);
-      return true;
-    }
-
-    const expectedSponsorWalletAddress = wallet.deriveSponsorWallet(masterHDNode, request.sponsorAddress).address;
-    if (request.sponsorWalletAddress !== expectedSponsorWalletAddress) {
-      const message = `Invalid sponsor wallet:${request.sponsorWalletAddress} for Request:${request.id}. Expected:${expectedSponsorWalletAddress}`;
-      const log = logger.pend('ERROR', message);
-      logs.push(log);
-      return false;
-    }
-
-    const message = `Request ID:${request.id} is linked to a valid sponsor wallet:${request.sponsorWalletAddress}`;
-    const log = logger.pend('DEBUG', message);
-    logs.push(log);
-    return true;
-  });
-
-  return [logs, verifiedRequests];
+      return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, request] };
+    },
+    { logs: [], requests: [] } as UpdatedRequests<T>
+  );
+  return [logs, requests];
 }
 
 export function verifyRrpTriggers(
@@ -48,65 +44,53 @@ export function verifyRrpTriggers(
   rrpTriggers: Trigger[],
   oises: OIS[]
 ): LogsData<Request<ApiCall>[]> {
-  const logsWithVerifiedApiCalls: LogsData<Request<ApiCall>>[] = apiCalls.map((apiCall) => {
-    if (apiCall.status !== RequestStatus.Pending) {
-      // TODO: Do we need to log this? We do not follow the same practice in applySponsorAndSponsorWalletRequestLimit
-      // (once the request is ignored it is not further mentioned in future logs)
-      const message = `Trigger verification skipped for Request:${apiCall.id} as it has status:${apiCall.status}`;
-      const log = logger.pend('DEBUG', message);
-      return [[log], apiCall];
-    }
+  const { logs, requests } = apiCalls.reduce(
+    (acc, apiCall) => {
+      if (apiCall.status !== RequestStatus.Pending) {
+        // TODO: Do we need to log this? We do not follow the same practice in applySponsorAndSponsorWalletRequestLimit
+        // (once the request is ignored it is not further mentioned in future logs)
+        const message = `Trigger verification skipped for Request:${apiCall.id} as it has status:${apiCall.status}`;
+        const log = logger.pend('DEBUG', message);
+        return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, apiCall] };
+      }
 
-    const rrpTrigger = rrpTriggers.find((t) => t.endpointId === apiCall.endpointId);
-    // If the request is for an unknown endpointId, the problem is with the requesting requester contract
-    if (!rrpTrigger) {
-      const message = `Request:${apiCall.id} has no matching endpointId:${apiCall.endpointId} in Airnode config`;
-      const log = logger.pend('WARN', message);
-      const updatedApiCall: Request<ApiCall> = {
-        ...apiCall,
-        status: RequestStatus.Errored,
-        errorMessage: `${RequestErrorMessage.UnknownEndpointId}: ${apiCall.endpointId}`,
-      };
-      return [[log], updatedApiCall];
-    }
+      const rrpTrigger = rrpTriggers.find((t) => t.endpointId === apiCall.endpointId);
+      // If the request is for an unknown endpointId, the problem is with the requesting requester contract
+      if (!rrpTrigger) {
+        const message = `Request:${apiCall.id} has no matching endpointId:${apiCall.endpointId} in Airnode config`;
+        const log = logger.pend('WARN', message);
+        return { ...acc, logs: [...acc.logs, log] };
+      }
 
-    const { oisTitle, endpointName } = rrpTrigger;
-    const ois = oises.find((o) => o.title === oisTitle);
-    // Although unlikely, it is possible that the Airnode instance was configured with a trigger
-    // with an 'oisTitle' that does not match an OIS in config.json. The responsibility to fix this
-    // lies with the API provider
-    if (!ois) {
-      const log = logger.pend('ERROR', `Unknown OIS:${oisTitle} received for Request:${apiCall.id}`);
-      const updatedApiCall: Request<ApiCall> = {
-        ...apiCall,
-        status: RequestStatus.Errored,
-        errorMessage: `${RequestErrorMessage.UnknownOIS}: ${oisTitle}`,
-      };
-      return [[log], updatedApiCall];
-    }
+      const { oisTitle, endpointName } = rrpTrigger;
+      const ois = oises.find((o) => o.title === oisTitle);
+      // Although unlikely, it is possible that the Airnode instance was configured with a trigger
+      // with an 'oisTitle' that does not match an OIS in config.json. The responsibility to fix this
+      // lies with the API provider
+      if (!ois) {
+        const log = logger.pend('ERROR', `Unknown OIS:${oisTitle} received for Request:${apiCall.id}`);
+        return { ...acc, logs: [...acc.logs, log] };
+      }
 
-    const endpoint = ois.endpoints.find((e) => e.name === endpointName);
-    // Although unlikely, it is possible that the Airnode instance was configured with a trigger
-    // with an 'endpointName' that does not match an endpoint within the given OIS in config.json.
-    // The responsibility to fix this lies with the API provider
-    if (!endpoint) {
+      const endpoint = ois.endpoints.find((e) => e.name === endpointName);
+      // Although unlikely, it is possible that the Airnode instance was configured with a trigger
+      // with an 'endpointName' that does not match an endpoint within the given OIS in config.json.
+      // The responsibility to fix this lies with the API provider
+      if (!endpoint) {
+        const log = logger.pend(
+          'ERROR',
+          `Unknown Endpoint:${endpointName} for OIS:${oisTitle} received for Request:${apiCall.id}`
+        );
+        return { ...acc, logs: [...acc.logs, log] };
+      }
+
       const log = logger.pend(
-        'ERROR',
-        `Unknown Endpoint:${endpointName} for OIS:${oisTitle} received for Request:${apiCall.id}`
+        'DEBUG',
+        `Request ID:${apiCall.id} is linked to a valid endpointId:${apiCall.endpointId}`
       );
-      const updatedApiCall: Request<ApiCall> = {
-        ...apiCall,
-        status: RequestStatus.Errored,
-        errorMessage: `${RequestErrorMessage.UnknownEndpointName}: ${endpointName} for OIS ${oisTitle}`,
-      };
-      return [[log], updatedApiCall];
-    }
-
-    const log = logger.pend('DEBUG', `Request ID:${apiCall.id} is linked to a valid endpointId:${apiCall.endpointId}`);
-    return [[log], apiCall];
-  });
-
-  const logs = flatMap(logsWithVerifiedApiCalls, (r) => r[0]);
-  const verifiedRequests = flatMap(logsWithVerifiedApiCalls, (r) => r[1]);
-  return [logs, verifiedRequests];
+      return { ...acc, logs: [...acc.logs, log], requests: [...acc.requests, apiCall] };
+    },
+    { logs: [], requests: [] } as UpdatedRequests<ApiCall>
+  );
+  return [logs, requests];
 }

--- a/packages/airnode-node/src/requests/request.test.ts
+++ b/packages/airnode-node/src/requests/request.test.ts
@@ -22,12 +22,10 @@ describe('filterActionableApiCalls', () => {
   it('returns actionable API calls', () => {
     const apiCalls = [
       fixtures.requests.buildApiCall({ status: RequestStatus.Pending }),
-      fixtures.requests.buildApiCall({ status: RequestStatus.Errored }),
       fixtures.requests.buildApiCall({ status: RequestStatus.Blocked }),
     ];
     expect(request.filterActionableApiCalls(apiCalls)).toEqual([
       fixtures.requests.buildApiCall({ status: RequestStatus.Pending }),
-      fixtures.requests.buildApiCall({ status: RequestStatus.Errored }),
     ]);
   });
 });
@@ -36,7 +34,6 @@ describe('filterActionableWithdrawals', () => {
   it('returns actionable withdrawals', () => {
     const withdrawals = [
       fixtures.requests.buildWithdrawal({ status: RequestStatus.Pending }),
-      fixtures.requests.buildWithdrawal({ status: RequestStatus.Errored }),
       fixtures.requests.buildWithdrawal({ status: RequestStatus.Blocked }),
     ];
     expect(request.filterActionableWithdrawals(withdrawals)).toEqual([
@@ -48,11 +45,6 @@ describe('filterActionableWithdrawals', () => {
 describe('hasActionableApiCalls', () => {
   it('returns true if pending API calls are present', () => {
     const apiCalls = [fixtures.requests.buildApiCall({ status: RequestStatus.Pending })];
-    expect(request.hasActionableApiCalls(apiCalls)).toEqual(true);
-  });
-
-  it('returns true if errored API calls are present', () => {
-    const apiCalls = [fixtures.requests.buildApiCall({ status: RequestStatus.Errored })];
     expect(request.hasActionableApiCalls(apiCalls)).toEqual(true);
   });
 
@@ -73,10 +65,7 @@ describe('hasActionableWithdrawals', () => {
   });
 
   it('returns false if there are no pending withdrawals', () => {
-    const withdrawals = [
-      fixtures.requests.buildWithdrawal({ status: RequestStatus.Errored }),
-      fixtures.requests.buildWithdrawal({ status: RequestStatus.Blocked }),
-    ];
+    const withdrawals = [fixtures.requests.buildWithdrawal({ status: RequestStatus.Blocked })];
     expect(request.hasActionableWithdrawals(withdrawals)).toEqual(false);
   });
 
@@ -96,8 +85,8 @@ describe('hasNoActionableRequests', () => {
 
   it('returns false if actionable withdrawals are present', () => {
     const requests: GroupedRequests = {
-      apiCalls: [fixtures.requests.buildApiCall({ status: RequestStatus.Errored })],
-      withdrawals: [],
+      apiCalls: [fixtures.requests.buildApiCall({ status: RequestStatus.Blocked })],
+      withdrawals: [fixtures.requests.buildWithdrawal()],
     };
     expect(request.hasNoActionableRequests(requests)).toEqual(false);
   });
@@ -105,18 +94,7 @@ describe('hasNoActionableRequests', () => {
   it('returns true if there are no actionable API calls or withdrawals', () => {
     const requests: GroupedRequests = {
       apiCalls: [fixtures.requests.buildApiCall({ status: RequestStatus.Blocked })],
-      withdrawals: [
-        fixtures.requests.buildWithdrawal({ status: RequestStatus.Errored }),
-        fixtures.requests.buildWithdrawal({ status: RequestStatus.Blocked }),
-      ],
-    };
-    expect(request.hasNoActionableRequests(requests)).toEqual(true);
-  });
-
-  it('returns true if no requests are present', () => {
-    const requests: GroupedRequests = {
-      apiCalls: [],
-      withdrawals: [],
+      withdrawals: [fixtures.requests.buildWithdrawal({ status: RequestStatus.Blocked })],
     };
     expect(request.hasNoActionableRequests(requests)).toEqual(true);
   });
@@ -132,7 +110,7 @@ describe('hasNoActionableRequests', () => {
 
 describe('getStatusNames', () => {
   it('returns a list of all status names', () => {
-    expect(request.getStatusNames()).toEqual(['Pending', 'Blocked', 'Errored']);
+    expect(request.getStatusNames()).toEqual(['Pending', 'Blocked']);
   });
 });
 

--- a/packages/airnode-node/src/requests/request.ts
+++ b/packages/airnode-node/src/requests/request.ts
@@ -7,7 +7,7 @@ export function hasExceededIgnoredBlockLimit<T>(request: Request<T>): boolean {
 }
 
 export function filterActionableApiCalls(apiCalls: Request<ApiCall>[]): Request<ApiCall>[] {
-  return apiCalls.filter((a) => a.status === RequestStatus.Pending || a.status === RequestStatus.Errored);
+  return apiCalls.filter((a) => a.status === RequestStatus.Pending);
 }
 
 export function filterActionableWithdrawals(withdrawals: Request<Withdrawal>[]): Request<Withdrawal>[] {

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -47,13 +47,6 @@ export enum RequestStatus {
   // wallet request limit exceeded). All other request from the same sponsor wallet should be deferred until this one
   // becomes unblocked
   Blocked = 'Blocked',
-  // A request is errorred if it is valid, but cannot be fulfilled on chain
-  // and thus should result in "fail" method called on AirnodeRrp.
-  //
-  // This can happen by multiple ways - request is unauthorized, API call fails, static call to fulfill fails
-  // TODO: The problem with this status is that we use errorMessage to distinguish errored requests
-  // and keeping this in sync is fragile - we can just drop this
-  Errored = 'Errored',
 }
 
 export enum RequestType {
@@ -178,6 +171,11 @@ export interface CoordinatorState {
   readonly providerStates: ProviderStates;
   readonly coordinatorId: string;
   readonly settings: CoordinatorSettings;
+}
+
+export interface UpdatedRequests<T> {
+  readonly logs: PendingLog[];
+  readonly requests: Request<T>[];
 }
 
 // ===========================================


### PR DESCRIPTION
[AN-482](https://api3dao.atlassian.net/browse/AN-482), part 4.

Potentially controversial changes include functions that previously accepted a single `Request<ApiCall>`, but now take `apiCalls: Request<ApiCall>[],` in order to use `reduce` to filter errored requests.