### PR TITLE
Remove unused export

### DIFF
--- a/packages/airnode-protocol/src/index.ts
+++ b/packages/airnode-protocol/src/index.ts
@@ -87,5 +87,3 @@ export {
   RequestedWithdrawalEvent,
   FulfilledWithdrawalEvent,
 } from './contracts/AirnodeRrp'; // eslint-disable-line import/no-unresolved
-
-export { TypedEventFilter } from './contracts/commons';


### PR DESCRIPTION
This line caused CI to fail for some reason (dunno why). This export is not used anywhere so we can remove it to unblock the CI (hopefully).