### PR TITLE
Fix naming for some of the GCP regions

### DIFF
--- a/.changeset/plenty-buttons-rhyme.md
+++ b/.changeset/plenty-buttons-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-deployer': patch
+'@api3/airnode-examples': patch
+---
+
+Fix naming for some of the GCP regions

--- a/packages/airnode-deployer/terraform/airnode/gcp/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/modules/function/main.tf
@@ -97,7 +97,7 @@ resource "google_app_engine_application" "app" {
   count = var.schedule_interval == 0 ? 0 : 1
 
   project     = data.google_project.project.project_id
-  location_id = var.region
+  location_id = local.app_engine_location_id
 }
 
 resource "google_service_account" "scheduler_service_account" {

--- a/packages/airnode-deployer/terraform/airnode/gcp/modules/function/variables.tf
+++ b/packages/airnode-deployer/terraform/airnode/gcp/modules/function/variables.tf
@@ -4,6 +4,10 @@ locals {
   tmp_configuration_dir = "${local.tmp_input_dir}/config-data"
   tmp_handlers_dir      = "${local.tmp_input_dir}/handlers"
   tmp_output_dir        = "${local.tmp_dir}/output"
+  # Two locations, which are called europe-west and us-central in App Engine commands and in the Google Cloud console,
+  # are called europe-west1 and us-central1, respectively, elsewhere in Google documentation.
+  # https://cloud.google.com/appengine/docs/locations
+  app_engine_location_id = var.region == "europe-west1" ? "europe-west" : (var.region == "us-central1" ? "us-central" : var.region)
 }
 
 variable "entry_point" {

--- a/packages/airnode-examples/integrations/coingecko-testable/README.md
+++ b/packages/airnode-examples/integrations/coingecko-testable/README.md
@@ -15,7 +15,7 @@ more information.
 You can trigger the API call with a POST request. For example, you can use `curl` in the terminal:
 
 ```sh
-curl -X POST -H 'x-api-key: <HTTP_GATEWAY_API_KEY>' -d '{"parameters": {"coinId": "bitcoin"}}' '<HTTP_GATEWAY_URL>/<ENDPOINT_ID>'
+curl -X POST -H 'x-api-key: <HTTP_GATEWAY_API_KEY>' -H 'Content-Type: application/json' -d '{"parameters": {"coinId": "bitcoin"}}' '<HTTP_GATEWAY_URL>/<ENDPOINT_ID>'
 ```
 
 ### When deployed on cloud


### PR DESCRIPTION
Close #1380

I tested both the regions and it works now. You provide the name from the documentation (with the `1` at the end) and we "translate" those two region names for the App Engine resource.