### PR TITLE
Update config txType to use number type instead of string

### DIFF
--- a/.changeset/beige-rocks-pull.md
+++ b/.changeset/beige-rocks-pull.md
@@ -1,0 +1,10 @@
+---
+'@api3/airnode-admin': minor
+'@api3/airnode-deployer': minor
+'@api3/airnode-examples': minor
+'@api3/airnode-node': minor
+'@api3/airnode-utilities': minor
+'@api3/airnode-validator': minor
+---
+
+Update txType config to use type numbers

--- a/packages/airnode-admin/src/implementation.ts
+++ b/packages/airnode-admin/src/implementation.ts
@@ -66,7 +66,7 @@ export const parseOverrides = async (
   if (supportsEip1559 && !hasEip1559Overrides && !hasLegacyOverrides) {
     const [_gasPriceLogs, gasTarget] = await getEip1559GasPricing({
       provider: provider,
-      chainOptions: { txType: 'eip1559' },
+      chainOptions: { txType: 2 },
     });
 
     return {
@@ -79,7 +79,7 @@ export const parseOverrides = async (
   if (!supportsEip1559 && !hasLegacyOverrides) {
     const [_gasPriceLogs, gasTarget] = await getLegacyGasPrice({
       provider: provider,
-      chainOptions: { txType: 'legacy' },
+      chainOptions: { txType: 0 },
     });
 
     return {

--- a/packages/airnode-deployer/config/config.example.json
+++ b/packages/airnode-deployer/config/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
@@ -23,7 +23,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
       },
       type: 'evm',
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,

--- a/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
@@ -23,7 +23,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
       },
       type: 'evm',
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,

--- a/packages/airnode-examples/integrations/coingecko-testable/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-testable/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
@@ -23,7 +23,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
       },
       type: 'evm',
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,

--- a/packages/airnode-examples/integrations/coingecko/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/coingecko/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko/create-config.ts
@@ -23,7 +23,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
       },
       type: 'evm',
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,

--- a/packages/airnode-examples/integrations/failing-example/config.example.json
+++ b/packages/airnode-examples/integrations/failing-example/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/failing-example/create-config.ts
+++ b/packages/airnode-examples/integrations/failing-example/create-config.ts
@@ -23,7 +23,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
       },
       type: 'evm',
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -23,7 +23,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
       },
       type: 'evm',
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,

--- a/packages/airnode-examples/integrations/weather-multi-value/config.example.json
+++ b/packages/airnode-examples/integrations/weather-multi-value/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
+++ b/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
@@ -23,7 +23,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
       },
       type: 'evm',
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,

