### PR TITLE
Disable renovate dependency dashboard, assign Airnode team as reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,6 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "reviewers": ["team:airnode"]
+  "reviewers": ["team:airnode"],
+  "dependencyDashboard": false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,5 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "reviewers": ["api3dao/airnode"]
+  "reviewers": ["team:airnode"]
 }


### PR DESCRIPTION
See https://github.com/api3dao/airnode/issues/1259 which was automatically opened by renovate and is enabled by default, but we don't really need it. (I think once this is merged renovate will automatically close that issue. If not I'll close it manually).

I also noticed that the Airnode team assignment does not work as expected. There is a fix for that: https://github.com/renovatebot/renovate/discussions/11217