### PR TITLE
Improve validator bundling

### DIFF
--- a/.changeset/lucky-falcons-lay.md
+++ b/.changeset/lucky-falcons-lay.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-ois': minor
+'@api3/airnode-validator': minor
+---
+
+Improved validator bundling

--- a/packages/airnode-ois/src/index.ts
+++ b/packages/airnode-ois/src/index.ts
@@ -1,12 +1,14 @@
-import { oisSchema } from '@api3/airnode-validator';
+import { ois as oisModule } from '@api3/airnode-validator';
 import { OIS } from './types';
 
-export * from '@api3/airnode-validator/dist/cjs/src/ois';
 export * from './types';
 export * from './constants';
 
 // NOTE: The main purpose of this function is to make sure that the validator schema inferred from Zod (used internally
 // in validator) is compatible with our manually defined OIS types.
 export function parseOIS(ois: unknown): OIS {
-  return oisSchema.parse(ois);
+  return oisModule.oisSchema.parse(ois);
 }
+
+// Exports OIS schemas
+export { ois } from '@api3/airnode-validator';

--- a/packages/airnode-ois/src/index.ts
+++ b/packages/airnode-ois/src/index.ts
@@ -1,7 +1,7 @@
 import { oisSchema } from '@api3/airnode-validator';
 import { OIS } from './types';
 
-export * from '@api3/airnode-validator/dist/src/ois';
+export * from '@api3/airnode-validator/dist/cjs/src/ois';
 export * from './types';
 export * from './constants';
 

--- a/packages/airnode-validator/package.json
+++ b/packages/airnode-validator/package.json
@@ -3,19 +3,24 @@
   "license": "MIT",
   "version": "0.6.0",
   "private": false,
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/src/index.js",
+  "browser": "./dist/es6/src/index.js",
   "bin": {
     "airnode-validator": "./dist/bin/validator.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
-    "build": "yarn run clean && yarn run compile && copyfiles templates/**/** dist/ && copyfiles conversions/** dist/",
+    "build": "yarn run clean && yarn run compile",
     "clean": "rimraf -rf ./dist *.tgz",
     "cli": "ts-node bin/validator.ts",
-    "compile": "tsc -p tsconfig.build.json",
+    "compile": "yarn compile:cjs && yarn compile:es6 && yarn compile:esm",
+    "compile:cjs": "yarn tsc -p tsconfig.build-cjs.json",
+    "compile:es6": "yarn tsc -p tsconfig.build-es6.json",
+    "compile:esm": "yarn tsc -p tsconfig.build-esm.json",
     "pack": "yarn pack",
     "test": "jest --selectProjects unit",
     "test:e2e": "jest --selectProjects e2e",
@@ -32,8 +37,6 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.2",
-    "copyfiles": "^2.4.1",
-    "markdown-snippet-injector": "^0.2.4",
     "rimraf": "^3.0.2",
     "ts-node": "^10.1.0",
     "typescript": "^4.2.4"

--- a/packages/airnode-validator/src/index.ts
+++ b/packages/airnode-validator/src/index.ts
@@ -1,6 +1,7 @@
-export * from './ois';
-export * from './config';
-export * from './api';
+export * as ois from './ois';
+export * as config from './config';
+export * as receipt from './receipt';
 
+export * from './api';
 export * from './validation-result';
 export * from './types';

--- a/packages/airnode-validator/test/cli.feature.ts
+++ b/packages/airnode-validator/test/cli.feature.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'child_process';
 import { join } from 'path';
 
 const runValidator = (args: string[]) => {
-  const command = ['node', join(__dirname, '../dist/bin/validator.js'), ...args].join(' ');
+  const command = ['node', join(__dirname, '../dist/cjs/bin/validator.js'), ...args].join(' ');
 
   return spawnSync(command, { shell: true });
 };

--- a/packages/airnode-validator/tsconfig.build-cjs.json
+++ b/packages/airnode-validator/tsconfig.build-cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonJS",
+    "moduleResolution": "node",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/packages/airnode-validator/tsconfig.build-es6.json
+++ b/packages/airnode-validator/tsconfig.build-es6.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "target": "es6",
+    "module": "es6",
+    "moduleResolution": "node",
+    "outDir": "./dist/es6"
+  }
+}

--- a/packages/airnode-validator/tsconfig.build-esm.json
+++ b/packages/airnode-validator/tsconfig.build-esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "outDir": "./dist/esm"
+  }
+}

--- a/scripts/make-cli-executable.ts
+++ b/scripts/make-cli-executable.ts
@@ -4,4 +4,4 @@ import { chmodSync } from 'fs';
 const addExecuteRightsMode = '755'; // default is 664
 chmodSync('packages/airnode-admin/dist/bin/admin.js', addExecuteRightsMode);
 chmodSync('packages/airnode-deployer/dist/bin/deployer.js', addExecuteRightsMode);
-chmodSync('packages/airnode-validator/dist/bin/validator.js', addExecuteRightsMode);
+chmodSync('packages/airnode-validator/dist/cjs/bin/validator.js', addExecuteRightsMode);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11217,14 +11217,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-snippet-injector@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/markdown-snippet-injector/-/markdown-snippet-injector-0.2.4.tgz#2a3913dcc85920673268b5f61290db682d740b5d"
-  integrity sha512-pgPJTb8Wv6mAtNypNDZQisnu0MG27BgH7go+50dg8P7p4DMsIjsga4aJEkIIpmCdnAf6yBt1S0YIDmiclZjvug==
-  dependencies:
-    typescript "~3.1.0"
-    yargs "^4.1.0"
-
 markdown-table@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
@@ -15760,11 +15752,6 @@ typescript@^4.2.4, typescript@^4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
-typescript@~3.1.0:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.8.tgz#20703f388d9fccc562ca4a049d8a7567c8e95ebd"
-  integrity sha512-R97qglMfoKjfKD0N24o7W6bS+SwjN/eaQNIaxR8S5HdLRnt7rCk6LCmE3tve1KN8gXKgbJU51aZHRRMAQcIbMA==
-
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/typewise-core/-/typewise-core-1.2.0.tgz#97eb91805c7f55d2f941748fa50d315d991ef195"
@@ -17242,7 +17229,7 @@ yargs@^17.0.1, yargs@^17.2.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
-yargs@^4.1.0, yargs@^4.7.1:
+yargs@^4.7.1:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
   integrity sha1-wMQpJMpKqmsObaFznfshZDn53cA=


### PR DESCRIPTION
https://api3dao.atlassian.net/browse/AN-622

Added build targets for non cjs targets. This makes it more optimal to load the validator inside the browser environment (although modern bundles would probably handle cjs as well). 

I've tested this using a simple FE application and validator published locally (using verdaccio). I've also made sure the source maps works.