### PR TITLE
Update conditions always return true if the data point is not initialized

### DIFF
--- a/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
@@ -470,16 +470,19 @@ contract DapiServer is
     ) external override returns (bool) {
         require(msg.sender == address(0), "Sender not zero address");
         bytes32 dapiId = keccak256(data);
-        int224 currentDapiValue = dataPoints[dapiId].value;
+        DataPoint memory initialDataPoint = dataPoints[dapiId];
         require(
             dapiId == updateDapiWithBeacons(abi.decode(data, (bytes32[]))),
             "Data length not correct"
         );
+        DataPoint storage updatedDataPoint = dataPoints[dapiId];
         return
             calculateUpdateInPercentage(
-                currentDapiValue,
+                initialDataPoint.value,
                 dataPoints[dapiId].value
-            ) >= decodeConditionParameters(conditionParameters);
+            ) >=
+            decodeConditionParameters(conditionParameters) ||
+            (initialDataPoint.timestamp == 0 && updatedDataPoint.timestamp > 0);
     }
 
     /// @notice Called by the Airnode/relayer using the sponsor wallet to

--- a/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol
@@ -318,11 +318,14 @@ contract DapiServer is
         require(msg.sender == address(0), "Sender not zero address");
         bytes32 beaconId = subscriptionIdToBeaconId[subscriptionId];
         require(beaconId != bytes32(0), "Subscription not registered");
+        DataPoint storage beacon = dataPoints[beaconId];
         return
             calculateUpdateInPercentage(
-                dataPoints[beaconId].value,
+                beacon.value,
                 decodeFulfillmentData(data)
-            ) >= decodeConditionParameters(conditionParameters);
+            ) >=
+            decodeConditionParameters(conditionParameters) ||
+            beacon.timestamp == 0;
     }
 
     /// @notice Called by the Airnode/relayer using the sponsor wallet to

