### PR TITLE
Fix condition for enabling GCP API gateway service

### DIFF
--- a/.changeset/rude-clouds-draw.md
+++ b/.changeset/rude-clouds-draw.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': patch
+---
+
+Fix condition for enabling GCP API gateway service

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dev:invoke": "(cd packages/airnode-node && yarn run dev:invoke)",
     "dev:list": "(cd packages/airnode-operation && yarn run dev:list)",
     "dev:stop": "(cd packages/airnode-operation && yarn run dev:stop)",
-    "docker": "yarn docker:build:artifacts && yarn docker:build:deployer && yarn docker:build:client && yarn docker:build:admin",
+    "docker:build": "yarn docker:build:artifacts && yarn docker:build:deployer && yarn docker:build:client && yarn docker:build:admin",
     "docker:build:admin": "docker build --tag api3/airnode-admin:latest --file packages/airnode-admin/docker/Dockerfile .",
     "docker:build:artifacts": "docker rmi --force api3/airnode-artifacts && docker build --tag api3/airnode-artifacts:latest --file docker/Dockerfile .",
     "docker:build:deployer": "docker build --tag api3/airnode-deployer:latest --file packages/airnode-deployer/docker/Dockerfile .",

--- a/packages/airnode-deployer/terraform/airnode/gcp/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/main.tf
@@ -71,7 +71,7 @@ module "startCoordinator" {
 }
 
 resource "google_project_service" "apigateway_api" {
-  count = var.http_api_key == null || var.http_signed_data_api_key == null ? 0 : 1
+  count = var.http_api_key == null && var.http_signed_data_api_key == null ? 0 : 1
 
   service = "apigateway.googleapis.com"
 
@@ -84,7 +84,7 @@ resource "google_project_service" "apigateway_api" {
 }
 
 resource "google_project_service" "servicecontrol_api" {
-  count = var.http_api_key == null || var.http_signed_data_api_key == null ? 0 : 1
+  count = var.http_api_key == null && var.http_signed_data_api_key == null ? 0 : 1
 
   service = "servicecontrol.googleapis.com"
 


### PR DESCRIPTION
This bug explains why all of a sudden we needed to enable the API gateway service manually on GCP.
Related to [AN-698](https://api3dao.atlassian.net/browse/AN-698) and [AN-700](https://api3dao.atlassian.net/browse/AN-700). Not sure it's the only issue though.