### PR TITLE
AN-614: Allowed security scheme must exist in config.json

### DIFF
--- a/.changeset/fifty-tools-attack.md
+++ b/.changeset/fifty-tools-attack.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-adapter': minor
+'@api3/airnode-validator': minor
+---
+
+Moves securityScheme reference check to airnode-validator package

--- a/packages/airnode-adapter/src/request-building/authentication.test.ts
+++ b/packages/airnode-adapter/src/request-building/authentication.test.ts
@@ -19,25 +19,6 @@ describe('building empty parameters', () => {
     });
   });
 
-  it('returns no parameters if API securitySchemes is empty', () => {
-    const ois = fixtures.buildOIS();
-    const apiSpecifications: ApiSpecification = {
-      ...ois.apiSpecifications,
-      components: {
-        ...ois.apiSpecifications.components,
-        securitySchemes: {},
-      },
-    };
-    const invalidOIS = fixtures.buildOIS({ apiSpecifications });
-    const options = fixtures.buildCacheRequestOptions({ ois: invalidOIS });
-    const res = authentication.buildParameters(options);
-    expect(res).toEqual({
-      headers: {},
-      query: {},
-      cookies: {},
-    });
-  });
-
   it('returns no parameters if API credentials is empty', () => {
     const options = fixtures.buildCacheRequestOptions({ apiCredentials: undefined });
     const res = authentication.buildParameters(options);

--- a/packages/airnode-adapter/src/request-building/authentication.ts
+++ b/packages/airnode-adapter/src/request-building/authentication.ts
@@ -116,11 +116,6 @@ export function buildParameters(options: CachedBuildRequestOptions): Authenticat
     options.ois.apiSpecifications.security,
     (authentication, _security, apiSecuritySchemeName) => {
       const apiSecurityScheme = options.ois.apiSpecifications.components.securitySchemes[apiSecuritySchemeName];
-      // If there is no security scheme, ignore the scheme
-      if (!apiSecurityScheme) {
-        return authentication;
-      }
-
       const apiCredentials = find(options.apiCredentials, ['securitySchemeName', apiSecuritySchemeName]) ?? null;
       return merge(authentication, getSchemeAuthentication(apiSecurityScheme, apiCredentials, options));
     },

--- a/packages/airnode-node/src/api/index.test.ts
+++ b/packages/airnode-node/src/api/index.test.ts
@@ -42,7 +42,7 @@ describe('callApi', () => {
         },
         apiCredentials: [
           {
-            securitySchemeName: 'My Security Scheme',
+            securitySchemeName: 'myApiSecurityScheme',
             securitySchemeValue: 'supersecret',
           },
         ],

--- a/packages/airnode-node/test/fixtures/config/config.ts
+++ b/packages/airnode-node/test/fixtures/config/config.ts
@@ -14,7 +14,7 @@ export function buildTrigger(overrides?: Partial<Trigger>): Trigger {
 
 export function buildApiCredentials(overrides?: Partial<ApiCredentials>): ApiCredentials {
   return {
-    securitySchemeName: 'My Security Scheme',
+    securitySchemeName: 'myApiSecurityScheme',
     securitySchemeValue: 'supersecret',
     oisTitle: 'Currency Converter API',
     ...overrides,

--- a/packages/airnode-node/test/fixtures/config/ois.ts
+++ b/packages/airnode-node/test/fixtures/config/ois.ts
@@ -37,7 +37,7 @@ export function buildOIS(ois?: Partial<OIS>): OIS {
       },
       components: {
         securitySchemes: {
-          'My Security Scheme': {
+          myApiSecurityScheme: {
             in: 'query',
             type: 'apiKey',
             name: 'access_key',

--- a/packages/airnode-validator/src/api/api.ts
+++ b/packages/airnode-validator/src/api/api.ts
@@ -1,13 +1,10 @@
+import { goSync } from '@api3/promise-utils';
 import template from 'lodash/template';
 import { z } from 'zod';
-import { goSync } from '@api3/promise-utils';
-import { SchemaType } from '../types';
 import { configSchema } from '../config';
 import { Receipt, receiptSchema } from '../receipt';
+import { Config, Secrets } from '../types';
 import { ValidationResult } from '../validation-result';
-
-type Secrets = Record<string, string | undefined>;
-type Config = SchemaType<typeof configSchema>;
 
 /**
  * Interpolates `secrets` into `config` and validates the interpolated configuration.

--- a/packages/airnode-validator/src/config/config.test.ts
+++ b/packages/airnode-validator/src/config/config.test.ts
@@ -133,14 +133,7 @@ it('fails if a securitySchemeName is enabled and it is of type "apiKey" or "http
       name: 'access_key',
     },
   };
-  const apiCredentials = [
-    {
-      oisTitle: 'Currency Converter API',
-      securitySchemeName: 'Currency Converter Security Scheme',
-      securitySchemeValue: '${SS_CURRENCY_CONVERTER_API_KEY}',
-    },
-  ];
-  const configWithSecuritySchemes = {
+  const invalidConfig = {
     ...config,
     ois: [
       ...config.ois,
@@ -153,19 +146,15 @@ it('fails if a securitySchemeName is enabled and it is of type "apiKey" or "http
         },
       },
     ],
-    apiCredentials,
-  };
-
-  const invalidConfig = {
-    ...configWithSecuritySchemes,
     apiCredentials: [],
   };
+
   expect(() => configSchema.parse(invalidConfig)).toThrow(
     new ZodError([
       {
         code: 'custom',
         message: 'The security scheme is enabled but no credentials are provided in "apiCredentials"',
-        path: ['ois', 1, 'apiSpecifications', 'security', 'Currency Converter Security Scheme'],
+        path: ['ois', 1, 'apiSpecifications', 'security', securitySchemeName],
       },
     ])
   );

--- a/packages/airnode-validator/src/config/config.test.ts
+++ b/packages/airnode-validator/src/config/config.test.ts
@@ -127,7 +127,7 @@ it('fails if ois.apiSpecifications.security.<securitySchemeName> is defined in o
 
   const securitySchemeName = 'Currency Converter Security Scheme';
   const securityScheme = {
-    securitySchemeName: {
+    [securitySchemeName]: {
       in: 'query',
       type: 'apiKey',
       name: 'access_key',
@@ -156,33 +156,19 @@ it('fails if ois.apiSpecifications.security.<securitySchemeName> is defined in o
     apiCredentials,
   };
 
-  const invalidConfigEmtpyApiCredentialValue = {
-    ...configWithSecuritySchemes,
-    apiCredentials: [...config.apiCredentials, { ...apiCredentials[0], securitySchemeValue: '' }],
-  };
-  expect(() => configSchema.parse(invalidConfigEmtpyApiCredentialValue)).toThrow(
-    new ZodError([
-      {
-        code: 'custom',
-        message: 'Security scheme "Currency Converter Security Scheme" is not defined in "components.securitySchemes"',
-        path: ['ois', 1, 'apiSpecifications', 'security', 0],
-      },
-    ])
-  );
-
-  const invalidConfigNoApiCredential = {
+  const invalidConfig = {
     ...configWithSecuritySchemes,
     apiCredentials: [
       ...config.apiCredentials,
       { ...apiCredentials[0], securitySchemeName: apiCredentials[0].securitySchemeName + Date.now().toString() },
     ],
   };
-  expect(() => configSchema.parse(invalidConfigNoApiCredential)).toThrow(
+  expect(() => configSchema.parse(invalidConfig)).toThrow(
     new ZodError([
       {
         code: 'custom',
-        message: 'Security scheme "Currency Converter Security Scheme" is not defined in "components.securitySchemes"',
-        path: ['ois', 1, 'apiSpecifications', 'security', 0],
+        message: 'The security scheme is enabled but no credentials are provided in "apiCredentials"',
+        path: ['ois', 1, 'apiSpecifications', 'security', 'Currency Converter Security Scheme'],
       },
     ])
   );

--- a/packages/airnode-validator/src/config/config.test.ts
+++ b/packages/airnode-validator/src/config/config.test.ts
@@ -120,7 +120,7 @@ describe('nodeSettingsSchema', () => {
   });
 });
 
-it('fails if ois.apiSpecifications.security.<securitySchemeName> is defined in ois.apiSpecifications.components.<securitySchemeName> but apiCredentials.securitySchemeValue is empty string', () => {
+it('fails if a securitySchemeName is enabled and it is of type "apiKey" or "http" but is missing credentials in "apiCredentials"', () => {
   const config: Config = JSON.parse(
     readFileSync(join(__dirname, '../../test/fixtures/interpolated-config.valid.json')).toString()
   );
@@ -158,10 +158,7 @@ it('fails if ois.apiSpecifications.security.<securitySchemeName> is defined in o
 
   const invalidConfig = {
     ...configWithSecuritySchemes,
-    apiCredentials: [
-      ...config.apiCredentials,
-      { ...apiCredentials[0], securitySchemeName: apiCredentials[0].securitySchemeName + Date.now().toString() },
-    ],
+    apiCredentials: [],
   };
   expect(() => configSchema.parse(invalidConfig)).toThrow(
     new ZodError([

--- a/packages/airnode-validator/src/config/config.ts
+++ b/packages/airnode-validator/src/config/config.ts
@@ -177,10 +177,10 @@ const validateSecuritySchemesReferences: SuperRefinement<{
         const securitySchemeApiCredentials = config.apiCredentials.find(
           (apiCredentials) => apiCredentials.securitySchemeName === enabledSecuritySchemeName
         );
-        if (!securitySchemeApiCredentials || !securitySchemeApiCredentials.securitySchemeValue) {
+        if (!securitySchemeApiCredentials) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: `The security scheme is enabled but no credentials are provided`,
+            message: `The security scheme is enabled but no credentials are provided in "apiCredentials"`,
             path: ['ois', index, 'apiSpecifications', 'security', enabledSecuritySchemeName],
           });
         }

--- a/packages/airnode-validator/src/config/config.ts
+++ b/packages/airnode-validator/src/config/config.ts
@@ -1,6 +1,7 @@
-import { z } from 'zod';
-import { oisSchema } from '../ois';
+import { SuperRefinement, z } from 'zod';
 import { version as packageVersion } from '../../package.json';
+import { oisSchema } from '../ois';
+import { ApiCredentials, OIS } from '../types';
 
 export const triggerSchema = z.object({
   endpointId: z.string(),
@@ -165,10 +166,35 @@ export const apiCredentialsSchema = baseApiCredentialsSchema.extend({
   oisTitle: z.string(),
 });
 
-export const configSchema = z.object({
-  chains: z.array(chainConfigSchema),
-  nodeSettings: nodeSettingsSchema,
-  ois: z.array(oisSchema),
-  triggers: triggersSchema,
-  apiCredentials: z.array(apiCredentialsSchema),
-});
+const validateSecuritySchemesReferences: SuperRefinement<{
+  ois: OIS[];
+  apiCredentials: ApiCredentials[];
+}> = (config, ctx) => {
+  config.ois.forEach((ois, index) => {
+    Object.keys(ois.apiSpecifications.security).forEach((enabledSecuritySchemeName) => {
+      const enabledSecurityScheme = ois.apiSpecifications.components.securitySchemes[enabledSecuritySchemeName];
+      if (enabledSecurityScheme && ['apiKey', 'http'].includes(enabledSecurityScheme.type)) {
+        const securitySchemeApiCredentials = config.apiCredentials.find(
+          (apiCredentials) => apiCredentials.securitySchemeName === enabledSecuritySchemeName
+        );
+        if (!securitySchemeApiCredentials || !securitySchemeApiCredentials.securitySchemeValue) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `The security scheme is enabled but no credentials are provided`,
+            path: ['ois', index, 'apiSpecifications', 'security', enabledSecuritySchemeName],
+          });
+        }
+      }
+    });
+  });
+};
+
+export const configSchema = z
+  .object({
+    chains: z.array(chainConfigSchema),
+    nodeSettings: nodeSettingsSchema,
+    ois: z.array(oisSchema),
+    triggers: triggersSchema,
+    apiCredentials: z.array(apiCredentialsSchema),
+  })
+  .superRefine(validateSecuritySchemesReferences);

--- a/packages/airnode-validator/src/ois/ois.test.ts
+++ b/packages/airnode-validator/src/ois/ois.test.ts
@@ -140,3 +140,27 @@ it('verifies parameter interpolation in "apiSpecification.paths"', () => {
     ])
   );
 });
+
+it('fails if apiSpecifications.security.<securitySchemeName> is not defined in apiSpecifications.components.<securitySchemeName>', () => {
+  const invalidSecuritySchemeName = 'INVALID_SECURITY_SCHEME_NAME';
+  const ois = loadOisFixture();
+  const invalidOis = {
+    ...ois,
+    ...{
+      apiSpecifications: {
+        ...ois.apiSpecifications,
+        security: { ...ois.apiSpecifications.security, [invalidSecuritySchemeName]: [] },
+      },
+    },
+  };
+
+  expect(() => oisSchema.parse(invalidOis)).toThrow(
+    new ZodError([
+      {
+        code: 'custom',
+        message: `Security scheme "${invalidSecuritySchemeName}" is not defined in "components.securitySchemes"`,
+        path: ['apiSpecifications', 'security', 1],
+      },
+    ])
+  );
+});

--- a/packages/airnode-validator/src/ois/ois.ts
+++ b/packages/airnode-validator/src/ois/ois.ts
@@ -1,9 +1,9 @@
-import { z } from 'zod';
-import intersection from 'lodash/intersection';
 import forEach from 'lodash/forEach';
+import intersection from 'lodash/intersection';
 import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';
-import { SchemaType, ValidatorRefinement } from '../types';
+import { z } from 'zod';
+import { OIS, SchemaType, ValidatorRefinement } from '../types';
 
 function removeBraces(value: string) {
   return trimEnd(trimStart(value, '{'), '}');
@@ -161,11 +161,11 @@ export const apiSpecificationSchema = z
     servers: z.array(serverSchema),
     security: z.record(z.tuple([])),
   })
-  .superRefine((apiSpecification, ctx) => {
-    Object.keys(apiSpecification.security).forEach((enabledSecuritySchemeName, index) => {
+  .superRefine((apiSpecifications, ctx) => {
+    Object.keys(apiSpecifications.security).forEach((enabledSecuritySchemeName, index) => {
       // Verify that ois.apiSpecifications.security.<securitySchemeName> is
       // referencing a valid ois.apiSpecifications.components.<securitySchemeName> object
-      const enabledSecurityScheme = apiSpecification.components.securitySchemes[enabledSecuritySchemeName];
+      const enabledSecurityScheme = apiSpecifications.components.securitySchemes[enabledSecuritySchemeName];
       if (!enabledSecurityScheme) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -218,5 +218,5 @@ export const baseOisSchema = z.object({
   apiSpecifications: apiSpecificationSchema,
   endpoints: z.array(endpointSchema),
 });
-type OIS = SchemaType<typeof baseOisSchema>;
+
 export const oisSchema = baseOisSchema.superRefine(ensureSingleParameterUsagePerEndpoint);

--- a/packages/airnode-validator/src/ois/ois.ts
+++ b/packages/airnode-validator/src/ois/ois.ts
@@ -161,16 +161,10 @@ export const apiSpecificationSchema = z
     servers: z.array(serverSchema),
     security: z.record(z.tuple([])),
   })
-  // .refine(
-  //   (apiSpecification) => {
-  //     return Object.keys(apiSpecification.security).every(
-  //       (securityScheme) => apiSpecification.components.securitySchemes[securityScheme] !== undefined
-  //     );
-  //   },
-  //   { path: ['security'], message: 'All security schemes must be defined in components.securitySchemes' }
-  // );
   .superRefine((apiSpecification, ctx) => {
     Object.keys(apiSpecification.security).forEach((enabledSecuritySchemeName, index) => {
+      // Verify that ois.apiSpecifications.security.<securitySchemeName> is
+      // referencing a valid ois.apiSpecifications.components.<securitySchemeName> object
       const enabledSecurityScheme = apiSpecification.components.securitySchemes[enabledSecuritySchemeName];
       if (!enabledSecurityScheme) {
         ctx.addIssue({

--- a/packages/airnode-validator/src/types.ts
+++ b/packages/airnode-validator/src/types.ts
@@ -1,5 +1,13 @@
-import { ZodFirstPartySchemaTypes, RefinementCtx, z } from 'zod';
+import { RefinementCtx, z, ZodFirstPartySchemaTypes } from 'zod';
+import { apiCredentialsSchema, configSchema } from './config';
+import { oisSchema } from './ois';
 
 export type SchemaType<Schema extends ZodFirstPartySchemaTypes> = z.infer<Schema>;
 
 export type ValidatorRefinement<T> = (arg: T, ctx: RefinementCtx) => void;
+
+export type Secrets = Record<string, string | undefined>;
+
+export type Config = SchemaType<typeof configSchema>;
+export type OIS = SchemaType<typeof oisSchema>;
+export type ApiCredentials = SchemaType<typeof apiCredentialsSchema>;


### PR DESCRIPTION
[AN-614](https://api3dao.atlassian.net/browse/AN-614): used [zod.superRefine()](https://github.com/colinhacks/zod#superRefine) in order to validate that the security scheme enabled under `ois.apiSpecifications.security` is defined in `ois.apiSpecifications.components`.