### PR TITLE
Loosen Solidity version requirement for RrpRequester

### DIFF
--- a/.changeset/three-schools-jam.md
+++ b/.changeset/three-schools-jam.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-protocol': patch
+---
+
+Looser Solidity version requirement for RrpRequester

--- a/packages/airnode-protocol/contracts/rrp/requesters/RrpRequester.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/RrpRequester.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity ^0.8.0;
 
-import "../interfaces/IAirnodeRrp.sol";
+import "./interfaces/IAirnodeRrp.sol";
 
 /// @title The contract to be inherited to make Airnode RRP requests
 contract RrpRequester {

--- a/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IAirnodeRrp.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IAirnodeRrp.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./IAuthorizationUtils.sol";
+import "./ITemplateUtils.sol";
+import "./IWithdrawalUtils.sol";
+
+interface IAirnodeRrp is IAuthorizationUtils, ITemplateUtils, IWithdrawalUtils {
+    event SetSponsorshipStatus(
+        address indexed sponsor,
+        address indexed requester,
+        bool sponsorshipStatus
+    );
+
+    event MadeTemplateRequest(
+        address indexed airnode,
+        bytes32 indexed requestId,
+        uint256 requesterRequestCount,
+        uint256 chainId,
+        address requester,
+        bytes32 templateId,
+        address sponsor,
+        address sponsorWallet,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes parameters
+    );
+
+    event MadeFullRequest(
+        address indexed airnode,
+        bytes32 indexed requestId,
+        uint256 requesterRequestCount,
+        uint256 chainId,
+        address requester,
+        bytes32 endpointId,
+        address sponsor,
+        address sponsorWallet,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes parameters
+    );
+
+    event FulfilledRequest(
+        address indexed airnode,
+        bytes32 indexed requestId,
+        bytes data
+    );
+
+    event FailedRequest(
+        address indexed airnode,
+        bytes32 indexed requestId,
+        string errorMessage
+    );
+
+    function setSponsorshipStatus(address requester, bool sponsorshipStatus)
+        external;
+
+    function makeTemplateRequest(
+        bytes32 templateId,
+        address sponsor,
+        address sponsorWallet,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata parameters
+    ) external returns (bytes32 requestId);
+
+    function makeFullRequest(
+        address airnode,
+        bytes32 endpointId,
+        address sponsor,
+        address sponsorWallet,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata parameters
+    ) external returns (bytes32 requestId);
+
+    function fulfill(
+        bytes32 requestId,
+        address airnode,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        bytes calldata data,
+        bytes calldata signature
+    ) external returns (bool callSuccess, bytes memory callData);
+
+    function fail(
+        bytes32 requestId,
+        address airnode,
+        address fulfillAddress,
+        bytes4 fulfillFunctionId,
+        string calldata errorMessage
+    ) external;
+
+    function sponsorToRequesterToSponsorshipStatus(
+        address sponsor,
+        address requester
+    ) external view returns (bool sponsorshipStatus);
+
+    function requesterToRequestCountPlusOne(address requester)
+        external
+        view
+        returns (uint256 requestCountPlusOne);
+
+    function requestIsAwaitingFulfillment(bytes32 requestId)
+        external
+        view
+        returns (bool isAwaitingFulfillment);
+}

--- a/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IAuthorizationUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IAuthorizationUtils.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IAuthorizationUtils {
+    function checkAuthorizationStatus(
+        address[] calldata authorizers,
+        address airnode,
+        bytes32 requestId,
+        bytes32 endpointId,
+        address sponsor,
+        address requester
+    ) external view returns (bool status);
+
+    function checkAuthorizationStatuses(
+        address[] calldata authorizers,
+        address airnode,
+        bytes32[] calldata requestIds,
+        bytes32[] calldata endpointIds,
+        address[] calldata sponsors,
+        address[] calldata requesters
+    ) external view returns (bool[] memory statuses);
+}

--- a/packages/airnode-protocol/contracts/rrp/requesters/interfaces/ITemplateUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/interfaces/ITemplateUtils.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ITemplateUtils {
+    event CreatedTemplate(
+        bytes32 indexed templateId,
+        address airnode,
+        bytes32 endpointId,
+        bytes parameters
+    );
+
+    function createTemplate(
+        address airnode,
+        bytes32 endpointId,
+        bytes calldata parameters
+    ) external returns (bytes32 templateId);
+
+    function getTemplates(bytes32[] calldata templateIds)
+        external
+        view
+        returns (
+            address[] memory airnodes,
+            bytes32[] memory endpointIds,
+            bytes[] memory parameters
+        );
+
+    function templates(bytes32 templateId)
+        external
+        view
+        returns (
+            address airnode,
+            bytes32 endpointId,
+            bytes memory parameters
+        );
+}

--- a/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IWithdrawalUtils.sol
+++ b/packages/airnode-protocol/contracts/rrp/requesters/interfaces/IWithdrawalUtils.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IWithdrawalUtils {
+    event RequestedWithdrawal(
+        address indexed airnode,
+        address indexed sponsor,
+        bytes32 indexed withdrawalRequestId,
+        address sponsorWallet
+    );
+
+    event FulfilledWithdrawal(
+        address indexed airnode,
+        address indexed sponsor,
+        bytes32 indexed withdrawalRequestId,
+        address sponsorWallet,
+        uint256 amount
+    );
+
+    function requestWithdrawal(address airnode, address sponsorWallet) external;
+
+    function fulfillWithdrawal(
+        bytes32 withdrawalRequestId,
+        address airnode,
+        address sponsor
+    ) external payable;
+
+    function sponsorToWithdrawalRequestCount(address sponsor)
+        external
+        view
+        returns (uint256 withdrawalRequestCount);
+}


### PR DESCRIPTION
I tried implementing a requester contract with Solidity 0.8.12 and realized that I can't because RrpRequester and the AirnodeRrp interfaces it depended on are fixed to 0.8.9. I updated the RrpRequester Solidity version to be ^0.8.0 but I couldn't do the same for AirnodeRrp interfaces because it changes the bytecode and breaks verifications. So I had to copy paste the AirnodeRrp interfaces to be used by RrpRequester. It's hacky but we can fix it in the v1 protocol.
