### PR TITLE
AN-754: callApi handler argument refactor

### DIFF
--- a/.changeset/mean-taxis-sing.md
+++ b/.changeset/mean-taxis-sing.md
@@ -1,0 +1,7 @@
+---
+'@api3/airnode-adapter': patch
+'@api3/airnode-deployer': patch
+'@api3/airnode-node': patch
+---
+
+callApi handler argument refactor

--- a/packages/airnode-adapter/src/types.ts
+++ b/packages/airnode-adapter/src/types.ts
@@ -3,15 +3,12 @@ import { BigNumber } from 'bignumber.js';
 import { baseResponseTypes, MULTIPLE_PARAMETERS_DELIMETER, PATH_DELIMETER } from './constants';
 
 export interface RequestMetadata {
-  airnodeAddress: string;
   requesterAddress: string;
   sponsorWalletAddress: string;
-  endpointId: string;
   sponsorAddress: string;
   requestId: string;
   chainId: string;
   chainType: string;
-  airnodeRrpAddress: string;
 }
 
 export interface BaseApiCredentials {

--- a/packages/airnode-adapter/test/fixtures/options.ts
+++ b/packages/airnode-adapter/test/fixtures/options.ts
@@ -11,15 +11,12 @@ export function buildRequestOptions(overrides?: Partial<BuildRequestOptions>): B
     parameters: { f: 'ETH', amount: '1' },
     apiCredentials: buildCredentials(),
     metadata: {
-      airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
       requesterAddress: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
       sponsorWalletAddress: '0xB604c9f7de852F26DB90C04000820850112905b4',
-      endpointId: '0xeddc421714e1b46ef350e8ecf380bd0b38a40ce1a534e7ecdf4db7dbc9319353',
       sponsorAddress: '0x7a9a6F6B21AEE3b905AEeC757bbBcA39747Ca4Fa',
       requestId: '0xcf2816af81f9cc7c9879dc84ce29c00fe1e290bcb8d2e4b204be1eeb120811bf',
       chainId: '31337',
       chainType: 'evm',
-      airnodeRrpAddress: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
     },
     ...overrides,
   };

--- a/packages/airnode-deployer/src/handlers/aws/index.ts
+++ b/packages/airnode-deployer/src/handlers/aws/index.ts
@@ -9,7 +9,6 @@ import {
   ProcessTransactionsPayload,
   CallApiPayload,
   loadTrustedConfig,
-  ApiCallPayload,
 } from '@api3/airnode-node';
 import { verifyHttpSignedDataRequest, verifyHttpRequest } from '../common';
 
