### PR TITLE
Set TS config "target" to es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "downlevelIteration": true,
-    "target": "es5",
+    "target": "es6",
 
     "strict": true,
     // This check doesn't work well in monorepos: https://github.com/microsoft/TypeScript/issues/38538


### PR DESCRIPTION
See: https://api3workspace.slack.com/archives/C02AYRX8D89/p1656603015667139

The ES5 was not supported by IE which is dead now. The current problem
with es5 are custom exceptions which do not work properly when targeting
es5. THe best solution is to set the target to es6.

See details in:
https://www.dannyguo.com/blog/how-to-fix-instanceof-not-working-for-custom-errors-in-typescript/