### PR TITLE
Reject invalid secrets

### DIFF
--- a/.changeset/odd-poems-shout.md
+++ b/.changeset/odd-poems-shout.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-validator': patch
+---
+
+Add more tests validating secrets naming

--- a/packages/airnode-node/src/cli/validate-config.ts
+++ b/packages/airnode-node/src/cli/validate-config.ts
@@ -1,7 +1,9 @@
 import * as path from 'path';
+import { readFileSync } from 'fs';
 import dotenv from 'dotenv';
 import { loadConfig } from '../config';
 
-dotenv.config({ path: path.resolve(`${__dirname}/../../config/secrets.env`) });
+const rawSecrets = readFileSync(path.resolve(`${__dirname}/../../config/secrets.env`));
+const secrets = dotenv.parse(rawSecrets);
 // We don't care about the config itself, we just need it to be validated when the airnode-client starts
-loadConfig(path.resolve(`${__dirname}/../../config/config.json`), process.env);
+loadConfig(path.resolve(`${__dirname}/../../config/config.json`), secrets);

--- a/packages/airnode-validator/src/api/api.test.ts
+++ b/packages/airnode-validator/src/api/api.test.ts
@@ -39,7 +39,7 @@ describe('parseConfigWithSecrets', () => {
     };
 
     expect(parseConfigWithSecrets(config, secrets)).toEqual({
-      error: new Error('PROVIDER_URL is not defined'),
+      error: new Error('Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'),
       success: false,
     });
   });
@@ -58,6 +58,38 @@ describe('parseConfigWithSecrets', () => {
     interpolatedResult.ois[0].endpoints[0].postProcessingSpecifications[0].value =
       'const someVar = 123; console.log(`${someVar}`);';
     expect(parseConfigWithSecrets(config, secrets)).toEqual({ success: true, data: interpolatedResult });
+  });
+
+  describe('cases when secrets are not valid JS identifiers', () => {
+    it('fails when a secret starts with a number', () => {
+      const config = loadConfigFixture();
+      config.nodeSettings.stage = '${0123STAGE_NAME}';
+      const secrets = {
+        PROVIDER_URL: 'http://127.0.0.1:8545/',
+        AIRNODE_WALLET_MNEMONIC: 'test test test test test test test test test test test junk',
+        ['0123STAGE_NAME']: 'dev',
+      };
+
+      expect(parseConfigWithSecrets(config, secrets)).toEqual({
+        error: new Error('Secrets interpolation failed. Caused by: Invalid or unexpected token'),
+        success: false,
+      });
+    });
+
+    it('fails when a secret contains a "-" character', () => {
+      const config = loadConfigFixture();
+      config.nodeSettings.stage = '${STAGE-NAME}';
+      const secrets = {
+        PROVIDER_URL: 'http://127.0.0.1:8545/',
+        AIRNODE_WALLET_MNEMONIC: 'test test test test test test test test test test test junk',
+        ['STAGE-NAME']: 'dev',
+      };
+
+      expect(parseConfigWithSecrets(config, secrets)).toEqual({
+        error: new Error('Secrets interpolation failed. Caused by: STAGE is not defined'),
+        success: false,
+      });
+    });
   });
 });
 

--- a/packages/airnode-validator/src/api/api.test.ts
+++ b/packages/airnode-validator/src/api/api.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
 import forEach from 'lodash/forEach';
+import { ZodError } from 'zod';
 import { parseConfigWithSecrets, unsafeParseConfigWithSecrets } from './api';
 import { Config } from '../config';
 
@@ -71,7 +72,14 @@ describe('parseConfigWithSecrets', () => {
       };
 
       expect(parseConfigWithSecrets(config, secrets)).toEqual({
-        error: new Error('Secrets interpolation failed. Caused by: Invalid or unexpected token'),
+        error: new ZodError([
+          {
+            validation: 'regex',
+            code: 'invalid_string',
+            message: 'Secret name is not a valid. Secret name must match /^[A-Z][A-Z0-9_]*$/',
+            path: ['0123STAGE_NAME'],
+          },
+        ]),
         success: false,
       });
     });
