### PR TITLE
Require conditionPspDapiUpdate caller to be zero address

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,15 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone airnode
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+      - name: Update latest paths
+        run: |
+          wget https://raw.githubusercontent.com/api3dao/api3-docs/main/docs/.vuepress/config.js
+          for i in latestVersion latestBeaconVersion latestOisVersion; do
+            path=$(grep $i config.js | cut -d\' -f2);
+            echo "Renaming: $i --> $path";
+            sed -i "s@$i@$path@" .github/workflows/mlc_config.json;
+          done
       - name: Check hyperlinks
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,4 +1,18 @@
 {
+  "replacementPatterns": [
+    {
+      "pattern": "/airnode/latest/",
+      "replacement": "latestVersion"
+    },
+    {
+      "pattern": "/beacon/latest/",
+      "replacement": "latestBeaconVersion"
+    },
+    {
+      "pattern": "/ois/latest/",
+      "replacement": "latestOisVersion"
+    }
+  ],
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "10s"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:e2e-node": "cd packages/airnode-node && yarn run test:e2e",
     "test:e2e-node:debug": "cd packages/airnode-node && yarn run test:e2e:debug",
     "test:protocol": "cd packages/airnode-protocol && yarn run test",
+    "test:protocol-v1": "cd packages/airnode-protocol-v1 && yarn run test",
     "test:node": "(cd packages/airnode-node && yarn run test)",
     "test:node:watch": "cd packages/airnode-node && yarn run test:watch",
     "test:validator": "(cd packages/airnode-validator && yarn run test)"

--- a/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
@@ -453,12 +453,8 @@ contract DapiServer is
 
     /// @notice Returns if the respective dAPI needs to be updated based on the
     /// condition parameters
-    /// @dev This method does not allow the caller to indirectly read a dAPI,
-    /// which is why it does not require the sender to be a void signer with
-    /// zero address. This allows the implementation of incentive mechanisms
-    /// that rewards keepers that trigger valid dAPI updates.
-    /// The template ID used in the respective Subscription is expected to be
-    /// zero, which means the `parameters` field of the Subscription will be
+    /// @dev The template ID used in the respective Subscription is expected to
+    /// be zero, which means the `parameters` field of the Subscription will be
     /// forwarded to this function as `data`. This field should be the beacon
     /// ID array encoded in contract ABI.
     /// @param subscriptionId Subscription ID
@@ -472,6 +468,7 @@ contract DapiServer is
         bytes calldata data,
         bytes calldata conditionParameters
     ) external override returns (bool) {
+        require(msg.sender == address(0), "Sender not zero address");
         bytes32 dapiId = keccak256(data);
         int224 currentDapiValue = dataPoints[dapiId].value;
         require(

--- a/packages/airnode-protocol-v1/hardhat.config.js
+++ b/packages/airnode-protocol-v1/hardhat.config.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   mocha: {
     timeout: process.env.EXTENDED_TEST ? 3600000 : 20000,
+    parallel: true,
   },
   paths: {
     tests: process.env.EXTENDED_TEST ? './extended-test' : './test',

--- a/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
+++ b/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
@@ -2040,114 +2040,138 @@ describe('updateDapiWithBeacons', function () {
 });
 
 describe('conditionPspDapiUpdate', function () {
-  context('Data length is correct', function () {
-    context('Condition parameters length is correct', function () {
-      context('Data makes a larger update than the threshold', function () {
-        context('Update is upwards', function () {
-          it('returns true', async function () {
-            // Set the dAPI to 100 first
-            let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-            timestamp++;
-            await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-            // dapiUpdateSubscriptionConditionParameters is 5%
-            // 100 -> 105 satisfies the condition and returns true
-            const encodedData = [105, 110, 100];
-            for (let ind = 0; ind < encodedData.length; ind++) {
+  context('Sender has zero address ', function () {
+    context('Data length is correct', function () {
+      context('Condition parameters length is correct', function () {
+        context('Data makes a larger update than the threshold', function () {
+          context('Update is upwards', function () {
+            it('returns true', async function () {
+              // Set the dAPI to 100 first
+              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
               timestamp++;
-              await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
-            }
-            expect(
-              await dapiServer
-                .connect(roles.randomPerson)
-                .callStatic.conditionPspDapiUpdate(
-                  dapiUpdateSubscriptionId,
-                  hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
-                  dapiUpdateSubscriptionConditionParameters
-                )
-            ).to.equal(true);
+              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+              // dapiUpdateSubscriptionConditionParameters is 5%
+              // 100 -> 105 satisfies the condition and returns true
+              const encodedData = [105, 110, 100];
+              for (let ind = 0; ind < encodedData.length; ind++) {
+                timestamp++;
+                await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+              }
+              expect(
+                await dapiServer
+                  .connect(voidSignerAddressZero)
+                  .callStatic.conditionPspDapiUpdate(
+                    dapiUpdateSubscriptionId,
+                    hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                    dapiUpdateSubscriptionConditionParameters
+                  )
+              ).to.equal(true);
+            });
+          });
+          context('Update is downwards', function () {
+            it('returns true', async function () {
+              // Set the dAPI to 100 first
+              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+              timestamp++;
+              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+              // dapiUpdateSubscriptionConditionParameters is 5%
+              // 100 -> 95 satisfies the condition and returns true
+              const encodedData = [95, 100, 90];
+              for (let ind = 0; ind < encodedData.length; ind++) {
+                timestamp++;
+                await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+              }
+              expect(
+                await dapiServer
+                  .connect(voidSignerAddressZero)
+                  .callStatic.conditionPspDapiUpdate(
+                    dapiUpdateSubscriptionId,
+                    hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                    dapiUpdateSubscriptionConditionParameters
+                  )
+              ).to.equal(true);
+            });
           });
         });
-        context('Update is downwards', function () {
-          it('returns true', async function () {
-            // Set the dAPI to 100 first
-            let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-            timestamp++;
-            await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-            // dapiUpdateSubscriptionConditionParameters is 5%
-            // 100 -> 95 satisfies the condition and returns true
-            const encodedData = [95, 100, 90];
-            for (let ind = 0; ind < encodedData.length; ind++) {
+        context('Data does not make a larger update than the threshold', function () {
+          context('Update is upwards', function () {
+            it('returns false', async function () {
+              // Set the dAPI to 100 first
+              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
               timestamp++;
-              await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
-            }
-            expect(
-              await dapiServer
-                .connect(roles.randomPerson)
-                .callStatic.conditionPspDapiUpdate(
-                  dapiUpdateSubscriptionId,
-                  hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
-                  dapiUpdateSubscriptionConditionParameters
-                )
-            ).to.equal(true);
+              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+              // dapiUpdateSubscriptionConditionParameters is 5%
+              // 100 -> 104 does not satisfy the condition and returns false
+              const encodedData = [110, 104, 95];
+              for (let ind = 0; ind < encodedData.length; ind++) {
+                timestamp++;
+                await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+              }
+              expect(
+                await dapiServer
+                  .connect(voidSignerAddressZero)
+                  .callStatic.conditionPspDapiUpdate(
+                    dapiUpdateSubscriptionId,
+                    hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                    dapiUpdateSubscriptionConditionParameters
+                  )
+              ).to.equal(false);
+            });
+          });
+          context('Update is downwards', function () {
+            it('returns false', async function () {
+              // Set the dAPI to 100 first
+              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+              timestamp++;
+              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+              // dapiUpdateSubscriptionConditionParameters is 5%
+              // 100 -> 96 does not satisfy the condition and returns false
+              const encodedData = [105, 96, 95];
+              for (let ind = 0; ind < encodedData.length; ind++) {
+                timestamp++;
+                await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+              }
+              expect(
+                await dapiServer
+                  .connect(voidSignerAddressZero)
+                  .callStatic.conditionPspDapiUpdate(
+                    dapiUpdateSubscriptionId,
+                    hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                    dapiUpdateSubscriptionConditionParameters
+                  )
+              ).to.equal(false);
+            });
           });
         });
       });
-      context('Data does not make a larger update than the threshold', function () {
-        context('Update is upwards', function () {
-          it('returns false', async function () {
-            // Set the dAPI to 100 first
-            let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-            timestamp++;
-            await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-            // dapiUpdateSubscriptionConditionParameters is 5%
-            // 100 -> 104 does not satisfy the condition and returns false
-            const encodedData = [110, 104, 95];
-            for (let ind = 0; ind < encodedData.length; ind++) {
-              timestamp++;
-              await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
-            }
-            expect(
-              await dapiServer
-                .connect(roles.randomPerson)
-                .callStatic.conditionPspDapiUpdate(
-                  dapiUpdateSubscriptionId,
-                  hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
-                  dapiUpdateSubscriptionConditionParameters
-                )
-            ).to.equal(false);
-          });
-        });
-        context('Update is downwards', function () {
-          it('returns false', async function () {
-            // Set the dAPI to 100 first
-            let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-            timestamp++;
-            await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-            // dapiUpdateSubscriptionConditionParameters is 5%
-            // 100 -> 96 does not satisfy the condition and returns false
-            const encodedData = [105, 96, 95];
-            for (let ind = 0; ind < encodedData.length; ind++) {
-              timestamp++;
-              await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
-            }
-            expect(
-              await dapiServer
-                .connect(roles.randomPerson)
-                .callStatic.conditionPspDapiUpdate(
-                  dapiUpdateSubscriptionId,
-                  hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
-                  dapiUpdateSubscriptionConditionParameters
-                )
-            ).to.equal(false);
-          });
+      context('Condition parameters length is not correct', function () {
+        it('reverts', async function () {
+          await expect(
+            dapiServer
+              .connect(voidSignerAddressZero)
+              .callStatic.conditionPspDapiUpdate(
+                testUtils.generateRandomBytes32(),
+                hre.ethers.utils.defaultAbiCoder.encode(
+                  ['bytes32[]'],
+                  [
+                    [
+                      testUtils.generateRandomBytes32(),
+                      testUtils.generateRandomBytes32(),
+                      testUtils.generateRandomBytes32(),
+                    ],
+                  ]
+                ),
+                dapiUpdateSubscriptionConditionParameters + '00'
+              )
+          ).to.be.revertedWith('Incorrect parameter length');
         });
       });
     });
-    context('Condition parameters length is not correct', function () {
+    context('Data length is not correct', function () {
       it('reverts', async function () {
         await expect(
           dapiServer
-            .connect(roles.randomPerson)
+            .connect(voidSignerAddressZero)
             .callStatic.conditionPspDapiUpdate(
               testUtils.generateRandomBytes32(),
               hre.ethers.utils.defaultAbiCoder.encode(
@@ -2159,15 +2183,16 @@ describe('conditionPspDapiUpdate', function () {
                     testUtils.generateRandomBytes32(),
                   ],
                 ]
-              ),
-              dapiUpdateSubscriptionConditionParameters + '00'
+              ) + '00',
+              dapiUpdateSubscriptionConditionParameters
             )
-        ).to.be.revertedWith('Incorrect parameter length');
+        ).to.be.revertedWith('Data length not correct');
       });
     });
   });
-  context('Data length is not correct', function () {
+  context('Sender does not have zero address ', function () {
     it('reverts', async function () {
+      // Static calls should revert
       await expect(
         dapiServer
           .connect(roles.randomPerson)
@@ -2182,10 +2207,29 @@ describe('conditionPspDapiUpdate', function () {
                   testUtils.generateRandomBytes32(),
                 ],
               ]
-            ) + '00',
+            ),
             dapiUpdateSubscriptionConditionParameters
           )
-      ).to.be.revertedWith('Data length not correct');
+      ).to.be.revertedWith('Sender not zero address');
+      // Calls should also revert
+      await expect(
+        dapiServer
+          .connect(roles.randomPerson)
+          .conditionPspDapiUpdate(
+            testUtils.generateRandomBytes32(),
+            hre.ethers.utils.defaultAbiCoder.encode(
+              ['bytes32[]'],
+              [
+                [
+                  testUtils.generateRandomBytes32(),
+                  testUtils.generateRandomBytes32(),
+                  testUtils.generateRandomBytes32(),
+                ],
+              ]
+            ),
+            dapiUpdateSubscriptionConditionParameters
+          )
+      ).to.be.revertedWith('Sender not zero address');
     });
   });
 });

--- a/packages/airnode-protocol/src/index.ts
+++ b/packages/airnode-protocol/src/index.ts
@@ -87,5 +87,3 @@ export {
   RequestedWithdrawalEvent,
   FulfilledWithdrawalEvent,
 } from './contracts/AirnodeRrp'; // eslint-disable-line import/no-unresolved
-
-export { TypedEventFilter } from './contracts/commons';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,12 +2493,7 @@
     "@opencensus/core" "^0.0.8"
     uuid "^3.2.1"
 
-"@openzeppelin/contracts@^4.3.2":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
-  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
-
-"@openzeppelin/contracts@^4.4.2":
+"@openzeppelin/contracts@^4.3.2", "@openzeppelin/contracts@^4.4.2":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
@@ -6873,7 +6868,7 @@ eslint-plugin-functional@^3.5.0:
     escape-string-regexp "^4.0.0"
     object.fromentries "^2.0.3"
 
-eslint-plugin-import@^2.24.2:
+eslint-plugin-import@^2.23.4:
   version "2.25.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
   integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==


### PR DESCRIPTION
When we require `msg.sender==address(0)` this function can no longer change the state, which makes its name accurate