### PR TITLE
Add config validation for local Airnode invocation including `airnode-client` container

### DIFF
--- a/.changeset/warm-knives-visit.md
+++ b/.changeset/warm-knives-visit.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-examples': minor
+'@api3/airnode-node': minor
+---
+
+Add config validation for local Airnode invocation including airnode-client container

--- a/packages/airnode-examples/README.md
+++ b/packages/airnode-examples/README.md
@@ -213,7 +213,7 @@ yarn run-airnode-locally api3/airnode-client-dev:bb9b8118940ec852c4223b13eba5a6e
 
 ### 11. Deploy a requester
 
-At this point, you have an RRP contract deployed. You will also either have Airnode running as a Docker container  
+At this point, you have an RRP contract deployed. You will also either have Airnode running as a Docker container
 locally or deployed to a cloud provider. Airnode is now listening for events (requests to be made) from the RRP
 contract. Requests via the RRP contract originate from requester contracts and therefore a requester contract will need
 to be deployed in order to make an on-chain request to your Airnode instance.
@@ -282,6 +282,14 @@ yarn remove-airnode
 ```
 
 This will use the deployer to remove the Airnode functions from the cloud provider.
+
+### 17. (Only if running Airnode locally) Stop the Airnode container
+
+If you wish to stop the Airnode container running locally run:
+
+```sh
+yarn stop-local-airnode
+```
 
 ## For developers
 

--- a/packages/airnode-examples/package.json
+++ b/packages/airnode-examples/package.json
@@ -26,6 +26,7 @@
     "remove-airnode": "ts-node scripts/remove-airnode.ts",
     "run-airnode-locally": "ts-node scripts/run-airnode-locally.ts",
     "sponsor-requester": "ts-node scripts/sponsor-requester.ts",
+    "stop-local-airnode": "ts-node scripts/stop-local-airnode.ts",
     "test:coingecko-aws": "ts-node scripts/aws-test/coingecko-aws-test.ts",
     "test": "jest --selectProjects unit",
     "test:e2e": "jest --selectProjects e2e"

--- a/packages/airnode-examples/scripts/stop-local-airnode.ts
+++ b/packages/airnode-examples/scripts/stop-local-airnode.ts
@@ -1,0 +1,13 @@
+import { cliPrint, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../src';
+
+const main = async () => {
+  const integrationInfo = readIntegrationInfo();
+  if (integrationInfo.airnodeType !== 'local') {
+    cliPrint.error('You only need to run this script if you want to stop Airnode running locally!');
+    return;
+  }
+
+  runShellCommand(`docker stop airnode`);
+};
+
+runAndHandleErrors(main);

--- a/packages/airnode-node/docker/Dockerfile
+++ b/packages/airnode-node/docker/Dockerfile
@@ -14,14 +14,17 @@ COPY --from=api3/airnode-artifacts /dependencies/airnode-node ${appDir}/node_mod
 COPY --from=api3/airnode-artifacts /packages ${appDir}/node_modules/@api3/
 COPY --from=api3/airnode-artifacts /build/packages/airnode-node/dist ${appDir}/
 COPY packages/airnode-node/docker/airnode-crontab ${cronjob}
+COPY packages/airnode-node/docker/entrypoint.sh /entrypoint.sh
 
     # Install Tini to pass signals correctly
-RUN apk add --update --no-cache tini && \
+RUN apk add --update --no-cache tini dos2unix && \
     # Create Airnode user
     adduser -h ${appDir} -s /bin/false -S -D -H ${name} && \
     # Enable Airnode cronjob
     chmod +x ${cronjob} && \
-    crontab -u ${name} ${cronjob}
+    crontab -u ${name} ${cronjob} && \
+    # Git swaps out LF with CRLF on Windows but only in the working directory
+    dos2unix /entrypoint.sh
 
 # We need to run the cron daemon as root but the Airnode itself is run under the airnode user
-ENTRYPOINT ["tini", "--", "crond", "-f"]
+ENTRYPOINT ["tini", "--", "/entrypoint.sh"]

--- a/packages/airnode-node/docker/entrypoint.sh
+++ b/packages/airnode-node/docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+node /app/src/cli/validate-config.js && crond -f

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -12,7 +12,7 @@
     "build": "yarn run clean && yarn run compile",
     "clean": "rimraf -rf *.tsbuildinfo ./dist *.tgz",
     "compile": "tsc --build tsconfig.build.json",
-    "dev:invoke": "ts-node src/cli/invoke.ts",
+    "dev:invoke": "ts-node src/cli/validate-config.ts && ts-node src/cli/invoke.ts",
     "dev:testApi": "ts-node src/cli/test-api.ts",
     "pack": "yarn pack",
     "test:e2e": "SILENCE_LOGGER=true jest --selectProjects e2e",

--- a/packages/airnode-node/src/cli/validate-config.ts
+++ b/packages/airnode-node/src/cli/validate-config.ts
@@ -1,0 +1,7 @@
+import * as path from 'path';
+import dotenv from 'dotenv';
+import { loadConfig } from '../config';
+
+dotenv.config({ path: path.resolve(`${__dirname}/../../config/secrets.env`) });
+// We don't care about the config itself, we just need it to be validated when the airnode-client starts
+loadConfig(path.resolve(`${__dirname}/../../config/config.json`), process.env);


### PR DESCRIPTION
[AN-595](https://api3dao.atlassian.net/browse/AN-595)

Doing the config file validation separately (instead of running it as a part of `invoke.ts`) so that if it fails, the container fails as well instead of running and throwing an error every minute.  