@@ -62,11 +61,7 @@ async function initializeProvider(payload: InitializeProviderPayload) {
 
 async function callApi(payload: CallApiPayload) {
   const { aggregatedApiCall, logOptions } = payload;
-  const [logs, apiCallResponse] = await handlers.callApi({
-    type: 'regular',
-    config: parsedConfig,
-    aggregatedApiCall,
-  } as ApiCallPayload);
+  const [logs, apiCallResponse] = await handlers.callApi(parsedConfig, aggregatedApiCall);
   logger.logPending(logs, logOptions);
   const response = JSON.stringify({ ok: true, data: apiCallResponse });
   return { statusCode: 200, body: response };

--- a/packages/airnode-deployer/src/handlers/aws/index.ts
+++ b/packages/airnode-deployer/src/handlers/aws/index.ts
@@ -62,7 +62,11 @@ async function initializeProvider(payload: InitializeProviderPayload) {
 
 async function callApi(payload: CallApiPayload) {
   const { aggregatedApiCall, logOptions } = payload;
-  const [logs, apiCallResponse] = await handlers.callApi({ config: parsedConfig, aggregatedApiCall } as ApiCallPayload);
+  const [logs, apiCallResponse] = await handlers.callApi({
+    type: 'regular',
+    config: parsedConfig,
+    aggregatedApiCall,
+  } as ApiCallPayload);
   logger.logPending(logs, logOptions);
   const response = JSON.stringify({ ok: true, data: apiCallResponse });
   return { statusCode: 200, body: response };

--- a/packages/airnode-deployer/src/handlers/aws/index.ts
+++ b/packages/airnode-deployer/src/handlers/aws/index.ts
@@ -9,6 +9,7 @@ import {
   ProcessTransactionsPayload,
   CallApiPayload,
   loadTrustedConfig,
+  ApiCallPayload,
 } from '@api3/airnode-node';
 import { verifyHttpSignedDataRequest, verifyHttpRequest } from '../common';
 
@@ -61,7 +62,7 @@ async function initializeProvider(payload: InitializeProviderPayload) {
 
 async function callApi(payload: CallApiPayload) {
   const { aggregatedApiCall, logOptions } = payload;
-  const [logs, apiCallResponse] = await handlers.callApi({ config: parsedConfig, aggregatedApiCall });
+  const [logs, apiCallResponse] = await handlers.callApi({ config: parsedConfig, aggregatedApiCall } as ApiCallPayload);
   logger.logPending(logs, logOptions);
   const response = JSON.stringify({ ok: true, data: apiCallResponse });
   return { statusCode: 200, body: response };

--- a/packages/airnode-deployer/src/handlers/gcp/index.ts
+++ b/packages/airnode-deployer/src/handlers/gcp/index.ts
@@ -69,7 +69,11 @@ async function initializeProvider(payload: InitializeProviderPayload, res: Respo
 
 async function callApi(payload: CallApiPayload, res: Response) {
   const { aggregatedApiCall, logOptions } = payload;
-  const [logs, apiCallResponse] = await handlers.callApi({ config: parsedConfig, aggregatedApiCall } as ApiCallPayload);
+  const [logs, apiCallResponse] = await handlers.callApi({
+    type: 'regular',
+    config: parsedConfig,
+    aggregatedApiCall,
+  } as ApiCallPayload);
   logger.logPending(logs, logOptions);
   const response = { ok: true, data: apiCallResponse };
   res.status(200).send(response);

--- a/packages/airnode-deployer/src/handlers/gcp/index.ts
+++ b/packages/airnode-deployer/src/handlers/gcp/index.ts
@@ -9,7 +9,6 @@ import {
   ProcessTransactionsPayload,
   WorkerPayload,
   loadTrustedConfig,
-  ApiCallPayload,
 } from '@api3/airnode-node';
 import { logger, DEFAULT_RETRY_DELAY_MS } from '@api3/airnode-utilities';
 import { go } from '@api3/promise-utils';
@@ -69,11 +68,7 @@ async function initializeProvider(payload: InitializeProviderPayload, res: Respo
 
 async function callApi(payload: CallApiPayload, res: Response) {
   const { aggregatedApiCall, logOptions } = payload;
-  const [logs, apiCallResponse] = await handlers.callApi({
-    type: 'regular',
-    config: parsedConfig,
-    aggregatedApiCall,
-  } as ApiCallPayload);
+  const [logs, apiCallResponse] = await handlers.callApi(parsedConfig, aggregatedApiCall);
   logger.logPending(logs, logOptions);
   const response = { ok: true, data: apiCallResponse };
   res.status(200).send(response);

--- a/packages/airnode-deployer/src/handlers/gcp/index.ts
+++ b/packages/airnode-deployer/src/handlers/gcp/index.ts
@@ -9,6 +9,7 @@ import {
   ProcessTransactionsPayload,
   WorkerPayload,
   loadTrustedConfig,
+  ApiCallPayload,
 } from '@api3/airnode-node';
 import { logger, DEFAULT_RETRY_DELAY_MS } from '@api3/airnode-utilities';
 import { go } from '@api3/promise-utils';
@@ -68,7 +69,7 @@ async function initializeProvider(payload: InitializeProviderPayload, res: Respo
 
 async function callApi(payload: CallApiPayload, res: Response) {
   const { aggregatedApiCall, logOptions } = payload;
-  const [logs, apiCallResponse] = await handlers.callApi({ config: parsedConfig, aggregatedApiCall });
+  const [logs, apiCallResponse] = await handlers.callApi({ config: parsedConfig, aggregatedApiCall } as ApiCallPayload);
   logger.logPending(logs, logOptions);
   const response = { ok: true, data: apiCallResponse };
   res.status(200).send(response);

--- a/packages/airnode-node/src/adapters/http/worker.test.ts
+++ b/packages/airnode-node/src/adapters/http/worker.test.ts
@@ -17,7 +17,7 @@ describe('spawnNewApiCall', () => {
   };
 
   it('handles remote AWS calls', async () => {
-    invokeMock.mockImplementationOnce((params, callback) =>
+    invokeMock.mockImplementationOnce((_params, callback) =>
       callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: true, data: { value: '0x123' } }) }) })
     );
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall();
@@ -31,14 +31,14 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );
   });
 
   it('returns an error if the worker rejects', async () => {
-    invokeMock.mockImplementationOnce((params, callback) => callback(new Error('Something went wrong'), null));
+    invokeMock.mockImplementationOnce((_params, callback) => callback(new Error('Something went wrong'), null));
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall();
     const workerOpts = fixtures.buildWorkerOptions({
       cloudProvider: { type: 'aws', region: 'us-east-1', disableConcurrencyReservations: false },
@@ -52,7 +52,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );
@@ -60,7 +60,7 @@ describe('spawnNewApiCall', () => {
 
   it('returns an error if the response has an error log', async () => {
     const errorLog = logger.pend('ERROR', 'Something went wrong');
-    invokeMock.mockImplementationOnce((params, callback) =>
+    invokeMock.mockImplementationOnce((_params, callback) =>
       callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false, errorLog }) }) })
     );
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall();
@@ -74,14 +74,14 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );
   });
 
   it('returns an error if the response is not ok', async () => {
-    invokeMock.mockImplementationOnce((params, callback) =>
+    invokeMock.mockImplementationOnce((_params, callback) =>
       callback(null, { Payload: JSON.stringify({ body: JSON.stringify({ ok: false }) }) })
     );
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall();
@@ -95,7 +95,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );

--- a/packages/airnode-node/src/adapters/http/worker.test.ts
+++ b/packages/airnode-node/src/adapters/http/worker.test.ts
@@ -31,7 +31,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );
@@ -52,7 +52,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );
@@ -74,7 +74,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );
@@ -95,7 +95,7 @@ describe('spawnNewApiCall', () => {
     expect(invokeMock).toHaveBeenCalledWith(
       {
         FunctionName: 'airnode-19255a4-test-run',
-        Payload: JSON.stringify({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' }),
+        Payload: JSON.stringify({ aggregatedApiCall, logOptions, functionName: 'callApi' }),
       },
       expect.anything()
     );

--- a/packages/airnode-node/src/adapters/http/worker.ts
+++ b/packages/airnode-node/src/adapters/http/worker.ts
@@ -10,7 +10,7 @@ export async function spawnNewApiCall(
 ): Promise<LogsData<ApiCallResponse | null>> {
   const options = {
     ...workerOpts,
-    payload: { type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' } as CallApiPayload,
+    payload: { aggregatedApiCall, logOptions, functionName: 'callApi' } as CallApiPayload,
   };
 
   const goRes = await go(() => workers.spawn(options));

--- a/packages/airnode-node/src/adapters/http/worker.ts
+++ b/packages/airnode-node/src/adapters/http/worker.ts
@@ -1,16 +1,16 @@
 import { logger, LogOptions } from '@api3/airnode-utilities';
 import { go } from '@api3/promise-utils';
 import * as workers from '../../workers';
-import { AggregatedApiCall, ApiCallResponse, LogsData, WorkerOptions, CallApiPayload } from '../../types';
+import { ApiCallResponse, LogsData, WorkerOptions, CallApiPayload, RegularAggregatedApiCall } from '../../types';
 
 export async function spawnNewApiCall(
-  aggregatedApiCall: AggregatedApiCall,
+  aggregatedApiCall: RegularAggregatedApiCall,
   logOptions: LogOptions,
   workerOpts: WorkerOptions
 ): Promise<LogsData<ApiCallResponse | null>> {
   const options = {
     ...workerOpts,
-    payload: { aggregatedApiCall, logOptions, functionName: 'callApi' } as CallApiPayload,
+    payload: { type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' } as CallApiPayload,
   };
 
   const goRes = await go(() => workers.spawn(options));

--- a/packages/airnode-node/src/api/index.test.ts
+++ b/packages/airnode-node/src/api/index.test.ts
@@ -33,11 +33,8 @@ describe('callApi', () => {
         ois: fixtures.buildOIS(),
         parameters: { from: 'ETH', amount: '1' },
         metadata: {
-          airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
-          airnodeRrpAddress: '0x197F3826040dF832481f835652c290aC7c41f073',
           chainId: '31337',
           chainType: 'evm',
-          endpointId: '0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6',
           requestId: '0xf40127616f09d41b20891bcfd326957a0e3d5a5ecf659cff4d8106c04b024374',
           requesterAddress: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
           sponsorAddress: '0x2479808b1216E998309A727df8A0A98A1130A162',

--- a/packages/airnode-node/src/api/index.test.ts
+++ b/packages/airnode-node/src/api/index.test.ts
@@ -51,14 +51,13 @@ describe('callApi', () => {
     );
   });
 
-  it('calls the adapter with the given parameters even if config.chains is missing', async () => {
+  it('calls the adapter with the given parameters even if config.chains cannot be found', async () => {
     const spy = jest.spyOn(adapter, 'buildAndExecuteRequest') as any;
     spy.mockResolvedValueOnce({ data: { price: 1000 } });
     const parameters = { _type: 'int256', _path: 'price', from: 'ETH' };
 
-    const { chains: _, ...rest } = fixtures.buildConfig();
     const [logs, res] = await callApi({
-      config: rest,
+      config: fixtures.buildConfig({ chains: [] }),
       aggregatedApiCall: fixtures.buildAggregatedRegularApiCall({ parameters }),
     });
 
@@ -289,26 +288,6 @@ describe('callApi', () => {
       errorMessage: `Unable to cast value to int256`,
       success: false,
     });
-  });
-
-  it('returns an error if aggregatedApiCall arg has type = "regular" but config arg is missing nodeSettings', async () => {
-    const spy = jest.spyOn(adapter, 'buildAndExecuteRequest') as any;
-
-    const parameters = { _type: 'int256', _path: 'unknown', from: 'ETH' };
-    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
-    const { chains, ois, apiCredentials } = fixtures.buildConfig();
-    const [logs, res] = await callApi({ config: { chains, ois, apiCredentials }, aggregatedApiCall });
-    expect(logs).toEqual([
-      {
-        level: 'ERROR',
-        message: 'Missing config.nodeSettings object',
-      },
-    ]);
-    expect(res).toEqual({
-      errorMessage: `Missing config.nodeSettings object`,
-      success: false,
-    });
-    expect(spy).not.toHaveBeenCalled();
   });
 
   describe('pre-processing', () => {

--- a/packages/airnode-node/src/api/index.test.ts
+++ b/packages/airnode-node/src/api/index.test.ts
@@ -1,8 +1,9 @@
 import * as adapter from '@api3/airnode-adapter';
 import { ethers } from 'ethers';
-import { ApiCallErrorResponse, RequestErrorMessage } from '../types';
 import * as fixtures from '../../test/fixtures';
-import { callApi } from '.';
+import { getExpectedTemplateIdV0 } from '../evm/templates';
+import { ApiCallErrorResponse, RequestErrorMessage } from '../types';
+import { callApi, verifyTemplateId } from '.';
 
 describe('callApi', () => {
   fixtures.setEnvVariables({ AIRNODE_WALLET_PRIVATE_KEY: fixtures.getAirnodeWalletPrivateKey() });
@@ -378,6 +379,101 @@ describe('callApi', () => {
         }),
         { timeout: 30_000 }
       );
+    });
+  });
+});
+
+describe('verifyTemplateId', () => {
+  const validTemplateFields = {
+    airnodeAddress: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+    endpointId: '0x2f3a3adf6daf5a3bb00ab83aa82262a6a84b59b0a89222386135330a1819ab48',
+    encodedParameters: '0x6466726f6d63455448',
+  };
+
+  const TEMPLATE_ID = '0xb2f063157fcc3c986daf4c2cf1b8ac8b8843f2b1a54c5de5e1ebdf12fb85a927';
+
+  it('returns API calls not linked to templates', () => {
+    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ templateId: null });
+    const config = fixtures.buildConfig();
+
+    const response = verifyTemplateId({ aggregatedApiCall, config });
+
+    expect(response).toEqual(null);
+  });
+
+  it('ignores API calls where the template cannot be found', () => {
+    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({
+      templateId: TEMPLATE_ID,
+      template: undefined,
+    });
+    const config = fixtures.buildConfig();
+
+    const response = verifyTemplateId({ aggregatedApiCall, config });
+
+    expect(response).toEqual([
+      [
+        {
+          level: 'ERROR',
+          message: `Ignoring Request:${aggregatedApiCall.id} as the template could not be found for verification`,
+        },
+      ],
+      {
+        errorMessage: `Ignoring Request:${aggregatedApiCall.id} as the template could not be found for verification`,
+        success: false,
+      },
+    ]);
+  });
+
+  it('does nothing where API calls are linked to a valid templated', () => {
+    const template = fixtures.requests.buildApiCallTemplate({
+      ...validTemplateFields,
+      id: TEMPLATE_ID,
+    });
+    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({
+      templateId: TEMPLATE_ID,
+      template,
+    });
+    const config = fixtures.buildConfig();
+
+    const response = verifyTemplateId({ aggregatedApiCall, config });
+
+    expect(response).toEqual(null);
+  });
+
+  describe('invalid fields', () => {
+    const validTemplate = fixtures.requests.buildApiCallTemplate({
+      ...validTemplateFields,
+      id: TEMPLATE_ID,
+    });
+    const config = fixtures.buildConfig();
+    const invalidFields = {
+      airnodeAddress: '0x69e2B095fbAc6C3f9E528Ef21882b86BF1595181',
+      endpointId: '0x05218bc3e2497776d24b7da2890e12c910d07ce647cc45bd565cbb167e620df3',
+      encodedParameters: '0x1234',
+    };
+
+    Object.keys(invalidFields).forEach((field) => {
+      it(`is invalid if ${field} has been changed`, () => {
+        const invalidTemplate = { ...validTemplate, [field]: (invalidFields as any)[field] };
+        const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({
+          templateId: TEMPLATE_ID,
+          template: invalidTemplate,
+        });
+        const expectedTemplateId = getExpectedTemplateIdV0(invalidTemplate);
+        const response = verifyTemplateId({ aggregatedApiCall, config });
+        expect(response).toEqual([
+          [
+            {
+              level: 'ERROR',
+              message: `Invalid template ID:${TEMPLATE_ID} found for Request:${aggregatedApiCall.id}. Expected template ID:${expectedTemplateId}`,
+            },
+          ],
+          {
+            errorMessage: `Invalid template ID:${TEMPLATE_ID} found for Request:${aggregatedApiCall.id}. Expected template ID:${expectedTemplateId}`,
+            success: false,
+          },
+        ]);
+      });
     });
   });
 });

--- a/packages/airnode-node/src/api/index.test.ts
+++ b/packages/airnode-node/src/api/index.test.ts
@@ -14,6 +14,7 @@ describe('callApi', () => {
     const parameters = { _type: 'int256', _path: 'price', from: 'ETH' };
 
     const [logs, res] = await callApi({
+      type: 'regular',
       config: fixtures.buildConfig(),
       aggregatedApiCall: fixtures.buildAggregatedRegularApiCall({ parameters }),
     });
@@ -58,6 +59,7 @@ describe('callApi', () => {
     const parameters = { _type: 'int256', _path: 'price', from: 'ETH' };
 
     const [logs, res] = await callApi({
+      type: 'regular',
       config: fixtures.buildConfig({ chains: [] }),
       aggregatedApiCall: fixtures.buildAggregatedRegularApiCall({ parameters }),
     });
@@ -102,6 +104,7 @@ describe('callApi', () => {
     const parameters = { _type: 'int256', _path: 'price', from: 'ETH' };
 
     const [logs, res] = await callApi({
+      type: 'http-gateway',
       config: { ois: [fixtures.buildOIS()], apiCredentials: [fixtures.buildApiCredentials()] },
       aggregatedApiCall: fixtures.buildAggregatedHttpGatewayApiCall({ parameters }),
     });
@@ -142,6 +145,7 @@ describe('callApi', () => {
     const endpointId = '0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6';
     const templateId = '0xaa1525fe964092a826934ff09c75e1db395b947543a4ca3eb4a19628bad6c6d5';
     const [logs, res] = await callApi({
+      type: 'http-signed-data-gateway',
       config: { ois: [fixtures.buildOIS()], apiCredentials: [fixtures.buildApiCredentials()] },
       aggregatedApiCall: fixtures.buildAggregatedHttpSignedDataApiCall({
         endpointId,
@@ -188,6 +192,7 @@ describe('callApi', () => {
     spy.mockResolvedValueOnce({ data: { price: 1000 } });
 
     await callApi({
+      type: 'regular',
       config: fixtures.buildConfig(),
       aggregatedApiCall: fixtures.buildAggregatedRegularApiCall(),
     });
@@ -207,7 +212,7 @@ describe('callApi', () => {
 
     const parameters = { _type: 'int256', _path: 'unknown', from: 'ETH' };
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
-    const [logs, res] = await callApi({ config: fixtures.buildConfig(), aggregatedApiCall });
+    const [logs, res] = await callApi({ type: 'regular', config: fixtures.buildConfig(), aggregatedApiCall });
     expect(logs).toEqual([
       { level: 'ERROR', message: 'Failed to call Endpoint:convertToUSD', error: new Error('Network is down') },
     ]);
@@ -222,7 +227,7 @@ describe('callApi', () => {
     spy.mockResolvedValueOnce({ data: { price: 1000 } });
     const parameters = { _type: 'int256', _path: 'unknown', from: 'ETH' };
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
-    const [logs, res] = await callApi({ config: fixtures.buildConfig(), aggregatedApiCall });
+    const [logs, res] = await callApi({ type: 'regular', config: fixtures.buildConfig(), aggregatedApiCall });
     expect(logs).toEqual([{ level: 'ERROR', message: `Unable to find value at path: 'unknown'` }]);
     expect(res).toEqual({
       errorMessage: `Unable to find value at path: 'unknown'`,
@@ -236,6 +241,7 @@ describe('callApi', () => {
     const parameters = { _type: 'uint256', _path: 'price', from: 'ETH' };
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
     const [logs, res] = await callApi({
+      type: 'regular',
       config: fixtures.buildConfig(),
       aggregatedApiCall,
     });
@@ -255,6 +261,7 @@ describe('callApi', () => {
     const parameters = { _type: 'string', _path: 'price', from: 'ETH', test: 'new' };
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
     const [logs, res] = await callApi({
+      type: 'regular',
       config: fixtures.buildConfig(),
       aggregatedApiCall,
     });
@@ -276,6 +283,7 @@ describe('callApi', () => {
     const parameters = { _type: 'int256', _path: 'price', from: 'ETH', test: 'new' };
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
     const [logs, res] = await callApi({
+      type: 'regular',
       config: fixtures.buildConfig(),
       aggregatedApiCall,
     });
@@ -316,6 +324,7 @@ describe('callApi', () => {
       config.ois[0].endpoints[0] = { ...config.ois[0].endpoints[0], preProcessingSpecifications };
 
       const [logs, res] = await callApi({
+        type: 'regular',
         config,
         aggregatedApiCall,
       });
@@ -359,6 +368,7 @@ describe('callApi', () => {
       config.ois[0].endpoints[0] = { ...config.ois[0].endpoints[0], postProcessingSpecifications };
 
       const [logs, res] = await callApi({
+        type: 'regular',
         config,
         aggregatedApiCall,
       });
@@ -396,7 +406,7 @@ describe('verifyTemplateId', () => {
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ templateId: null });
     const config = fixtures.buildConfig();
 
-    const response = verifyTemplateId({ aggregatedApiCall, config });
+    const response = verifyTemplateId({ type: 'regular', aggregatedApiCall, config });
 
     expect(response).toEqual(null);
   });
@@ -408,7 +418,7 @@ describe('verifyTemplateId', () => {
     });
     const config = fixtures.buildConfig();
 
-    const response = verifyTemplateId({ aggregatedApiCall, config });
+    const response = verifyTemplateId({ type: 'regular', aggregatedApiCall, config });
 
     expect(response).toEqual([
       [
@@ -435,7 +445,7 @@ describe('verifyTemplateId', () => {
     });
     const config = fixtures.buildConfig();
 
-    const response = verifyTemplateId({ aggregatedApiCall, config });
+    const response = verifyTemplateId({ type: 'regular', aggregatedApiCall, config });
 
     expect(response).toEqual(null);
   });
@@ -460,7 +470,7 @@ describe('verifyTemplateId', () => {
           template: invalidTemplate,
         });
         const expectedTemplateId = getExpectedTemplateIdV0(invalidTemplate);
-        const response = verifyTemplateId({ aggregatedApiCall, config });
+        const response = verifyTemplateId({ type: 'regular', aggregatedApiCall, config });
         expect(response).toEqual([
           [
             {

--- a/packages/airnode-node/src/api/index.ts
+++ b/packages/airnode-node/src/api/index.ts
@@ -52,10 +52,9 @@ function buildOptions(payload: CallApiPayload): adapter.BuildRequestOptions {
       };
     }
     case 'regular': {
-      const { airnodeAddress, requesterAddress, sponsorAddress, sponsorWalletAddress, endpointId, id, chainId } =
-        aggregatedApiCall;
+      const { requesterAddress, sponsorAddress, sponsorWalletAddress, id, chainId } = aggregatedApiCall;
       // Find the chain config based on the aggregatedApiCall chainId
-      const chain = config.chains.find((c) => c.id === chainId)!;
+      const chain = config.chains?.find((c) => c.id === chainId);
 
       return {
         endpointName,
@@ -63,15 +62,12 @@ function buildOptions(payload: CallApiPayload): adapter.BuildRequestOptions {
         ois,
         apiCredentials,
         metadata: {
-          airnodeAddress: airnodeAddress,
           requesterAddress: requesterAddress,
           sponsorAddress: sponsorAddress,
           sponsorWalletAddress: sponsorWalletAddress,
-          endpointId: endpointId,
           requestId: id,
           chainId: chainId,
-          chainType: chain.type,
-          airnodeRrpAddress: chain.contracts.AirnodeRrp,
+          chainType: chain?.type || 'evm',
         },
       };
     }
@@ -100,7 +96,8 @@ async function signWithTemplateId(templateId: string, timestamp: string, data: s
   );
 }
 
-type CallApiConfig = Pick<Config, 'chains' | 'ois' | 'apiCredentials'> &
+type CallApiConfig = Pick<Config, 'ois' | 'apiCredentials'> &
+  Partial<Pick<Config, 'chains'>> &
   Partial<{
     nodeSettings: Pick<Config['nodeSettings'], 'airnodeWalletMnemonic'>;
   }>;

--- a/packages/airnode-node/src/api/processing.test.ts
+++ b/packages/airnode-node/src/api/processing.test.ts
@@ -23,7 +23,7 @@ describe('processing', () => {
       const parameters = { _type: 'int256', _path: 'price' };
       const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
 
-      const result = await preProcessApiSpecifications({ config, aggregatedApiCall });
+      const result = await preProcessApiSpecifications({ type: 'regular', config, aggregatedApiCall });
 
       expect(result.aggregatedApiCall.parameters).toEqual({
         _path: 'price',
@@ -52,7 +52,7 @@ describe('processing', () => {
       const parameters = { _type: 'int256', _path: 'price', from: 'TBD' };
       const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
 
-      const throwingFunc = async () => preProcessApiSpecifications({ config, aggregatedApiCall });
+      const throwingFunc = async () => preProcessApiSpecifications({ type: 'regular', config, aggregatedApiCall });
 
       await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
     });
@@ -71,7 +71,7 @@ describe('processing', () => {
       const parameters = { _type: 'int256', _path: 'price', from: '*ETH' };
       const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
 
-      const throwingFunc = async () => preProcessApiSpecifications({ config, aggregatedApiCall });
+      const throwingFunc = async () => preProcessApiSpecifications({ type: 'regular', config, aggregatedApiCall });
 
       await expect(throwingFunc).rejects.toEqual(
         new ZodError([

--- a/packages/airnode-node/src/api/processing.ts
+++ b/packages/airnode-node/src/api/processing.ts
@@ -3,9 +3,9 @@ import { go } from '@api3/promise-utils';
 import { unsafeEvaluate, unsafeEvaluateAsync } from './unsafe-evaluate';
 import { apiCallParametersSchema } from '../validation';
 import { PROCESSING_TIMEOUT } from '../constants';
-import { CallApiPayload } from './index';
+import { ApiCallPayload } from '../types';
 
-export const preProcessApiSpecifications = async (payload: CallApiPayload): Promise<CallApiPayload> => {
+export const preProcessApiSpecifications = async (payload: ApiCallPayload): Promise<ApiCallPayload> => {
   const { config, aggregatedApiCall } = payload;
   const { endpointName, oisTitle } = aggregatedApiCall;
   const ois = config.ois.find((o) => o.title === oisTitle)!;
@@ -46,7 +46,7 @@ export const preProcessApiSpecifications = async (payload: CallApiPayload): Prom
       ...aggregatedApiCall,
       parameters,
     },
-  };
+  } as ApiCallPayload;
 };
 
 export const postProcessApiSpecifications = async (input: unknown, endpoint: Endpoint) => {

--- a/packages/airnode-node/src/coordinator/calls/aggregation.test.ts
+++ b/packages/airnode-node/src/coordinator/calls/aggregation.test.ts
@@ -12,7 +12,6 @@ describe('aggregate (API calls)', () => {
     const res = aggregation.aggregate(fixtures.buildConfig(), apiCalls);
     expect(res).toEqual({
       apiCallId: {
-        type: 'regular',
         sponsorAddress: 'sponsorAddress',
         airnodeAddress: 'airnodeAddress',
         requesterAddress: 'requesterAddress',
@@ -50,7 +49,6 @@ describe('aggregate (API calls)', () => {
     const res = aggregation.aggregate(fixtures.buildConfig(), apiCalls);
     expect(res).toEqual({
       apiCallId: {
-        type: 'regular',
         sponsorAddress: 'sponsorAddress',
         airnodeAddress: 'airnodeAddress',
         requesterAddress: 'requesterAddress',

--- a/packages/airnode-node/src/coordinator/calls/aggregation.ts
+++ b/packages/airnode-node/src/coordinator/calls/aggregation.ts
@@ -24,7 +24,6 @@ function buildRegularAggregatedCall(config: Config, request: Request<ApiCall>): 
   const trigger = config.triggers.rrp.find((t) => t.endpointId === endpointId)!;
 
   return {
-    type: 'regular',
     id: id,
     sponsorAddress: sponsorAddress,
     airnodeAddress: airnodeAddress!,

--- a/packages/airnode-node/src/evm/templates/template-verification.test.ts
+++ b/packages/airnode-node/src/evm/templates/template-verification.test.ts
@@ -1,18 +1,13 @@
 import { utils } from 'ethers';
 import * as verification from './template-verification';
-import * as fixtures from '../../../test/fixtures';
-import { verifyTemplateId } from '../../api';
 
-// TODO: Move to call-api.test.ts
-describe('verify', () => {
-  const validTemplateFields = {
-    airnodeAddress: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
-    endpointId: '0x2f3a3adf6daf5a3bb00ab83aa82262a6a84b59b0a89222386135330a1819ab48',
-    encodedParameters: '0x6466726f6d63455448',
-  };
+const validTemplateFields = {
+  airnodeAddress: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+  endpointId: '0x2f3a3adf6daf5a3bb00ab83aa82262a6a84b59b0a89222386135330a1819ab48',
+  encodedParameters: '0x6466726f6d63455448',
+};
 
-  const TEMPLATE_ID = '0xb2f063157fcc3c986daf4c2cf1b8ac8b8843f2b1a54c5de5e1ebdf12fb85a927';
-
+describe('getExpectedTemplateIdV0', () => {
   it('derives templateId for V0', () => {
     const expectedTemplateIdV0 = verification.getExpectedTemplateIdV0(validTemplateFields);
 
@@ -29,6 +24,8 @@ describe('verify', () => {
       )
     );
   });
+
+  describe('getExpectedTemplateIdV1', () => {});
   it('derives templateId for V1', () => {
     const expectedTemplateIdV1 = verification.getExpectedTemplateIdV1(validTemplateFields);
 
@@ -40,90 +37,5 @@ describe('verify', () => {
         )
       )
     );
-  });
-
-  it('returns API calls not linked to templates', () => {
-    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ templateId: null });
-    const config = fixtures.buildConfig();
-
-    const response = verifyTemplateId({ aggregatedApiCall, config });
-
-    expect(response).toEqual(null);
-  });
-
-  it('ignores API calls where the template cannot be found', () => {
-    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({
-      templateId: TEMPLATE_ID,
-      template: undefined,
-    });
-    const config = fixtures.buildConfig();
-
-    const response = verifyTemplateId({ aggregatedApiCall, config });
-
-    expect(response).toEqual([
-      [
-        {
-          level: 'ERROR',
-          message: `Ignoring Request:${aggregatedApiCall.id} as the template could not be found for verification`,
-        },
-      ],
-      {
-        errorMessage: `Ignoring Request:${aggregatedApiCall.id} as the template could not be found for verification`,
-        success: false,
-      },
-    ]);
-  });
-
-  it('does nothing where API calls are linked to a valid templated', () => {
-    const template = fixtures.requests.buildApiCallTemplate({
-      ...validTemplateFields,
-      id: TEMPLATE_ID,
-    });
-    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({
-      templateId: TEMPLATE_ID,
-      template,
-    });
-    const config = fixtures.buildConfig();
-
-    const response = verifyTemplateId({ aggregatedApiCall, config });
-
-    expect(response).toEqual(null);
-  });
-
-  describe('invalid fields', () => {
-    const validTemplate = fixtures.requests.buildApiCallTemplate({
-      ...validTemplateFields,
-      id: TEMPLATE_ID,
-    });
-    const config = fixtures.buildConfig();
-    const invalidFields = {
-      airnodeAddress: '0x69e2B095fbAc6C3f9E528Ef21882b86BF1595181',
-      endpointId: '0x05218bc3e2497776d24b7da2890e12c910d07ce647cc45bd565cbb167e620df3',
-      encodedParameters: '0x1234',
-    };
-
-    Object.keys(invalidFields).forEach((field) => {
-      it(`is invalid if ${field} has been changed`, () => {
-        const invalidTemplate = { ...validTemplate, [field]: (invalidFields as any)[field] };
-        const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({
-          templateId: TEMPLATE_ID,
-          template: invalidTemplate,
-        });
-        const expectedTemplateId = verification.getExpectedTemplateIdV0(invalidTemplate);
-        const response = verifyTemplateId({ aggregatedApiCall, config });
-        expect(response).toEqual([
-          [
-            {
-              level: 'ERROR',
-              message: `Invalid template ID:${TEMPLATE_ID} found for Request:${aggregatedApiCall.id}. Expected template ID:${expectedTemplateId}`,
-            },
-          ],
-          {
-            errorMessage: `Invalid template ID:${TEMPLATE_ID} found for Request:${aggregatedApiCall.id}. Expected template ID:${expectedTemplateId}`,
-            success: false,
-          },
-        ]);
-      });
-    });
   });
 });

--- a/packages/airnode-node/src/evm/verification/request-verification.ts
+++ b/packages/airnode-node/src/evm/verification/request-verification.ts
@@ -4,11 +4,6 @@ import * as wallet from '../wallet';
 import { ApiCall, Request, LogsData, UpdatedRequests } from '../../types';
 import { Trigger } from '../../config';
 
-export const isValidSponsorWallet = (hdNode: ethers.utils.HDNode, sponsor: string, sponsorWallet: string) => {
-  const derivedSponsorWallet = wallet.deriveSponsorWallet(hdNode, sponsor);
-  return derivedSponsorWallet.address === sponsorWallet;
-};
-
 // TODO: Remove this once https://api3dao.atlassian.net/browse/AN-400 is done
 export function verifySponsorWallets<T>(
   unverifiedRequests: Request<T>[],

--- a/packages/airnode-node/src/evm/wallet.test.ts
+++ b/packages/airnode-node/src/evm/wallet.test.ts
@@ -1,5 +1,6 @@
 import * as wallet from './wallet';
 import * as fixtures from '../../test/fixtures';
+import { getMasterKeyMnemonic } from '../config';
 
 const config = fixtures.buildConfig();
 
@@ -34,5 +35,28 @@ describe('deriveSponsorWallet', () => {
     const signingWallet = wallet.deriveSponsorWallet(masterHDNode, '0x06f509f73eefba36352bc8228f9112c3786100da');
     expect(signingWallet._isSigner).toEqual(true);
     expect(signingWallet.address).toEqual('0x228A54F33E46fbb32a62ca650Fcc9eD3C730511d');
+  });
+});
+
+describe('deriveSponsorWalletFromMnemonic', () => {
+  it('returns the wallet for the given sponsor (will use default protocolId = 1)', () => {
+    const mnemonic = getMasterKeyMnemonic(config);
+    const signingWallet = wallet.deriveSponsorWalletFromMnemonic(
+      mnemonic,
+      '0x06f509f73eefba36352bc8228f9112c3786100da'
+    );
+    expect(signingWallet._isSigner).toEqual(true);
+    expect(signingWallet.address).toEqual('0x228A54F33E46fbb32a62ca650Fcc9eD3C730511d');
+  });
+
+  it('returns the wallet for the given sponsor and protocolId', () => {
+    const mnemonic = getMasterKeyMnemonic(config);
+    const signingWallet = wallet.deriveSponsorWalletFromMnemonic(
+      mnemonic,
+      '0x06f509f73eefba36352bc8228f9112c3786100da',
+      '2'
+    );
+    expect(signingWallet._isSigner).toEqual(true);
+    expect(signingWallet.address).toEqual('0x9F3c41801c55a557ddCEdd25E29bA05780f31c37');
   });
 });

--- a/packages/airnode-node/src/evm/wallet.ts
+++ b/packages/airnode-node/src/evm/wallet.ts
@@ -63,7 +63,7 @@ export function deriveSponsorWallet(
   return new ethers.Wallet(sponsorWalletHdNode.privateKey);
 }
 
-export const deriveSponsorWalletFromMnemonic = (airnodeMnemonic: string, sponsorAddress: string, protocolId: string) =>
+export const deriveSponsorWalletFromMnemonic = (airnodeMnemonic: string, sponsorAddress: string, protocolId?: string) =>
   ethers.Wallet.fromMnemonic(
     airnodeMnemonic,
     `m/44'/60'/0'/${deriveWalletPathFromSponsorAddress(sponsorAddress, protocolId)}`

--- a/packages/airnode-node/src/handlers/call-api.test.ts
+++ b/packages/airnode-node/src/handlers/call-api.test.ts
@@ -1,18 +1,15 @@
 import * as fixtures from '../../test/fixtures';
 import * as api from '../api';
-import { ApiCallPayload } from '../types';
 import { callApi } from '.';
 
 describe('callApi', () => {
   it('calls API', () => {
     const initializeSpy = jest.spyOn(api, 'callApi');
-    const payload: ApiCallPayload = {
-      type: 'regular',
-      config: fixtures.buildConfig(),
-      aggregatedApiCall: fixtures.buildAggregatedRegularApiCall(),
-    };
-    callApi(payload);
+    const config = fixtures.buildConfig();
+    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall();
+
+    callApi(config, aggregatedApiCall);
     expect(initializeSpy).toHaveBeenCalledTimes(1);
-    expect(initializeSpy).toHaveBeenCalledWith(payload);
+    expect(initializeSpy).toHaveBeenCalledWith({ type: 'regular', config, aggregatedApiCall });
   });
 });

--- a/packages/airnode-node/src/handlers/call-api.test.ts
+++ b/packages/airnode-node/src/handlers/call-api.test.ts
@@ -1,11 +1,13 @@
 import * as fixtures from '../../test/fixtures';
 import * as api from '../api';
+import { ApiCallPayload } from '../types';
 import { callApi } from '.';
 
 describe('callApi', () => {
   it('calls API', () => {
     const initializeSpy = jest.spyOn(api, 'callApi');
-    const payload = {
+    const payload: ApiCallPayload = {
+      type: 'regular',
       config: fixtures.buildConfig(),
       aggregatedApiCall: fixtures.buildAggregatedRegularApiCall(),
     };

--- a/packages/airnode-node/src/handlers/call-api.ts
+++ b/packages/airnode-node/src/handlers/call-api.ts
@@ -1,6 +1,13 @@
-import { ApiCallResponse, ApiCallPayload, LogsData } from '../types';
+import { ApiCallResponse, LogsData, RegularAggregatedApiCall, RegularApiCallConfig } from '../types';
 import * as api from '../api';
 
-export async function callApi(payload: ApiCallPayload): Promise<LogsData<ApiCallResponse>> {
-  return api.callApi(payload);
+export async function callApi(
+  config: RegularApiCallConfig,
+  aggregatedApiCall: RegularAggregatedApiCall
+): Promise<LogsData<ApiCallResponse>> {
+  return api.callApi({
+    type: 'regular',
+    config,
+    aggregatedApiCall,
+  });
 }

--- a/packages/airnode-node/src/handlers/call-api.ts
+++ b/packages/airnode-node/src/handlers/call-api.ts
@@ -1,6 +1,6 @@
-import { LogsData, ApiCallResponse } from '../types';
+import { ApiCallResponse, ApiCallPayload, LogsData } from '../types';
 import * as api from '../api';
 
-export async function callApi(payload: api.CallApiPayload): Promise<LogsData<ApiCallResponse>> {
+export async function callApi(payload: ApiCallPayload): Promise<LogsData<ApiCallResponse>> {
   return api.callApi(payload);
 }

--- a/packages/airnode-node/src/handlers/process-http-request.test.ts
+++ b/packages/airnode-node/src/handlers/process-http-request.test.ts
@@ -42,6 +42,6 @@ describe('processHttpRequest', () => {
     expect(err).toBeNull();
     expect(res).toEqual(mockedResponse);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({ config, aggregatedApiCall });
+    expect(spy).toHaveBeenCalledWith({ type: 'http-gateway', config, aggregatedApiCall });
   });
 });

--- a/packages/airnode-node/src/handlers/process-http-request.ts
+++ b/packages/airnode-node/src/handlers/process-http-request.ts
@@ -1,6 +1,6 @@
 import find from 'lodash/find';
 import { buildBaseOptions, logger, randomHexString } from '@api3/airnode-utilities';
-import { AggregatedApiCall, HttpGatewayApiCallSuccessResponse } from '../types';
+import { BaseAggregatedApiCall, HttpGatewayApiCallSuccessResponse } from '../types';
 import { callApi } from '../api';
 import { Config } from '../config';
 
@@ -14,14 +14,13 @@ export async function processHttpRequest(
   // Guaranteed to exist because validation is already performed in the deployer handler
   const trigger = find(config.triggers.http, ['endpointId', endpointId])!;
 
-  const aggregatedApiCall: AggregatedApiCall = {
-    type: 'http-gateway',
+  const aggregatedApiCall: BaseAggregatedApiCall = {
     endpointName: trigger.endpointName,
     oisTitle: trigger.oisTitle,
     parameters,
   };
 
-  const [logs, response] = await callApi({ config, aggregatedApiCall });
+  const [logs, response] = await callApi({ type: 'http-gateway', config, aggregatedApiCall });
 
   logger.logPending(logs, logOptions);
 

--- a/packages/airnode-node/src/handlers/process-http-signed-data-request.test.ts
+++ b/packages/airnode-node/src/handlers/process-http-signed-data-request.test.ts
@@ -44,6 +44,6 @@ describe('processHttpSignedDataRequests', () => {
     expect(err).toBeNull();
     expect(res).toEqual(mockedResponse);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({ config, aggregatedApiCall });
+    expect(spy).toHaveBeenCalledWith({ type: 'http-signed-data-gateway', config, aggregatedApiCall });
   });
 });

--- a/packages/airnode-node/src/handlers/process-http-signed-data-request.ts
+++ b/packages/airnode-node/src/handlers/process-http-signed-data-request.ts
@@ -2,7 +2,11 @@ import find from 'lodash/find';
 import { buildBaseOptions, logger, randomHexString } from '@api3/airnode-utilities';
 import * as wallet from '../evm/wallet';
 import * as evm from '../evm';
-import { AggregatedApiCall, HttpSignedDataApiCallSuccessResponse, ApiCallTemplateWithoutId } from '../types';
+import {
+  HttpSignedDataApiCallSuccessResponse,
+  ApiCallTemplateWithoutId,
+  HttpSignedDataAggregatedApiCall,
+} from '../types';
 import { callApi } from '../api';
 import { Config } from '../config';
 import { getExpectedTemplateIdV1 } from '../evm/templates';
@@ -28,8 +32,7 @@ export async function processHttpSignedDataRequest(
   };
   const templateId = getExpectedTemplateIdV1(template);
 
-  const aggregatedApiCall: AggregatedApiCall = {
-    type: 'http-signed-data-gateway',
+  const aggregatedApiCall: HttpSignedDataAggregatedApiCall = {
     id: requestId,
     endpointId,
     endpointName: trigger.endpointName,
@@ -42,7 +45,7 @@ export async function processHttpSignedDataRequest(
     },
   };
 
-  const [logs, response] = await callApi({ config, aggregatedApiCall });
+  const [logs, response] = await callApi({ type: 'http-signed-data-gateway', config, aggregatedApiCall });
 
   logger.logPending(logs, logOptions);
 

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -290,6 +290,32 @@ export interface HttpSignedDataAggregatedApiCall extends BaseAggregatedApiCall {
   template: ApiCallTemplate;
 }
 
+export type HttpApiCallConfig = Pick<Config, 'ois' | 'apiCredentials'>;
+
+export type RegularApiCallConfig = HttpApiCallConfig &
+  Pick<Config, 'chains'> & {
+    nodeSettings: Pick<Config['nodeSettings'], 'airnodeWalletMnemonic'>;
+  };
+
+export type ApiCallConfig = RegularApiCallConfig | HttpApiCallConfig;
+
+export interface RegularApiCallPayload {
+  readonly config: RegularApiCallConfig;
+  readonly aggregatedApiCall: RegularAggregatedApiCall;
+}
+
+export interface HttpApiCallPayload {
+  readonly config: HttpApiCallConfig;
+  readonly aggregatedApiCall: HttpAggregatedApiCall;
+}
+
+export interface HttpSignedApiCallPayload {
+  readonly config: HttpApiCallConfig;
+  readonly aggregatedApiCall: HttpSignedDataAggregatedApiCall;
+}
+
+export type ApiCallPayload = RegularApiCallPayload | HttpApiCallPayload | HttpSignedApiCallPayload;
+
 // ===========================================
 // Workers
 // ===========================================

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -246,7 +246,7 @@ export interface ApiCallErrorResponse {
   errorMessage: string;
 }
 
-export type AggregatedApiCall = RegularAggregatedApiCall | HttpAggregatedApiCall | HttpSignedDataAggregatedApiCall;
+export type AggregatedApiCall = RegularAggregatedApiCall | HttpSignedDataAggregatedApiCall;
 
 export interface BaseAggregatedApiCall {
   endpointName: string;
@@ -257,7 +257,6 @@ export interface BaseAggregatedApiCall {
 }
 
 export interface RegularAggregatedApiCall extends BaseAggregatedApiCall {
-  type: 'regular';
   id: string;
   airnodeAddress: string;
   endpointId: string;
@@ -278,12 +277,7 @@ export interface RegularAggregatedApiCall extends BaseAggregatedApiCall {
 
 export type RegularAggregatedApiCallWithResponse = RegularAggregatedApiCall & RegularApiCallResponse;
 
-export interface HttpAggregatedApiCall extends BaseAggregatedApiCall {
-  type: 'http-gateway';
-}
-
 export interface HttpSignedDataAggregatedApiCall extends BaseAggregatedApiCall {
-  type: 'http-signed-data-gateway';
   id: string;
   endpointId: string;
   templateId: string;
@@ -300,16 +294,19 @@ export type RegularApiCallConfig = HttpApiCallConfig &
 export type ApiCallConfig = RegularApiCallConfig | HttpApiCallConfig;
 
 export interface RegularApiCallPayload {
+  type: 'regular';
   readonly config: RegularApiCallConfig;
   readonly aggregatedApiCall: RegularAggregatedApiCall;
 }
 
 export interface HttpApiCallPayload {
+  type: 'http-gateway';
   readonly config: HttpApiCallConfig;
-  readonly aggregatedApiCall: HttpAggregatedApiCall;
+  readonly aggregatedApiCall: BaseAggregatedApiCall;
 }
 
 export interface HttpSignedApiCallPayload {
+  type: 'http-signed-data-gateway';
   readonly config: HttpApiCallConfig;
   readonly aggregatedApiCall: HttpSignedDataAggregatedApiCall;
 }
@@ -337,6 +334,7 @@ export interface ProcessTransactionsPayload {
 
 export interface CallApiPayload {
   readonly functionName: 'callApi';
+  readonly type: 'regular' | 'http-gateway' | 'http-signed-data-gateway';
   readonly aggregatedApiCall: AggregatedApiCall;
   readonly logOptions: LogOptions;
 }

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -334,8 +334,7 @@ export interface ProcessTransactionsPayload {
 
 export interface CallApiPayload {
   readonly functionName: 'callApi';
-  readonly type: 'regular' | 'http-gateway' | 'http-signed-data-gateway';
-  readonly aggregatedApiCall: AggregatedApiCall;
+  readonly aggregatedApiCall: RegularAggregatedApiCall;
   readonly logOptions: LogOptions;
 }
 

--- a/packages/airnode-node/src/workers/local-handlers.test.ts
+++ b/packages/airnode-node/src/workers/local-handlers.test.ts
@@ -71,7 +71,7 @@ describe('callApi', () => {
 
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall();
     const logOptions = fixtures.buildLogOptions();
-    const res = await local.callApi({ aggregatedApiCall, logOptions, functionName: 'callApi' });
+    const res = await local.callApi({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' });
     expect(res).toEqual({ ok: true, data: callResponse });
   });
 });

--- a/packages/airnode-node/src/workers/local-handlers.test.ts
+++ b/packages/airnode-node/src/workers/local-handlers.test.ts
@@ -71,7 +71,7 @@ describe('callApi', () => {
 
     const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall();
     const logOptions = fixtures.buildLogOptions();
-    const res = await local.callApi({ type: 'regular', aggregatedApiCall, logOptions, functionName: 'callApi' });
+    const res = await local.callApi({ aggregatedApiCall, logOptions, functionName: 'callApi' });
     expect(res).toEqual({ ok: true, data: callResponse });
   });
 });

--- a/packages/airnode-node/src/workers/local-handlers.ts
+++ b/packages/airnode-node/src/workers/local-handlers.ts
@@ -5,7 +5,13 @@ import { go } from '@api3/promise-utils';
 import { loadTrustedConfig, setEnvValue } from '../config';
 import * as handlers from '../handlers';
 import * as state from '../providers/state';
-import { WorkerResponse, InitializeProviderPayload, CallApiPayload, ProcessTransactionsPayload } from '../types';
+import {
+  WorkerResponse,
+  InitializeProviderPayload,
+  CallApiPayload,
+  ProcessTransactionsPayload,
+  ApiCallPayload,
+} from '../types';
 
 function loadConfig() {
   return loadTrustedConfig(path.resolve(`${__dirname}/../../config/config.json`), process.env);
@@ -45,7 +51,7 @@ export async function initializeProvider({ state: providerState }: InitializePro
 export async function callApi({ aggregatedApiCall, logOptions }: CallApiPayload): Promise<WorkerResponse> {
   const config = loadConfig();
   setAirnodePrivateKeyToEnv(config.nodeSettings.airnodeWalletMnemonic);
-  const [logs, response] = await handlers.callApi({ config, aggregatedApiCall });
+  const [logs, response] = await handlers.callApi({ config, aggregatedApiCall } as ApiCallPayload);
   logger.logPending(logs, logOptions);
   return { ok: true, data: response };
 }

--- a/packages/airnode-node/src/workers/local-handlers.ts
+++ b/packages/airnode-node/src/workers/local-handlers.ts
@@ -48,10 +48,10 @@ export async function initializeProvider({ state: providerState }: InitializePro
   return { ok: true, data: scrubbedState };
 }
 
-export async function callApi({ aggregatedApiCall, logOptions }: CallApiPayload): Promise<WorkerResponse> {
+export async function callApi({ type, aggregatedApiCall, logOptions }: CallApiPayload): Promise<WorkerResponse> {
   const config = loadConfig();
   setAirnodePrivateKeyToEnv(config.nodeSettings.airnodeWalletMnemonic);
-  const [logs, response] = await handlers.callApi({ config, aggregatedApiCall } as ApiCallPayload);
+  const [logs, response] = await handlers.callApi({ type, config, aggregatedApiCall } as ApiCallPayload);
   logger.logPending(logs, logOptions);
   return { ok: true, data: response };
 }

--- a/packages/airnode-node/src/workers/local-handlers.ts
+++ b/packages/airnode-node/src/workers/local-handlers.ts
@@ -5,13 +5,7 @@ import { go } from '@api3/promise-utils';
 import { loadTrustedConfig, setEnvValue } from '../config';
 import * as handlers from '../handlers';
 import * as state from '../providers/state';
-import {
-  WorkerResponse,
-  InitializeProviderPayload,
-  CallApiPayload,
-  ProcessTransactionsPayload,
-  ApiCallPayload,
-} from '../types';
+import { WorkerResponse, InitializeProviderPayload, CallApiPayload, ProcessTransactionsPayload } from '../types';
 
 function loadConfig() {
   return loadTrustedConfig(path.resolve(`${__dirname}/../../config/config.json`), process.env);
@@ -48,10 +42,10 @@ export async function initializeProvider({ state: providerState }: InitializePro
   return { ok: true, data: scrubbedState };
 }
 
-export async function callApi({ type, aggregatedApiCall, logOptions }: CallApiPayload): Promise<WorkerResponse> {
+export async function callApi({ aggregatedApiCall, logOptions }: CallApiPayload): Promise<WorkerResponse> {
   const config = loadConfig();
   setAirnodePrivateKeyToEnv(config.nodeSettings.airnodeWalletMnemonic);
-  const [logs, response] = await handlers.callApi({ type, config, aggregatedApiCall } as ApiCallPayload);
+  const [logs, response] = await handlers.callApi(config, aggregatedApiCall);
   logger.logPending(logs, logOptions);
   return { ok: true, data: response };
 }

--- a/packages/airnode-node/test/fixtures/aggregated-api-call.ts
+++ b/packages/airnode-node/test/fixtures/aggregated-api-call.ts
@@ -1,13 +1,12 @@
 import {
   RegularAggregatedApiCall,
   HttpSignedDataAggregatedApiCall,
-  HttpAggregatedApiCall,
+  BaseAggregatedApiCall,
   RegularAggregatedApiCallWithResponse,
 } from '../../src/types';
 
 export function buildAggregatedRegularApiCall(params?: Partial<RegularAggregatedApiCall>): RegularAggregatedApiCall {
   return {
-    type: 'regular',
     sponsorAddress: '0x2479808b1216E998309A727df8A0A98A1130A162',
     airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
     requesterAddress: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
@@ -53,9 +52,8 @@ export function buildAggregatedRegularApiCallWithResponse(
   };
 }
 
-export function buildAggregatedHttpGatewayApiCall(params?: Partial<HttpAggregatedApiCall>): HttpAggregatedApiCall {
+export function buildAggregatedHttpGatewayApiCall(params?: Partial<BaseAggregatedApiCall>): BaseAggregatedApiCall {
   return {
-    type: 'http-gateway',
     endpointName: 'convertToUSD',
     oisTitle: 'Currency Converter API',
     parameters: { from: 'ETH' },
@@ -67,7 +65,6 @@ export function buildAggregatedHttpSignedDataApiCall(
   params?: Partial<HttpSignedDataAggregatedApiCall>
 ): HttpSignedDataAggregatedApiCall {
   return {
-    type: 'http-signed-data-gateway',
     endpointId: 'endpointId',
     endpointName: 'convertToUSD',
     id: '0xb56b66dc089eab3dc98672ea5e852488730a8f76621fd9ea719504ea205980f8',


### PR DESCRIPTION
1. This is a draft PR because I've created a new branch out of `private-key-env` to be ahead of possible merge conflicts

2. Main change I did was limiting the required fields on the payload.config object by creating a [new type](https://github.com/api3dao/airnode/blob/f3c9957f8809629372009c97e758061c46ca41bb/packages/airnode-node/src/api/index.ts#L104-L108) using the typescript Pick utility type. I could have created a new type with only those required fields but I wanted to keep backwards compatibility with anyone calling this handler passing the whole config object.