### PR TITLE
Update root tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "changeset:new-version": "yarn changeset version && yarn ts-node scripts/update-config-fixtures.ts",
     "clean": "lerna run clean --stream",
     "cli:deployer": "lerna run --scope @api3/airnode-deployer cli -- --",
+    "compile": "yarn tsc --build",
     "dev:api": "(cd packages/airnode-operation && yarn run dev:api)",
     "dev:api:background": "(cd packages/airnode-operation && yarn run dev:api:background)",
     "dev:background": "(cd packages/airnode-operation && yarn run dev:background)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,28 @@
     "skipLibCheck": true,
     "composite": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  }
+    "noFallthroughCasesInSwitch": true,
+    // Disabled because they are too restrictive
+    "exactOptionalPropertyTypes": false,
+    "noUncheckedIndexedAccess": false,
+    // Disabled because they are covered by Eslint rules
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    // Disabled because prefer the property syntax
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "files": [],
+  "references": [
+    { "path": "./packages/airnode-abi" },
+    { "path": "./packages/airnode-deployer" },
+    { "path": "./packages/airnode-ois" },
+    { "path": "./packages/airnode-utilities" },
+    { "path": "./packages/airnode-adapter" },
+    { "path": "./packages/airnode-examples" },
+    { "path": "./packages/airnode-operation" },
+    { "path": "./packages/airnode-validator" },
+    { "path": "./packages/airnode-admin" },
+    { "path": "./packages/airnode-node" },
+    { "path": "./packages/airnode-protocol" }
+  ]
 }


### PR DESCRIPTION
https://api3dao.atlassian.net/browse/AN-743

- I've considered enabling the advanced checks similarly how I considered enabling them in Airseeker, but they are a bit restricting, so I've just explicitely disabled them.
- I haven't removed the `tsconfig.build.json` files simply because the current setup works and I do not see the refactor as worth it. 
- I've added a `compile` command which builds all of the projects - This runs TypreScript in all of the source files including tests. It's the most convenient way to check whether there are any TS errors in the project (because `build` only looks into source files without tests).