### PR TITLE
[v0.6] Adjust memory allocation for gateway serverless functions

### DIFF
--- a/.changeset/wise-pots-wait.md
+++ b/.changeset/wise-pots-wait.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': patch
+---
+
+Adjust memory allocation for gateway serverless functions

--- a/packages/airnode-deployer/terraform/airnode/aws/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/aws/main.tf
@@ -44,7 +44,7 @@ module "httpReq" {
   name                           = "${local.name_prefix}-httpReq"
   handler                        = "index.httpReq"
   source_dir                     = var.handler_dir
-  memory_size                    = 256
+  memory_size                    = 128
   timeout                        = 15
   configuration_file             = var.configuration_file
   secrets_file                   = var.secrets_file
@@ -75,7 +75,7 @@ module "httpSignedReq" {
   name                           = "${local.name_prefix}-httpSignedReq"
   handler                        = "index.httpSignedReq"
   source_dir                     = var.handler_dir
-  memory_size                    = 256
+  memory_size                    = 128
   timeout                        = 15
   configuration_file             = var.configuration_file
   secrets_file                   = var.secrets_file

--- a/packages/airnode-deployer/terraform/airnode/gcp/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/main.tf
@@ -103,7 +103,7 @@ module "httpReq" {
   name               = "${local.name_prefix}-httpReq"
   entry_point        = "httpReq"
   source_dir         = var.handler_dir
-  memory_size        = 256
+  memory_size        = 128
   timeout            = 15
   configuration_file = var.configuration_file
   secrets_file       = var.secrets_file
@@ -152,7 +152,7 @@ module "httpSignedReq" {
   name               = "${local.name_prefix}-httpSignedReq"
   entry_point        = "httpSignedReq"
   source_dir         = var.handler_dir
-  memory_size        = 256
+  memory_size        = 128
   timeout            = 15
   configuration_file = var.configuration_file
   secrets_file       = var.secrets_file


### PR DESCRIPTION
Backporting changes from https://github.com/api3dao/airnode/pull/1155 to v0.6