### PR TITLE
Fail validation with empty secret value

### DIFF
--- a/.changeset/breezy-bees-tickle.md
+++ b/.changeset/breezy-bees-tickle.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-validator': minor
+---
+
+Fail validation with empty secret value

--- a/packages/airnode-validator/src/api/api.test.ts
+++ b/packages/airnode-validator/src/api/api.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { readFileSync } from 'fs';
 import forEach from 'lodash/forEach';
 import { ZodError } from 'zod';
-import { parseConfigWithSecrets, unsafeParseConfigWithSecrets } from './api';
+import { parseConfigWithSecrets, unsafeParseConfigWithSecrets, parseSecrets } from './api';
 import { Config } from '../config';
 
 const loadConfigFixture = (): Config =>
@@ -68,8 +68,24 @@ describe('parseConfigWithSecrets', () => {
       AIRNODE_WALLET_MNEMONIC: '',
     };
 
+    const emptyError = new ZodError([
+      {
+        code: 'too_small',
+        minimum: 1,
+        type: 'string',
+        inclusive: true,
+        message: 'Secret cannot be empty',
+        path: ['AIRNODE_WALLET_MNEMONIC'],
+      },
+    ]);
+
+    expect(parseSecrets(secrets)).toEqual({
+      error: emptyError,
+      success: false,
+    });
+
     expect(parseConfigWithSecrets(config, secrets)).toEqual({
-      error: new Error('Secrets interpolation failed. Caused by: Secret "AIRNODE_WALLET_MNEMONIC" has an empty value'),
+      error: emptyError,
       success: false,
     });
   });


### PR DESCRIPTION
[AN-776](https://api3dao.atlassian.net/browse/AN-776)

Note `emptySecret` has been removed from `interpolateSecrets` as the secrets are parsed first within `parseConfigWithSecrets` then interpolated so the `.min(1)` catches empty secrets.