--- a/packages/airnode-protocol-v1/contracts/dapis/interfaces/IDapiServer.sol
+++ b/packages/airnode-protocol-v1/contracts/dapis/interfaces/IDapiServer.sol
@@ -139,6 +139,11 @@ interface IDapiServer is IAirnodeRequester {
         external
         returns (bytes32 dapiId);
 
+    function updateDapiWithBeaconsAndReturnCondition(
+        bytes32[] memory beaconIds,
+        uint256 updateThresholdInPercentage
+    ) external returns (bool);
+
     function conditionPspDapiUpdate(
         bytes32 subscriptionId,
         bytes calldata data,

--- a/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
+++ b/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
@@ -1468,113 +1468,137 @@ describe('conditionPspBeaconUpdate', function () {
     context('Subscription is registered', function () {
       context('Data length is correct', function () {
         context('Condition parameters length is correct', function () {
-          context('Data was initially zero', function () {
-            context('Update is upwards', function () {
-              it('returns true', async function () {
-                const conditionData = encodeData(1);
-                expect(
-                  await dapiServer
-                    .connect(voidSignerAddressZero)
-                    .callStatic.conditionPspBeaconUpdate(
-                      beaconUpdateSubscriptionId,
-                      conditionData,
-                      beaconUpdateSubscriptionConditionParameters
-                    )
-                ).to.equal(true);
-              });
-            });
-            context('Update is downwards', function () {
-              it('returns true', async function () {
-                const conditionData = encodeData(-1);
-                expect(
-                  await dapiServer
-                    .connect(voidSignerAddressZero)
-                    .callStatic.conditionPspBeaconUpdate(
-                      beaconUpdateSubscriptionId,
-                      conditionData,
-                      beaconUpdateSubscriptionConditionParameters
-                    )
-                ).to.equal(true);
-              });
+          context('Beacon timestamp is zero', function () {
+            it('returns true', async function () {
+              // Even if the fulfillment value is zero, since the Beacon timestamp is zero,
+              // the condition will return true
+              const conditionData = encodeData(0);
+              expect(
+                await dapiServer
+                  .connect(voidSignerAddressZero)
+                  .callStatic.conditionPspBeaconUpdate(
+                    beaconUpdateSubscriptionId,
+                    conditionData,
+                    beaconUpdateSubscriptionConditionParameters
+                  )
+              ).to.equal(true);
             });
           });
-          context('Data makes a larger update than the threshold', function () {
-            context('Update is upwards', function () {
-              it('returns true', async function () {
-                // Set the Beacon to 100 first
-                const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                await setBeacon(templateId, 100, timestamp);
-                // beaconUpdateSubscriptionConditionParameters is 10%
-                // 100 -> 110 satisfies the condition and returns true
-                const conditionData = encodeData(110);
-                expect(
-                  await dapiServer
-                    .connect(voidSignerAddressZero)
-                    .callStatic.conditionPspBeaconUpdate(
-                      beaconUpdateSubscriptionId,
-                      conditionData,
-                      beaconUpdateSubscriptionConditionParameters
-                    )
-                ).to.equal(true);
+          context('Beacon timestamp is not zero', function () {
+            context('Data was initially zero', function () {
+              context('Update is upwards', function () {
+                it('returns true', async function () {
+                  // Set the Beacon to 0 first
+                  const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                  await setBeacon(templateId, 0, timestamp);
+                  const conditionData = encodeData(1);
+                  expect(
+                    await dapiServer
+                      .connect(voidSignerAddressZero)
+                      .callStatic.conditionPspBeaconUpdate(
+                        beaconUpdateSubscriptionId,
+                        conditionData,
+                        beaconUpdateSubscriptionConditionParameters
+                      )
+                  ).to.equal(true);
+                });
+              });
+              context('Update is downwards', function () {
+                it('returns true', async function () {
+                  // Set the Beacon to 0 first
+                  const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                  await setBeacon(templateId, 0, timestamp);
+                  const conditionData = encodeData(-1);
+                  expect(
+                    await dapiServer
+                      .connect(voidSignerAddressZero)
+                      .callStatic.conditionPspBeaconUpdate(
+                        beaconUpdateSubscriptionId,
+                        conditionData,
+                        beaconUpdateSubscriptionConditionParameters
+                      )
+                  ).to.equal(true);
+                });
               });
             });
-            context('Update is downwards', function () {
-              it('returns true', async function () {
-                // Set the Beacon to 100 first
-                const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                await setBeacon(templateId, 100, timestamp);
-                // beaconUpdateSubscriptionConditionParameters is 10%
-                // 100 -> 90 satisfies the condition and returns true
-                const conditionData = encodeData(90);
-                expect(
-                  await dapiServer
-                    .connect(voidSignerAddressZero)
-                    .callStatic.conditionPspBeaconUpdate(
-                      beaconUpdateSubscriptionId,
-                      conditionData,
-                      beaconUpdateSubscriptionConditionParameters
-                    )
-                ).to.equal(true);
+            context('Data makes a larger update than the threshold', function () {
+              context('Update is upwards', function () {
+                it('returns true', async function () {
+                  // Set the Beacon to 100 first
+                  const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                  await setBeacon(templateId, 100, timestamp);
+                  // beaconUpdateSubscriptionConditionParameters is 10%
+                  // 100 -> 110 satisfies the condition and returns true
+                  const conditionData = encodeData(110);
+                  expect(
+                    await dapiServer
+                      .connect(voidSignerAddressZero)
+                      .callStatic.conditionPspBeaconUpdate(
+                        beaconUpdateSubscriptionId,
+                        conditionData,
+                        beaconUpdateSubscriptionConditionParameters
+                      )
+                  ).to.equal(true);
+                });
+              });
+              context('Update is downwards', function () {
+                it('returns true', async function () {
+                  // Set the Beacon to 100 first
+                  const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                  await setBeacon(templateId, 100, timestamp);
+                  // beaconUpdateSubscriptionConditionParameters is 10%
+                  // 100 -> 90 satisfies the condition and returns true
+                  const conditionData = encodeData(90);
+                  expect(
+                    await dapiServer
+                      .connect(voidSignerAddressZero)
+                      .callStatic.conditionPspBeaconUpdate(
+                        beaconUpdateSubscriptionId,
+                        conditionData,
+                        beaconUpdateSubscriptionConditionParameters
+                      )
+                  ).to.equal(true);
+                });
               });
             });
-          });
-          context('Data does not make a larger update than the threshold', function () {
-            context('Update is upwards', function () {
-              it('returns false', async function () {
-                // Set the Beacon to 100 first
-                const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                await setBeacon(templateId, 100, timestamp);
-                // beaconUpdateSubscriptionConditionParameters is 10%
-                // 100 -> 109 doesn't satisfy the condition and returns false
-                const conditionData = encodeData(109);
-                expect(
-                  await dapiServer
-                    .connect(voidSignerAddressZero)
-                    .callStatic.conditionPspBeaconUpdate(
-                      beaconUpdateSubscriptionId,
-                      conditionData,
-                      beaconUpdateSubscriptionConditionParameters
-                    )
-                ).to.equal(false);
+            context('Data does not make a larger update than the threshold', function () {
+              context('Update is upwards', function () {
+                it('returns false', async function () {
+                  // Set the Beacon to 100 first
+                  const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                  await setBeacon(templateId, 100, timestamp);
+                  // beaconUpdateSubscriptionConditionParameters is 10%
+                  // 100 -> 109 doesn't satisfy the condition and returns false
+                  const conditionData = encodeData(109);
+                  expect(
+                    await dapiServer
+                      .connect(voidSignerAddressZero)
+                      .callStatic.conditionPspBeaconUpdate(
+                        beaconUpdateSubscriptionId,
+                        conditionData,
+                        beaconUpdateSubscriptionConditionParameters
+                      )
+                  ).to.equal(false);
+                });
               });
-            });
-            context('Update is downwards', function () {
-              it('returns false', async function () {
-                // Set the Beacon to 100 first
-                const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                await setBeacon(templateId, 100, timestamp);
-                // beaconUpdateSubscriptionConditionParameters is 10%
-                // 100 -> 91 doesn't satisfy the condition and returns false
-                const conditionData = encodeData(91);
-                expect(
-                  await dapiServer
-                    .connect(voidSignerAddressZero)
-                    .callStatic.conditionPspBeaconUpdate(
-                      beaconUpdateSubscriptionId,
-                      conditionData,
-                      beaconUpdateSubscriptionConditionParameters
-                    )
-                ).to.equal(false);
+              context('Update is downwards', function () {
+                it('returns false', async function () {
+                  // Set the Beacon to 100 first
+                  const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                  await setBeacon(templateId, 100, timestamp);
+                  // beaconUpdateSubscriptionConditionParameters is 10%
+                  // 100 -> 91 doesn't satisfy the condition and returns false
+                  const conditionData = encodeData(91);
+                  expect(
+                    await dapiServer
+                      .connect(voidSignerAddressZero)
+                      .callStatic.conditionPspBeaconUpdate(
+                        beaconUpdateSubscriptionId,
+                        conditionData,
+                        beaconUpdateSubscriptionConditionParameters
+                      )
+                  ).to.equal(false);
+                });
               });
             });
           });
@@ -2052,7 +2076,7 @@ describe('conditionPspDapiUpdate', function () {
                 timestamp++;
                 await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
               }
-              // Even if the beacon values are zero, since their timestamps are not zero,
+              // Even if the Beacon values are zero, since their timestamps are not zero,
               // the condition will return true
               expect(
                 await dapiServer

--- a/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
+++ b/packages/airnode-protocol-v1/test/dapis/DapiServer.sol.js
@@ -2043,20 +2043,17 @@ describe('conditionPspDapiUpdate', function () {
   context('Sender has zero address ', function () {
     context('Data length is correct', function () {
       context('Condition parameters length is correct', function () {
-        context('Data makes a larger update than the threshold', function () {
-          context('Update is upwards', function () {
+        context('dAPI timestamp is zero', function () {
+          context('Update will set the dAPI timestamp to a non-zero value', function () {
             it('returns true', async function () {
-              // Set the dAPI to 100 first
               let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-              timestamp++;
-              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-              // dapiUpdateSubscriptionConditionParameters is 5%
-              // 100 -> 105 satisfies the condition and returns true
-              const encodedData = [105, 110, 100];
+              const encodedData = [0, 0, 0];
               for (let ind = 0; ind < encodedData.length; ind++) {
                 timestamp++;
                 await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
               }
+              // Even if the beacon values are zero, since their timestamps are not zero,
+              // the condition will return true
               expect(
                 await dapiServer
                   .connect(voidSignerAddressZero)
@@ -2068,19 +2065,8 @@ describe('conditionPspDapiUpdate', function () {
               ).to.equal(true);
             });
           });
-          context('Update is downwards', function () {
-            it('returns true', async function () {
-              // Set the dAPI to 100 first
-              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-              timestamp++;
-              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-              // dapiUpdateSubscriptionConditionParameters is 5%
-              // 100 -> 95 satisfies the condition and returns true
-              const encodedData = [95, 100, 90];
-              for (let ind = 0; ind < encodedData.length; ind++) {
-                timestamp++;
-                await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
-              }
+          context('Update will not set the dAPI timestamp to a non-zero value', function () {
+            it('returns false', async function () {
               expect(
                 await dapiServer
                   .connect(voidSignerAddressZero)
@@ -2089,57 +2075,109 @@ describe('conditionPspDapiUpdate', function () {
                     hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
                     dapiUpdateSubscriptionConditionParameters
                   )
-              ).to.equal(true);
+              ).to.equal(false);
             });
           });
         });
-        context('Data does not make a larger update than the threshold', function () {
-          context('Update is upwards', function () {
-            it('returns false', async function () {
-              // Set the dAPI to 100 first
-              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-              timestamp++;
-              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-              // dapiUpdateSubscriptionConditionParameters is 5%
-              // 100 -> 104 does not satisfy the condition and returns false
-              const encodedData = [110, 104, 95];
-              for (let ind = 0; ind < encodedData.length; ind++) {
+        context('dAPI timestamp is not zero', function () {
+          context('Data makes a larger update than the threshold', function () {
+            context('Update is upwards', function () {
+              it('returns true', async function () {
+                // Set the dAPI to 100 first
+                let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
                 timestamp++;
-                await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
-              }
-              expect(
-                await dapiServer
-                  .connect(voidSignerAddressZero)
-                  .callStatic.conditionPspDapiUpdate(
-                    dapiUpdateSubscriptionId,
-                    hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
-                    dapiUpdateSubscriptionConditionParameters
-                  )
-              ).to.equal(false);
+                await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+                // dapiUpdateSubscriptionConditionParameters is 5%
+                // 100 -> 105 satisfies the condition and returns true
+                const encodedData = [105, 110, 100];
+                for (let ind = 0; ind < encodedData.length; ind++) {
+                  timestamp++;
+                  await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+                }
+                expect(
+                  await dapiServer
+                    .connect(voidSignerAddressZero)
+                    .callStatic.conditionPspDapiUpdate(
+                      dapiUpdateSubscriptionId,
+                      hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                      dapiUpdateSubscriptionConditionParameters
+                    )
+                ).to.equal(true);
+              });
+            });
+            context('Update is downwards', function () {
+              it('returns true', async function () {
+                // Set the dAPI to 100 first
+                let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+                timestamp++;
+                await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+                // dapiUpdateSubscriptionConditionParameters is 5%
+                // 100 -> 95 satisfies the condition and returns true
+                const encodedData = [95, 100, 90];
+                for (let ind = 0; ind < encodedData.length; ind++) {
+                  timestamp++;
+                  await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+                }
+                expect(
+                  await dapiServer
+                    .connect(voidSignerAddressZero)
+                    .callStatic.conditionPspDapiUpdate(
+                      dapiUpdateSubscriptionId,
+                      hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                      dapiUpdateSubscriptionConditionParameters
+                    )
+                ).to.equal(true);
+              });
             });
           });
-          context('Update is downwards', function () {
-            it('returns false', async function () {
-              // Set the dAPI to 100 first
-              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
-              timestamp++;
-              await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
-              // dapiUpdateSubscriptionConditionParameters is 5%
-              // 100 -> 96 does not satisfy the condition and returns false
-              const encodedData = [105, 96, 95];
-              for (let ind = 0; ind < encodedData.length; ind++) {
+          context('Data does not make a larger update than the threshold', function () {
+            context('Update is upwards', function () {
+              it('returns false', async function () {
+                // Set the dAPI to 100 first
+                let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
                 timestamp++;
-                await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
-              }
-              expect(
-                await dapiServer
-                  .connect(voidSignerAddressZero)
-                  .callStatic.conditionPspDapiUpdate(
-                    dapiUpdateSubscriptionId,
-                    hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
-                    dapiUpdateSubscriptionConditionParameters
-                  )
-              ).to.equal(false);
+                await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+                // dapiUpdateSubscriptionConditionParameters is 5%
+                // 100 -> 104 does not satisfy the condition and returns false
+                const encodedData = [110, 104, 95];
+                for (let ind = 0; ind < encodedData.length; ind++) {
+                  timestamp++;
+                  await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+                }
+                expect(
+                  await dapiServer
+                    .connect(voidSignerAddressZero)
+                    .callStatic.conditionPspDapiUpdate(
+                      dapiUpdateSubscriptionId,
+                      hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                      dapiUpdateSubscriptionConditionParameters
+                    )
+                ).to.equal(false);
+              });
+            });
+            context('Update is downwards', function () {
+              it('returns false', async function () {
+                // Set the dAPI to 100 first
+                let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+                timestamp++;
+                await setDapi(airnodeAddress, dapiTemplateIds, [100, 100, 100], [timestamp, timestamp, timestamp]);
+                // dapiUpdateSubscriptionConditionParameters is 5%
+                // 100 -> 96 does not satisfy the condition and returns false
+                const encodedData = [105, 96, 95];
+                for (let ind = 0; ind < encodedData.length; ind++) {
+                  timestamp++;
+                  await setBeacon(dapiTemplateIds[ind], encodedData[ind], timestamp);
+                }
+                expect(
+                  await dapiServer
+                    .connect(voidSignerAddressZero)
+                    .callStatic.conditionPspDapiUpdate(
+                      dapiUpdateSubscriptionId,
+                      hre.ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [dapiBeaconIds]),
+                      dapiUpdateSubscriptionConditionParameters
+                    )
+                ).to.equal(false);
+              });
             });
           });
         });


### PR DESCRIPTION
Both for Beacons and dAPIs, the condition functions return `true` if the data point to be updated hasn't been initialized. This addresses the issue (even though it's not usable due to being front-runnable) where people can extract 1 bit from Beacon values by utilizing unintialized dAPIs. 

Also implemented a `updateDapiWithBeaconsAndReturnCondition()` with nicer interface. Note that it doesn't require `msg.sender==address(0)` because that`s not needed.