--- a/packages/airnode-node/config/config.example.json
+++ b/packages/airnode-node/config/config.example.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-node/src/config/types.ts
+++ b/packages/airnode-node/src/config/types.ts
@@ -38,7 +38,7 @@ export interface PriorityFee {
 }
 
 export interface ChainOptions {
-  readonly txType: 'legacy' | 'eip1559';
+  readonly txType: 0 | 2;
   readonly gasPriceMultiplier?: number;
   readonly baseFeeMultiplier?: number;
   readonly priorityFee?: PriorityFee;

--- a/packages/airnode-node/src/coordinator/calls/chain-limits.test.ts
+++ b/packages/airnode-node/src/coordinator/calls/chain-limits.test.ts
@@ -14,7 +14,7 @@ const createChainConfig = (overrides: Partial<ChainConfig>): ChainConfig => {
     id: '31337',
     type: 'evm',
     options: {
-      txType: 'legacy',
+      txType: 0,
       fulfillmentGasLimit: 123456,
     },
     providers: {},

--- a/packages/airnode-node/src/evm/handlers/process-transactions.test.ts
+++ b/packages/airnode-node/src/evm/handlers/process-transactions.test.ts
@@ -24,7 +24,7 @@ import { processTransactions } from './process-transactions';
 import * as fixtures from '../../../test/fixtures';
 import { GroupedRequests } from '../../types';
 
-const createConfig = (txType: 'legacy' | 'eip1559') => {
+const createConfig = (txType: 0 | 2) => {
   const initialConfig = fixtures.buildConfig();
   return {
     ...initialConfig,
@@ -39,7 +39,7 @@ const createConfig = (txType: 'legacy' | 'eip1559') => {
 };
 
 describe('processTransactions', () => {
-  test.each(['legacy', 'eip1559'] as const)(
+  test.each([0, 2] as const)(
     'fetches the gas price, assigns nonces and submits transactions - txType: %s',
     async (txType) => {
       const config = createConfig(txType);
@@ -97,8 +97,8 @@ describe('processTransactions', () => {
 
       let res = await processTransactions(state);
 
-      expect(txType === 'legacy' ? blockSpy : gasPriceSpy).not.toHaveBeenCalled();
-      expect(txType === 'eip1559' ? blockSpy : gasPriceSpy).toHaveBeenCalled();
+      expect(txType === 0 ? blockSpy : gasPriceSpy).not.toHaveBeenCalled();
+      expect(txType === 2 ? blockSpy : gasPriceSpy).toHaveBeenCalled();
       expect(res.requests.apiCalls[0]).toEqual({
         ...apiCall,
         nonce: 79,
@@ -171,7 +171,7 @@ describe('processTransactions', () => {
     }
   );
 
-  test.each(['legacy', 'eip1559'] as const)(
+  test.each([0, 2] as const)(
     `does not submit transactions if a gas price cannot be fetched - txType: %s`,
     async (txType) => {
       const config = createConfig(txType);
@@ -179,7 +179,7 @@ describe('processTransactions', () => {
       const fulfillMock = jest.spyOn(contract, 'fulfill');
       const gasPriceSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getGasPrice');
       const blockSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlock');
-      if (txType === 'legacy') {
+      if (txType === 0) {
         gasPriceSpy.mockRejectedValue(new Error('Gas price cannot be fetched'));
       } else {
         blockSpy.mockRejectedValue(new Error('Block header cannot be fetched'));

--- a/packages/airnode-node/src/evm/handlers/process-transactions.ts
+++ b/packages/airnode-node/src/evm/handlers/process-transactions.ts
@@ -42,7 +42,7 @@ export async function processTransactions(
     return state2;
   }
 
-  if (chainOptions.txType === 'eip1559') {
+  if (chainOptions.txType === 2) {
     const gweiMaxFee = utils.weiToGwei(gasTarget.maxFeePerGas!);
     const gweiPriorityFee = utils.weiToGwei(gasTarget.maxPriorityFeePerGas!);
     logger.info(

--- a/packages/airnode-node/src/handlers/process-transactions.test.ts
+++ b/packages/airnode-node/src/handlers/process-transactions.test.ts
@@ -3,7 +3,7 @@ import * as evmHandler from '../evm/handlers/process-transactions';
 import * as fixtures from '../../test/fixtures';
 
 describe('processTransactions', () => {
-  test.each(['legacy', 'eip1559'] as const)('processes EVM providers - txType: %s', async (txType) => {
+  test.each([0, 2] as const)('processes EVM providers - txType: %s', async (txType) => {
     const processSpy = jest.spyOn(evmHandler, 'processTransactions');
     const initialState = fixtures.buildEVMProviderSponsorState();
     const chainOptions = { txType, fulfillmentGasLimit: 500_000 };

--- a/packages/airnode-node/src/handlers/start-coordinator.test.ts
+++ b/packages/airnode-node/src/handlers/start-coordinator.test.ts
@@ -30,7 +30,7 @@ import { startCoordinator } from './start-coordinator';
 import * as fixtures from '../../test/fixtures';
 
 describe('startCoordinator', () => {
-  test.each(['legacy', 'eip1559'] as const)(`fetches and processes requests - txType: %s`, async (txType) => {
+  test.each([0, 2] as const)(`fetches and processes requests - txType: %s`, async (txType) => {
     jest.setTimeout(30000);
     const initialConfig = fixtures.buildConfig();
     const config = {
@@ -78,8 +78,8 @@ describe('startCoordinator', () => {
 
     await startCoordinator(config);
 
-    expect(txType === 'legacy' ? blockSpy : gasPriceSpy).not.toHaveBeenCalled();
-    expect(txType === 'eip1559' ? blockSpy : gasPriceSpy).toHaveBeenCalled();
+    expect(txType === 0 ? blockSpy : gasPriceSpy).not.toHaveBeenCalled();
+    expect(txType === 2 ? blockSpy : gasPriceSpy).toHaveBeenCalled();
 
     // API call was submitted
     expect(fulfillMock).toHaveBeenCalledTimes(1);

--- a/packages/airnode-node/src/providers/actions.test.ts
+++ b/packages/airnode-node/src/providers/actions.test.ts
@@ -49,7 +49,7 @@ const chains: ChainConfig[] = [
     },
     type: 'evm',
     options: {
-      txType: 'eip1559',
+      txType: 2,
       baseFeeMultiplier: 2,
       priorityFee: {
         value: 3.12,
@@ -72,7 +72,7 @@ const chains: ChainConfig[] = [
     },
     type: 'evm',
     options: {
-      txType: 'eip1559',
+      txType: 2,
       baseFeeMultiplier: 2,
       priorityFee: {
         value: 3.12,
@@ -112,7 +112,7 @@ describe('initialize', () => {
             chainId: '1',
             chainType: 'evm',
             chainOptions: {
-              txType: 'eip1559',
+              txType: 2,
               baseFeeMultiplier: 2,
               priorityFee: {
                 value: 3.12,
@@ -156,7 +156,7 @@ describe('initialize', () => {
             chainId: '3',
             chainType: 'evm',
             chainOptions: {
-              txType: 'eip1559',
+              txType: 2,
               baseFeeMultiplier: 2,
               priorityFee: {
                 value: 3.12,
@@ -201,7 +201,7 @@ describe('initialize', () => {
 });
 
 describe('processRequests', () => {
-  test.each(['legacy', 'eip1559'] as const)('processes requests for each EVM provider - txType: %s', async (txType) => {
+  test.each([0, 2] as const)('processes requests for each EVM provider - txType: %s', async (txType) => {
     const { blockSpy, gasPriceSpy } = createAndMockGasTarget(txType);
 
     estimateGasWithdrawalMock.mockResolvedValueOnce(ethers.BigNumber.from(50_000));
@@ -232,8 +232,8 @@ describe('processRequests', () => {
     const [logs, res] = await providers.processRequests(allProviders, workerOpts);
     expect(logs).toEqual([]);
 
-    expect(txType === 'legacy' ? blockSpy : gasPriceSpy).not.toHaveBeenCalled();
-    expect(txType === 'eip1559' ? blockSpy : gasPriceSpy).toHaveBeenCalled();
+    expect(txType === 0 ? blockSpy : gasPriceSpy).not.toHaveBeenCalled();
+    expect(txType === 2 ? blockSpy : gasPriceSpy).toHaveBeenCalled();
 
     expect(res.evm.map((evm) => evm.requests.apiCalls[0])).toEqual(
       range(allProviders.length).map(() => ({

--- a/packages/airnode-node/src/providers/state.test.ts
+++ b/packages/airnode-node/src/providers/state.test.ts
@@ -24,7 +24,7 @@ describe('create', () => {
       },
       type: chainType,
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,
@@ -47,7 +47,7 @@ describe('create', () => {
         chainId: '1337',
         chainType: 'evm',
         chainOptions: {
-          txType: 'eip1559',
+          txType: 2,
           baseFeeMultiplier: 2,
           priorityFee: {
             value: 3.12,
@@ -102,7 +102,7 @@ describe('create', () => {
       },
       type: chainType,
       options: {
-        txType: 'eip1559',
+        txType: 2,
         baseFeeMultiplier: 2,
         priorityFee: {
           value: 3.12,
@@ -124,7 +124,7 @@ describe('create', () => {
         blockHistoryLimit: 150,
         chainId: '1337',
         chainOptions: {
-          txType: 'eip1559',
+          txType: 2,
           baseFeeMultiplier: 2,
           priorityFee: {
             value: 3.12,

--- a/packages/airnode-node/test/fixtures/config/config.ts
+++ b/packages/airnode-node/test/fixtures/config/config.ts
@@ -33,7 +33,7 @@ export function buildConfig(overrides?: Partial<Config>): Config {
         id: '31337',
         type: 'evm',
         options: {
-          txType: 'legacy',
+          txType: 0,
           fulfillmentGasLimit: 123456,
         },
         providers: {

--- a/packages/airnode-node/test/fixtures/provider-states/evm.ts
+++ b/packages/airnode-node/test/fixtures/provider-states/evm.ts
@@ -19,7 +19,7 @@ export function buildEVMProviderState(
     id: chainId,
     type: chainType,
     options: {
-      txType: 'legacy',
+      txType: 0,
       fulfillmentGasLimit: 123456,
     },
     providers: {

--- a/packages/airnode-node/test/mock-utils.ts
+++ b/packages/airnode-node/test/mock-utils.ts
@@ -46,11 +46,11 @@ export function mockEthers({ airnodeRrpMocks = {}, ethersMocks = {} }: MockProps
 /**
  * Creates and mocks gas pricing-related resources based on txType.
  */
-export const createAndMockGasTarget = (txType: 'legacy' | 'eip1559') => {
+export const createAndMockGasTarget = (txType: 0 | 2) => {
   const gasPriceSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getGasPrice');
   const blockSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlock');
   const gasLimit = ethers.BigNumber.from(500_000);
-  if (txType === 'legacy') {
+  if (txType === 0) {
     const gasPrice = ethers.BigNumber.from(1_000);
     gasPriceSpy.mockResolvedValue(gasPrice);
     return { gasTarget: { type: 0, gasPrice, gasLimit }, blockSpy, gasPriceSpy };

--- a/packages/airnode-node/test/setup/e2e/utils.ts
+++ b/packages/airnode-node/test/setup/e2e/utils.ts
@@ -19,7 +19,7 @@ export function buildChainConfig(contracts: Contracts): ChainConfig {
     id: '31337',
     type: 'evm',
     options: {
-      txType: 'eip1559',
+      txType: 2,
       baseFeeMultiplier: 2,
       priorityFee: {
         value: 3.12,

--- a/packages/airnode-utilities/src/evm/gas-prices/gas-prices.test.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/gas-prices.test.ts
@@ -25,7 +25,7 @@ import { BASE_FEE_MULTIPLIER, PRIORITY_FEE_IN_WEI } from '../../constants';
 const createLegacyBaseOptions = (): FetchOptions => ({
   provider: new ethers.providers.JsonRpcProvider(),
   chainOptions: {
-    txType: 'legacy',
+    txType: 0,
     fulfillmentGasLimit: 500_000,
   },
 });
@@ -35,7 +35,7 @@ const createEip1559BaseOptions = () => {
 
   const eip1559ChainOptions = [
     {
-      txType: 'eip1559',
+      txType: 2,
       baseFeeMultiplier: BASE_FEE_MULTIPLIER,
       priorityFee: {
         value: 3.12,
@@ -44,7 +44,7 @@ const createEip1559BaseOptions = () => {
       fulfillmentGasLimit: 500_000,
     },
     {
-      txType: 'eip1559',
+      txType: 2,
       baseFeeMultiplier: undefined,
       priorityFee: {
         value: 3.12,
@@ -53,13 +53,13 @@ const createEip1559BaseOptions = () => {
       fulfillmentGasLimit: 500_000,
     },
     {
-      txType: 'eip1559',
+      txType: 2,
       baseFeeMultiplier: BASE_FEE_MULTIPLIER,
       priorityFee: undefined,
       fulfillmentGasLimit: 500_000,
     },
     {
-      txType: 'eip1559',
+      txType: 2,
       baseFeeMultiplier: undefined,
       priorityFee: undefined,
       fulfillmentGasLimit: 500_000,

--- a/packages/airnode-utilities/src/evm/gas-prices/gas-prices.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/gas-prices.ts
@@ -37,7 +37,7 @@ export const getLegacyGasPrice = async (options: FetchOptions): Promise<LogsData
   return [
     [],
     {
-      type: 0,
+      type: chainOptions.txType,
       gasPrice: multipliedGasPrice,
       ...getGasLimit(chainOptions.fulfillmentGasLimit),
     },
@@ -68,7 +68,7 @@ export const getEip1559GasPricing = async (options: FetchOptions): Promise<LogsD
   return [
     logs,
     {
-      type: 2,
+      type: chainOptions.txType,
       maxPriorityFeePerGas,
       maxFeePerGas,
       ...getGasLimit(chainOptions.fulfillmentGasLimit),
@@ -80,9 +80,9 @@ export const getGasPrice = async (options: FetchOptions): Promise<LogsData<GasTa
   const { chainOptions } = options;
 
   switch (chainOptions.txType) {
-    case 'legacy':
+    case 0:
       return getLegacyGasPrice(options);
-    case 'eip1559':
+    case 2:
       return getEip1559GasPricing(options);
   }
 };

--- a/packages/airnode-utilities/src/evm/gas-prices/types.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/types.ts
@@ -15,7 +15,7 @@ export interface PriorityFee {
 }
 
 export interface ChainOptions extends PromiseOptions {
-  txType: 'legacy' | 'eip1559';
+  txType: 0 | 2;
   gasPriceMultiplier?: number;
   baseFeeMultiplier?: number;
   priorityFee?: PriorityFee;

--- a/packages/airnode-validator/exampleSpecs/config.specs.json
+++ b/packages/airnode-validator/exampleSpecs/config.specs.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-validator/src/config/config.ts
+++ b/packages/airnode-validator/src/config/config.ts
@@ -44,7 +44,7 @@ export const priorityFeeSchema = z.object({
 });
 
 export const chainOptionsSchema = z.object({
-  txType: z.union([z.literal('legacy'), z.literal('eip1559')]),
+  txType: z.union([z.literal(0), z.literal(2)]),
   gasPriceMultiplier: z.number().optional(),
   baseFeeMultiplier: z.number().int().optional(),
   priorityFee: priorityFeeSchema.optional(),

--- a/packages/airnode-validator/test/fixtures/config.valid.json
+++ b/packages/airnode-validator/test/fixtures/config.valid.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,

--- a/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
+++ b/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
@@ -14,7 +14,7 @@
       },
       "type": "evm",
       "options": {
-        "txType": "eip1559",
+        "txType": 2,
         "baseFeeMultiplier": 2,
         "priorityFee": {
           "value": 3.12,


### PR DESCRIPTION
This changes the **config.json** `txType` to accept either `0` (for legacy) or `2` (for eip1559) as values.