@@ -86,7 +94,14 @@ describe('parseConfigWithSecrets', () => {
       };
 
       expect(parseConfigWithSecrets(config, secrets)).toEqual({
-        error: new Error('Secrets interpolation failed. Caused by: STAGE is not defined'),
+        error: new ZodError([
+          {
+            validation: 'regex',
+            code: 'invalid_string',
+            message: 'Secret name is not a valid. Secret name must match /^[A-Z][A-Z0-9_]*$/',
+            path: ['STAGE-NAME'],
+          },
+        ]),
         success: false,
       });
     });

--- a/packages/airnode-validator/src/api/api.ts
+++ b/packages/airnode-validator/src/api/api.ts
@@ -36,12 +36,17 @@ export function parseConfig(config: unknown): ValidationResult<Config> {
   return configSchema.safeParse(config);
 }
 
+const secretNamePattern = /^[A-Z][A-Z0-9_]*$/;
+export const secretNameSchema = z
+  .string()
+  .regex(secretNamePattern, `Secret name is not a valid. Secret name must match ${secretNamePattern.toString()}`);
+export const secretsSchema = z.record(secretNameSchema, z.string());
+
 /**
  * @param secrets a key value object with the secrets
  * @returns `{success: true, data: <secrets>}` if successful, `{success: false, error: <error>}` otherwise
  */
 export function parseSecrets(secrets: unknown): ValidationResult<Secrets> {
-  const secretsSchema = z.record(z.string(), z.string());
   return secretsSchema.safeParse(secrets);
 }
 

--- a/packages/airnode-validator/src/api/api.ts
+++ b/packages/airnode-validator/src/api/api.ts
@@ -14,11 +14,16 @@ import { ValidationResult } from '../validation-result';
  * @returns `{success: true, data: <interpolated config>}` if successful, `{success: false, error: <error>}` otherwise
  */
 export function parseConfigWithSecrets(config: unknown, secrets: unknown): ValidationResult<Config> {
-  const parseSecretsRes = parseSecrets(secrets);
-  if (!parseSecretsRes.success) return parseSecretsRes;
+  const parsedSecrets = parseSecrets(secrets);
+  if (!parsedSecrets.success) return parsedSecrets;
 
-  const interpolateConfigRes = interpolateSecrets(config, parseSecretsRes.data);
-  if (!interpolateConfigRes.success) return interpolateConfigRes;
+  const interpolateConfigRes = interpolateSecrets(config, parsedSecrets.data);
+  if (!interpolateConfigRes.success) {
+    return {
+      success: false,
+      error: new Error('Secrets interpolation failed. Caused by: ' + interpolateConfigRes.error.message),
+    };
+  }
 
   return parseConfig(interpolateConfigRes.data);
 }

--- a/packages/airnode-validator/src/cli/cli.test.ts
+++ b/packages/airnode-validator/src/cli/cli.test.ts
@@ -20,7 +20,7 @@ describe('validateConfiguration', () => {
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          'Unable to read config file at "non-existent-config.json". Reason: Error: Error: ENOENT: no such file or directory'
+          'Unable to read config file at "non-existent-config.json". Reason: Error: ENOENT: no such file or directory'
         )
       );
     });
@@ -31,7 +31,7 @@ describe('validateConfiguration', () => {
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          'Unable to read secrets file at "non-existent-secrets.env". Reason: Error: Error: ENOENT: no such file or directory'
+          'Unable to read secrets file at "non-existent-secrets.env". Reason: Error: ENOENT: no such file or directory'
         )
       );
     });
@@ -41,7 +41,7 @@ describe('validateConfiguration', () => {
 
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
-        'The configuration is not valid. Reason: Error: Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'
+        'The configuration is not valid. Reason: Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'
       );
     });
 
@@ -50,7 +50,7 @@ describe('validateConfiguration', () => {
 
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
-        'The configuration is not valid. Reason: Error: Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'
+        'The configuration is not valid. Reason: Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'
       );
     });
 
@@ -62,7 +62,7 @@ describe('validateConfiguration', () => {
 
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
-        'The configuration is not valid. Reason: Error: Secrets interpolation failed. Caused by: Invalid or unexpected token'
+        'The configuration is not valid. Reason: Secrets interpolation failed. Caused by: Invalid or unexpected token'
       );
     });
   });

--- a/packages/airnode-validator/src/cli/cli.test.ts
+++ b/packages/airnode-validator/src/cli/cli.test.ts
@@ -62,7 +62,18 @@ describe('validateConfiguration', () => {
 
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
-        'The configuration is not valid. Reason: Secrets interpolation failed. Caused by: Invalid or unexpected token'
+        `
+The configuration is not valid. Reason: [
+  {
+    "validation": "regex",
+    "code": "invalid_string",
+    "message": "Secret name is not a valid. Secret name must match /^[A-Z][A-Z0-9_]*$/",
+    "path": [
+      "0123STAGE_NAME"
+    ]
+  }
+]
+`.trim()
       );
     });
   });

