### PR TITLE
Add axios dependency in Airnode for Processing

### DIFF
--- a/.changeset/popular-kings-protect.md
+++ b/.changeset/popular-kings-protect.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': patch
+---
+
+Fix missing axios dependency in airnode-node package

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -29,6 +29,7 @@
     "@api3/airnode-utilities": "^0.6.0",
     "@api3/airnode-validator": "^0.6.0",
     "aws-sdk": "^2.992.0",
+    "axios": "^0.27.2",
     "dotenv": "^16.0.0",
     "ethers": "^5.4.5",
     "google-auth-library": "^8.0.1",


### PR DESCRIPTION
@Ashar2shahid found a bug in Airnode-node when using it within Airkeeper, relating to axios not being included as a dependency in package.json.