### PR TITLE
Add authorizer type to config.json

### DIFF
--- a/.changeset/plenty-pants-matter.md
+++ b/.changeset/plenty-pants-matter.md
@@ -1,0 +1,13 @@
+---
+'@api3/airnode-adapter': minor
+'@api3/airnode-admin': minor
+'@api3/airnode-deployer': minor
+'@api3/airnode-examples': minor
+'@api3/airnode-node': minor
+'@api3/airnode-operation': minor
+'@api3/airnode-protocol': minor
+'@api3/airnode-utilities': minor
+'@api3/airnode-validator': minor
+---
+
+Add authorizer type to config.json

--- a/packages/airnode-deployer/config/config.example.json
+++ b/packages/airnode-deployer/config/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/coingecko-template/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-template/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/coingecko-template/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-template/create-config.ts
@@ -12,7 +12,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/coingecko-testable/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-testable/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/coingecko/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/coingecko/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/failing-example/config.example.json
+++ b/packages/airnode-examples/integrations/failing-example/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/failing-example/create-config.ts
+++ b/packages/airnode-examples/integrations/failing-example/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-examples/integrations/weather-multi-value/config.example.json
+++ b/packages/airnode-examples/integrations/weather-multi-value/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
+++ b/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
@@ -11,7 +11,9 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   chains: [
     {
       maxConcurrency: 100,
-      authorizers: [],
+      authorizers: {
+        requesterEndpointAuthorizers: [],
+      },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },

--- a/packages/airnode-node/config/config.example.json
+++ b/packages/airnode-node/config/config.example.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-node/src/coordinator/calls/chain-limits.test.ts
+++ b/packages/airnode-node/src/coordinator/calls/chain-limits.test.ts
@@ -7,7 +7,9 @@ import { ChainConfig } from '../../config';
 const createChainConfig = (overrides: Partial<ChainConfig>): ChainConfig => {
   return {
     maxConcurrency: 100,
-    authorizers: [],
+    authorizers: {
+      requesterEndpointAuthorizers: [],
+    },
     authorizations: {
       requesterEndpointAuthorizations: {},
     },

--- a/packages/airnode-node/src/evm/authorization/authorization-fetching.test.ts
+++ b/packages/airnode-node/src/evm/authorization/authorization-fetching.test.ts
@@ -19,7 +19,12 @@ describe('fetch (authorizations)', () => {
 
   beforeEach(() => {
     mutableFetchOptions = {
-      authorizers: ['0x711c93B32c0D28a5d18feD87434cce11C3e5699B', '0x9E0e23766b0ed0C492804872c5164E9187fB56f5'],
+      authorizers: {
+        requesterEndpointAuthorizers: [
+          '0x711c93B32c0D28a5d18feD87434cce11C3e5699B',
+          '0x9E0e23766b0ed0C492804872c5164E9187fB56f5',
+        ],
+      },
       airnodeAddress: '0xf5ad700af68118777f79fd1d1c8568f7377d4ae9e9ccce5970fe63bc7a1c1d6d',
       airnodeRrpAddress: '0xD5659F26A72A8D718d1955C42B3AE418edB001e0',
       provider: new ethers.providers.JsonRpcProvider(),
@@ -42,7 +47,11 @@ describe('fetch (authorizations)', () => {
         sponsorAddress: 'sponsorAddress',
       });
     });
-    const [logs, res] = await authorization.fetch(apiCalls, { ...mutableFetchOptions, authorizers: [] });
+    const [logs, res] = await authorization.fetch(apiCalls, {
+      ...mutableFetchOptions,
+      authorizers: { requesterEndpointAuthorizers: [] },
+    });
+
     expect(logs).toEqual([]);
     expect(Object.keys(res).length).toEqual(19);
     expect(res['0']).toEqual(true);
@@ -169,7 +178,7 @@ describe('fetch (authorizations)', () => {
 });
 
 describe('fetchAuthorizationStatus', () => {
-  const authorizers = ['0x0000000000000000000000000000000000000000'];
+  const authorizers = { requesterEndpointAuthorizers: ['0x0000000000000000000000000000000000000000'] };
   const airnodeAddress = '0xairnodeAddress';
   let mutableAirnodeRrp: AirnodeRrpV0;
 

--- a/packages/airnode-node/src/evm/authorization/authorization-fetching.ts
+++ b/packages/airnode-node/src/evm/authorization/authorization-fetching.ts
@@ -115,7 +115,7 @@ export async function fetch(
   }
 
   // If there are no authorizer contracts then endpoint is public
-  if (isEmpty(Object.values(fetchOptions.authorizers).flatMap((authorizer) => authorizer))) {
+  if (isEmpty(fetchOptions.authorizers.requesterEndpointAuthorizers)) {
     const authorizationByRequestIds = apiCalls.map((pendingApiCall) => ({
       [pendingApiCall.id]: true,
     }));

--- a/packages/airnode-node/src/evm/authorization/authorization-fetching.ts
+++ b/packages/airnode-node/src/evm/authorization/authorization-fetching.ts
@@ -8,9 +8,10 @@ import { go } from '@api3/promise-utils';
 import { ApiCall, AuthorizationByRequestId, Request, LogsData } from '../../types';
 import { CONVENIENCE_BATCH_SIZE, DEFAULT_RETRY_TIMEOUT_MS } from '../../constants';
 import { AirnodeRrpV0, AirnodeRrpV0Factory } from '../contracts';
+import { ChainAuthorizers } from '../../config';
 
 export interface FetchOptions {
-  readonly authorizers: string[];
+  readonly authorizers: ChainAuthorizers;
   readonly airnodeAddress: string;
   readonly airnodeRrpAddress: string;
   readonly provider: ethers.providers.JsonRpcProvider;
@@ -18,13 +19,13 @@ export interface FetchOptions {
 
 export async function fetchAuthorizationStatus(
   airnodeRrp: AirnodeRrpV0,
-  authorizers: string[],
+  authorizers: ChainAuthorizers,
   airnodeAddress: string,
   apiCall: Request<ApiCall>
 ): Promise<LogsData<boolean | null>> {
   const contractCall = (): Promise<boolean> =>
     airnodeRrp.checkAuthorizationStatus(
-      authorizers,
+      authorizers.requesterEndpointAuthorizers,
       airnodeAddress,
       apiCall.id,
       // TODO: make sure endpointId is not null
@@ -52,7 +53,7 @@ export async function fetchAuthorizationStatus(
 
 async function fetchAuthorizationStatuses(
   airnodeRrp: AirnodeRrpV0,
-  authorizers: string[],
+  authorizers: ChainAuthorizers,
   airnodeAddress: string,
   apiCalls: Request<ApiCall>[]
 ): Promise<LogsData<AuthorizationByRequestId | null>> {
@@ -64,7 +65,7 @@ async function fetchAuthorizationStatuses(
 
   const contractCall = (): Promise<boolean[]> =>
     airnodeRrp.checkAuthorizationStatuses(
-      authorizers,
+      authorizers.requesterEndpointAuthorizers,
       airnodeAddress,
       requestIds,
       // TODO: make sure all endpointIds are non null
@@ -114,7 +115,7 @@ export async function fetch(
   }
 
   // If there are no authorizer contracts then endpoint is public
-  if (isEmpty(fetchOptions.authorizers)) {
+  if (isEmpty(Object.values(fetchOptions.authorizers).flatMap((authorizer) => authorizer))) {
     const authorizationByRequestIds = apiCalls.map((pendingApiCall) => ({
       [pendingApiCall.id]: true,
     }));

--- a/packages/airnode-node/src/providers/actions.test.ts
+++ b/packages/airnode-node/src/providers/actions.test.ts
@@ -36,7 +36,7 @@ const chainProviderName1 = 'Pocket Ethereum Mainnet';
 const chainProviderName3 = 'Infura Ropsten';
 const chains: ChainConfig[] = [
   {
-    authorizers: [ethers.constants.AddressZero],
+    authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
     authorizations: {
       requesterEndpointAuthorizations: {},
     },
@@ -62,7 +62,7 @@ const chains: ChainConfig[] = [
     },
   },
   {
-    authorizers: [ethers.constants.AddressZero],
+    authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
     authorizations: {
       requesterEndpointAuthorizations: {},
     },
@@ -113,7 +113,7 @@ describe('initialize', () => {
           settings: {
             airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
             airnodeAddressShort: 'a30ca71',
-            authorizers: [ethers.constants.AddressZero],
+            authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
             authorizations: {
               requesterEndpointAuthorizations: {},
             },
@@ -160,7 +160,7 @@ describe('initialize', () => {
           settings: {
             airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
             airnodeAddressShort: 'a30ca71',
-            authorizers: [ethers.constants.AddressZero],
+            authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
             authorizations: {
               requesterEndpointAuthorizations: {},
             },

--- a/packages/airnode-node/src/providers/state.test.ts
+++ b/packages/airnode-node/src/providers/state.test.ts
@@ -12,7 +12,7 @@ describe('create', () => {
     const chainProviderName = 'Ganache test';
     const chainConfig: ChainConfig = {
       maxConcurrency: 100,
-      authorizers: [ethers.constants.AddressZero],
+      authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },
@@ -45,7 +45,7 @@ describe('create', () => {
       settings: {
         airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
         airnodeAddressShort: 'a30ca71',
-        authorizers: [ethers.constants.AddressZero],
+        authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
         authorizations: {
           requesterEndpointAuthorizations: {},
         },
@@ -94,7 +94,7 @@ describe('create', () => {
     const chainProviderName = 'Ganache test';
     const chainConfig: ChainConfig = {
       maxConcurrency: 100,
-      authorizers: [ethers.constants.AddressZero],
+      authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
       authorizations: {
         requesterEndpointAuthorizations: {},
       },
@@ -129,7 +129,7 @@ describe('create', () => {
       settings: {
         airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
         airnodeAddressShort: 'a30ca71',
-        authorizers: [ethers.constants.AddressZero],
+        authorizers: { requesterEndpointAuthorizers: [ethers.constants.AddressZero] },
         authorizations: {
           requesterEndpointAuthorizations: {},
         },

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -9,7 +9,15 @@ import {
 } from '@api3/airnode-protocol';
 import { PendingLog, LogFormat, LogLevel, LogOptions, GasTarget } from '@api3/airnode-utilities';
 import { z } from 'zod';
-import { Config, ChainOptions, ChainType, LocalOrCloudProvider, Amount, ChainAuthorizations } from './config';
+import {
+  Config,
+  ChainOptions,
+  ChainType,
+  LocalOrCloudProvider,
+  Amount,
+  ChainAuthorizers,
+  ChainAuthorizations,
+} from './config';
 import { apiCallParametersSchema } from './validation';
 import { AirnodeRrpV0 } from './evm/contracts';
 
@@ -125,7 +133,7 @@ export interface SubmitRequest<T> {
 }
 
 export interface ProviderSettings extends CoordinatorSettings {
-  readonly authorizers: string[];
+  readonly authorizers: ChainAuthorizers;
   readonly authorizations: ChainAuthorizations;
   readonly blockHistoryLimit: number;
   readonly chainId: string;

--- a/packages/airnode-node/test/fixtures/config/config.ts
+++ b/packages/airnode-node/test/fixtures/config/config.ts
@@ -26,7 +26,9 @@ export function buildConfig(overrides?: Partial<Config>): Config {
     chains: [
       {
         maxConcurrency: 100,
-        authorizers: [],
+        authorizers: {
+          requesterEndpointAuthorizers: [],
+        },
         authorizations: {
           requesterEndpointAuthorizations: {},
         },

--- a/packages/airnode-node/test/fixtures/operation/deploy-config.ts
+++ b/packages/airnode-node/test/fixtures/operation/deploy-config.ts
@@ -9,7 +9,9 @@ export function buildDeployConfig(config?: Partial<Config>): Config {
         // We need to create a new mnemonic each time otherwise E2E tests
         // will share the same Airnode wallet
         mnemonic: ethers.Wallet.createRandom().mnemonic.phrase,
-        authorizers: [],
+        authorizers: {
+          requesterEndpointAuthorizers: [],
+        },
         authorizations: {
           requesterEndpointAuthorizations: {},
         },

--- a/packages/airnode-node/test/fixtures/provider-states/evm.ts
+++ b/packages/airnode-node/test/fixtures/provider-states/evm.ts
@@ -12,7 +12,9 @@ export function buildEVMProviderState(
   const chainProviderName = 'Ganache test';
   const chainConfig: ChainConfig = {
     maxConcurrency: 100,
-    authorizers: [],
+    authorizers: {
+      requesterEndpointAuthorizers: [],
+    },
     authorizations: {
       requesterEndpointAuthorizations: {},
     },

--- a/packages/airnode-node/test/setup/e2e/utils.ts
+++ b/packages/airnode-node/test/setup/e2e/utils.ts
@@ -15,7 +15,9 @@ export function buildChainConfig(contracts: Contracts): ChainConfig {
     contracts: {
       AirnodeRrp: contracts.AirnodeRrp,
     },
-    authorizers: [],
+    authorizers: {
+      requesterEndpointAuthorizers: [],
+    },
     authorizations: {
       requesterEndpointAuthorizations: {},
     },

--- a/packages/airnode-operation/README.md
+++ b/packages/airnode-operation/README.md
@@ -136,15 +136,15 @@ WALLET LINKED TO A TEST MNEMONIC**
 
 **Authorizers**
 
-`authorizers` - a list of `authorizer` contracts. The values must correspond to a value defined in the `authorizers`
-top-level field.
+`authorizers` - a key/value object where the key is the type of `authorizer` and the value is a list of `authorizer`
+contracts. The values must correspond to a value defined in the `authorizers` top-level field.
 
 **Authorizations**
 
-`authorizations` - a key/value object where the key is the type of authorization and the value is an object containing a
-list of the authorized addresses for an endpoint id.
+`authorizations` - a key/value object where the key is the type of `authorization` and the value is an object containing
+a list of the authorized addresses for an endpoint id.
 
-`authorizations.requesterEndpointAuthorizations.[endpointId]` - a key-value object where the key is the endpoint id and
+`authorizations.requesterEndpointAuthorizations.[endpointId]` - a key-value object where the key is the `endpointId` and
 the value is a list of the authorized addresses.
 
 **Endpoints**
@@ -246,7 +246,9 @@ The withdrawn funds should be sent back to the address of the sponsor.
   "airnodes": {
     "CurrencyConverterAirnode": {
       "mnemonic": "achieve climb couple wait accident symbol spy blouse reduce foil echo label",
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-operation/src/config/evm-dev-config.json
+++ b/packages/airnode-operation/src/config/evm-dev-config.json
@@ -3,7 +3,9 @@
   "airnodes": {
     "CurrencyConverterAirnode": {
       "mnemonic": "achieve climb couple wait accident symbol spy blouse reduce foil echo label",
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-operation/src/types.ts
+++ b/packages/airnode-operation/src/types.ts
@@ -111,7 +111,7 @@ export interface ConfigTemplate {
 }
 
 export interface ConfigAirnode {
-  readonly authorizers: string[];
+  readonly authorizers: { requesterEndpointAuthorizers: string[] };
   readonly authorizations: {
     requesterEndpointAuthorizations: { [endpointId: string]: string[] };
   };

--- a/packages/airnode-validator/src/config/config.ts
+++ b/packages/airnode-validator/src/config/config.ts
@@ -113,9 +113,13 @@ export const chainAuthorizationsSchema = z.object({
   requesterEndpointAuthorizations: z.record(endpointIdSchema, z.array(evmAddressSchema)),
 });
 
+export const chainAuthorizersSchema = z.object({
+  requesterEndpointAuthorizers: z.array(evmAddressSchema),
+});
+
 export const chainConfigSchema = z
   .object({
-    authorizers: z.array(evmAddressSchema),
+    authorizers: chainAuthorizersSchema,
     authorizations: chainAuthorizationsSchema,
     blockHistoryLimit: z.number().int().optional(), // Defaults to BLOCK_COUNT_HISTORY_LIMIT defined in airnode-node
     contracts: chainContractsSchema,
@@ -379,6 +383,7 @@ export type AwsCloudProvider = SchemaType<typeof awsCloudProviderSchema>;
 export type GcpCloudProvider = SchemaType<typeof gcpCloudProviderSchema>;
 export type LocalOrCloudProvider = SchemaType<typeof localOrCloudProviderSchema>;
 export type Gateway = SchemaType<typeof gatewaySchema>;
+export type ChainAuthorizers = SchemaType<typeof chainAuthorizersSchema>;
 export type ChainAuthorizations = SchemaType<typeof chainAuthorizationsSchema>;
 export type ChainOptions = SchemaType<typeof chainOptionsSchema>;
 export type ChainType = SchemaType<typeof chainTypeSchema>;

--- a/packages/airnode-validator/test/fixtures/config.valid.json
+++ b/packages/airnode-validator/test/fixtures/config.valid.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
+++ b/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
@@ -2,7 +2,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },

--- a/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
+++ b/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
@@ -3,7 +3,9 @@
   "chains": [
     {
       "maxConcurrency": 100,
-      "authorizers": [],
+      "authorizers": {
+        "requesterEndpointAuthorizers": []
+      },
       "authorizations": { 
         "requesterEndpointAuthorizations": {} 
       },


### PR DESCRIPTION
This updates the `authorizer` field in `config.json` to be an object specifying the type of `authorizer` as the key and a list of `authorizer contracts` as the value.

