### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ package.json_
 
 # TypeScript build files
 *.tsbuildinfo
+
+# Other
+.DS_Store


### PR DESCRIPTION
The `.DS_Store` is created when you open a finder in macOS...

I am not adding it to the other ignore files, since it doesn't matter much.
Synchronizing ignore files is tracked in https://api3dao.atlassian.net/browse/AN-565