--- a/packages/airnode-validator/src/cli/cli.test.ts
+++ b/packages/airnode-validator/src/cli/cli.test.ts
@@ -41,16 +41,28 @@ describe('validateConfiguration', () => {
 
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
-        'The configuration is not valid. Reason: ReferenceError: PROVIDER_URL is not defined'
+        'The configuration is not valid. Reason: Error: Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'
       );
     });
 
-    it('when configuration is invalid', () => {
+    it('when secret is missing', () => {
       cli.validateConfiguration(configPath, join(__dirname, '../../test/fixtures/missing-secrets.env'));
 
       expect(failSpy).toHaveBeenCalledTimes(1);
       expect(failSpy).toHaveBeenCalledWith(
-        'The configuration is not valid. Reason: ReferenceError: PROVIDER_URL is not defined'
+        'The configuration is not valid. Reason: Error: Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'
+      );
+    });
+
+    it('when secret is not a valid JS identifier', () => {
+      cli.validateConfiguration(
+        join(__dirname, '../../test/fixtures/invalid-secret-name/config.json'),
+        join(__dirname, '../../test/fixtures/invalid-secret-name/secrets.env')
+      );
+
+      expect(failSpy).toHaveBeenCalledTimes(1);
+      expect(failSpy).toHaveBeenCalledWith(
+        'The configuration is not valid. Reason: Error: Secrets interpolation failed. Caused by: Invalid or unexpected token'
       );
     });
   });

--- a/packages/airnode-validator/src/cli/cli.ts
+++ b/packages/airnode-validator/src/cli/cli.ts
@@ -20,21 +20,22 @@ const examples = [
 
 export const validateConfiguration = (configPath: string, secretsPath: string) => {
   const goRawConfig = goSync(() => readFileSync(path.resolve(configPath), 'utf-8'));
-  if (!goRawConfig.success) return fail(`Unable to read config file at "${configPath}". Reason: ${goRawConfig.error}`);
+  if (!goRawConfig.success)
+    return fail(`Unable to read config file at "${configPath}". Reason: ${goRawConfig.error.message}`);
 
   const goConfig = goSync(() => JSON.parse(goRawConfig.data));
   if (!goConfig.success) return fail(`The configuration is not a valid JSON.`);
 
   const goRawSecrets = goSync(() => readFileSync(path.resolve(secretsPath), 'utf-8'));
   if (!goRawSecrets.success) {
-    return fail(`Unable to read secrets file at "${secretsPath}". Reason: ${goRawSecrets.error}`);
+    return fail(`Unable to read secrets file at "${secretsPath}". Reason: ${goRawSecrets.error.message}`);
   }
 
   const goSecrets = goSync(() => dotenv.parse(goRawSecrets.data));
   if (!goSecrets.success) return fail(`The secrets have incorrect format.`);
 
   const parseResult = parseConfigWithSecrets(goConfig.data, goSecrets.data);
-  if (!parseResult.success) return fail(`The configuration is not valid. Reason: ${parseResult.error}`);
+  if (!parseResult.success) return fail(`The configuration is not valid. Reason: ${parseResult.error.message}`);
 
   return succeed('The configuration is valid');
 };

--- a/packages/airnode-validator/test/cli.feature.ts
+++ b/packages/airnode-validator/test/cli.feature.ts
@@ -38,7 +38,9 @@ describe('validator CLI', () => {
     expect(output.status).toBe(1);
     expect(output.stderr.toString()).toEqual(
       // We use "expect.stringContaining" because the output begins with "✖"
-      expect.stringContaining('The configuration is not valid. Reason: ReferenceError: PROVIDER_URL is not defined')
+      expect.stringContaining(
+        'The configuration is not valid. Reason: Secrets interpolation failed. Caused by: PROVIDER_URL is not defined'
+      )
     );
   });
 });

