### PR TITLE
Change protocolId to have default value

### DIFF
--- a/.changeset/shiny-moose-care.md
+++ b/.changeset/shiny-moose-care.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': patch
+---
+
+Change `deriveWalletPathFromSponsorAddress` `protocolId` to have a default value

--- a/packages/airnode-node/src/evm/wallet.ts
+++ b/packages/airnode-node/src/evm/wallet.ts
@@ -18,14 +18,14 @@ import { Config } from '../config/types';
  * @param protocolId An optional string representing the protocol id. Defaults to '1'.
  * @returns The path derived from the address
  */
-export const deriveWalletPathFromSponsorAddress = (sponsorAddress: string, protocolId?: string) => {
+export const deriveWalletPathFromSponsorAddress = (sponsorAddress: string, protocolId = '1') => {
   const sponsorAddressBN = ethers.BigNumber.from(ethers.utils.getAddress(sponsorAddress));
   const paths = [];
   for (let i = 0; i < 6; i++) {
     const shiftedSponsorAddressBN = sponsorAddressBN.shr(31 * i);
     paths.push(shiftedSponsorAddressBN.mask(31).toString());
   }
-  return `${protocolId || '1'}/${paths.join('/')}`;
+  return `${protocolId}/${paths.join('/')}`;
 };
 
 export function getMasterHDNode(config: Config): ethers.utils.HDNode {


### PR DESCRIPTION
This fixes `protocolId` in **deriveWalletPathFromSponsorAddress** to have a default value (from [here](https://github.com/api3dao/airnode/pull/944#discussion_r831052861))