### PR TITLE
Add additional dependabot PR reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     open-pull-requests-limit: 15
     reviewers:
       - andreogle
+      - aquarat
+      - Siegrift


### PR DESCRIPTION
This PR adds @Siegrift and @aquarat as dependabot reviewers.