### PR TITLE
Update renovate group names

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,13 +9,13 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 2am on monday"],
-      "groupName": "Update devDependencies (non-major)"
+      "groupName": "devDependencies (non-major)"
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 2am on monday"],
-      "groupName": "Update dependencies (non-major)"
+      "groupName": "dependencies (non-major)"
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
The generated PR title of renovate PRs is pre-pends "Update ..." automatically so currently we have "Update Update ...". See https://github.com/api3dao/airnode/pull/1289

This fixes that.