### PR TITLE
Turn off GCP service disabling when removing deployment to enable multiple deployments per project

### DIFF
--- a/.changeset/yellow-emus-remain.md
+++ b/.changeset/yellow-emus-remain.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': patch
+---
+
+Set disable_dependent_services, disable_on_destroy in GCP recipes to false to allow removing one of multiple deployments from the same project

--- a/packages/airnode-deployer/terraform/airnode/gcp/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/main.tf
@@ -1,8 +1,8 @@
 resource "google_project_service" "resourcemanager_api" {
   service = "cloudresourcemanager.googleapis.com"
 
-  disable_dependent_services = true
-  disable_on_destroy         = true
+  disable_dependent_services = false
+  disable_on_destroy         = false
 }
 
 resource "google_project_service" "management_apis" {
@@ -15,8 +15,8 @@ resource "google_project_service" "management_apis" {
   ])
   service = each.key
 
-  disable_dependent_services = true
-  disable_on_destroy         = true
+  disable_dependent_services = false
+  disable_on_destroy         = false
 
   depends_on = [
     google_project_service.resourcemanager_api
@@ -79,8 +79,8 @@ resource "google_project_service" "apigateway_api" {
 
   service = "apigateway.googleapis.com"
 
-  disable_dependent_services = true
-  disable_on_destroy         = true
+  disable_dependent_services = false
+  disable_on_destroy         = false
 
   depends_on = [
     google_project_service.resourcemanager_api
@@ -92,8 +92,8 @@ resource "google_project_service" "servicecontrol_api" {
 
   service = "servicecontrol.googleapis.com"
 
-  disable_dependent_services = true
-  disable_on_destroy         = true
+  disable_dependent_services = false
+  disable_on_destroy         = false
 
   depends_on = [
     google_project_service.resourcemanager_api


### PR DESCRIPTION
Closes #1344.