--- a/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
+++ b/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
@@ -1,0 +1,190 @@
+
+{
+  "chains": [
+    {
+      "maxConcurrency": 100,
+      "authorizers": [],
+      "contracts": {
+        "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+      },
+      "id": "31337",
+      "providers": {
+        "exampleProvider": {
+          "url": "${PROVIDER_URL}"
+        }
+      },
+      "type": "evm",
+      "options": {
+        "txType": "eip1559",
+        "baseFeeMultiplier": 2,
+        "priorityFee": {
+          "value": 3.12,
+          "unit": "gwei"
+        },
+        "fulfillmentGasLimit": 500000
+      }
+    }
+  ],
+  "nodeSettings": {
+    "cloudProvider": {
+      "type": "local"
+    },
+    "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
+    "heartbeat": {
+      "enabled": false
+    },
+    "httpGateway": {
+      "enabled": false
+    },
+    "httpSignedDataGateway": {
+      "enabled": false
+    },
+    "logFormat": "plain",
+    "logLevel": "INFO",
+    "nodeVersion": "0.6.0",
+    "stage": "${0123STAGE_NAME}"
+  },
+  "triggers": {
+    "rrp": [
+      {
+        "endpointId": "0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153",
+        "oisTitle": "CoinGecko basic request",
+        "endpointName": "coinMarketData"
+      }
+    ],
+    "http": [],
+    "httpSignedData": []
+  },
+  "templates": [],
+  "ois": [
+    {
+      "oisFormat": "1.0.0",
+      "title": "CoinGecko basic request",
+      "version": "1.0.0",
+      "apiSpecifications": {
+        "servers": [
+          {
+            "url": "https://api.coingecko.com/api/v3"
+          }
+        ],
+        "paths": {
+          "/coins/{id}": {
+            "get": {
+              "parameters": [
+                {
+                  "in": "path",
+                  "name": "id"
+                },
+                {
+                  "in": "query",
+                  "name": "localization"
+                },
+                {
+                  "in": "query",
+                  "name": "tickers"
+                },
+                {
+                  "in": "query",
+                  "name": "market_data"
+                },
+                {
+                  "in": "query",
+                  "name": "community_data"
+                },
+                {
+                  "in": "query",
+                  "name": "developer_data"
+                },
+                {
+                  "in": "query",
+                  "name": "sparkline"
+                }
+              ]
+            }
+          }
+        },
+        "components": {
+          "securitySchemes": {}
+        },
+        "security": {}
+      },
+      "endpoints": [
+        {
+          "name": "coinMarketData",
+          "operation": {
+            "method": "get",
+            "path": "/coins/{id}"
+          },
+          "fixedOperationParameters": [
+            {
+              "operationParameter": {
+                "in": "query",
+                "name": "localization"
+              },
+              "value": "false"
+            },
+            {
+              "operationParameter": {
+                "in": "query",
+                "name": "tickers"
+              },
+              "value": "false"
+            },
+            {
+              "operationParameter": {
+                "in": "query",
+                "name": "market_data"
+              },
+              "value": "true"
+            },
+            {
+              "operationParameter": {
+                "in": "query",
+                "name": "community_data"
+              },
+              "value": "false"
+            },
+            {
+              "operationParameter": {
+                "in": "query",
+                "name": "developer_data"
+              },
+              "value": "false"
+            },
+            {
+              "operationParameter": {
+                "in": "query",
+                "name": "sparkline"
+              },
+              "value": "false"
+            }
+          ],
+          "reservedParameters": [
+            {
+              "name": "_type",
+              "fixed": "int256"
+            },
+            {
+              "name": "_path",
+              "fixed": "market_data.current_price.usd"
+            },
+            {
+              "name": "_times",
+              "fixed": "1000000"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "coinId",
+              "operationParameter": {
+                "in": "path",
+                "name": "id"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "apiCredentials": []
+}

--- a/packages/airnode-validator/test/fixtures/invalid-secret-name/secrets.env
+++ b/packages/airnode-validator/test/fixtures/invalid-secret-name/secrets.env
@@ -1,0 +1,3 @@
+AIRNODE_WALLET_MNEMONIC=tube spin artefact salad slab lumber foot bitter wash reward vote cook
+PROVIDER_URL=http://127.0.0.1:8545/
+0123STAGE_NAME=dev


### PR DESCRIPTION
https://api3dao.atlassian.net/browse/AN-471

Turns out we already handle this. At first, I thought I will add a more descriptive error message (saying make sure the secret is a valid identifier), but this makes the error message inaccurate when there is a missing secret which will be the most common error. I've simplified the CLI error message a bit though.