### PR TITLE
Add upper bound to Amount numbers

### DIFF
--- a/.changeset/fast-kangaroos-bake.md
+++ b/.changeset/fast-kangaroos-bake.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-validator': patch
+---
+
+Add upper bound to Amount numbers

--- a/packages/airnode-validator/src/config/config.test.ts
+++ b/packages/airnode-validator/src/config/config.test.ts
@@ -1,7 +1,16 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ZodError } from 'zod';
-import { Config, chainOptionsSchema, configSchema, nodeSettingsSchema, ChainOptions, NodeSettings } from './config';
+import {
+  Config,
+  chainOptionsSchema,
+  configSchema,
+  nodeSettingsSchema,
+  ChainOptions,
+  NodeSettings,
+  amountSchema,
+  Amount,
+} from './config';
 import { version as packageVersion } from '../../package.json';
 
 it('successfully parses config.json', () => {
@@ -77,6 +86,24 @@ describe('chainOptionsSchema', () => {
         },
       ])
     );
+  });
+});
+
+describe('amountSchema', () => {
+  const amount: Amount = {
+    value: 2 ** 52,
+    unit: 'wei',
+  };
+
+  it('does not allow numbers greater than (2**53 - 1) i.e. those accurately represented as integers', () => {
+    expect(() => amountSchema.parse(amount)).not.toThrow();
+
+    // 1 ETH in wei
+    const invalidAmount = { ...amount, value: 1_000_000_000_000_000_000 };
+    expect(() => amountSchema.parse(invalidAmount)).toThrow();
+
+    const otherInvalidAmount = { ...amount, value: 2 ** 53 };
+    expect(() => amountSchema.parse(otherInvalidAmount)).toThrow();
   });
 });
 

--- a/packages/airnode-validator/src/config/config.ts
+++ b/packages/airnode-validator/src/config/config.ts
@@ -52,7 +52,7 @@ export const providerSchema = z
 
 export const amountSchema = z
   .object({
-    value: z.number(),
+    value: z.number().lte(9007199254740991), // 2**53 - 1
     unit: z
       .union([
         z.literal('wei'),


### PR DESCRIPTION
Rationale explained well by the ethers `BigNumber` [documentation](https://docs.ethers.io/v5/api/utils/bignumber/#BigNumber--notes-safenumbers).