### PR TITLE
Fix airnode-client httpGatewayPath

### DIFF
--- a/.changeset/nice-shoes-happen.md
+++ b/.changeset/nice-shoes-happen.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': patch
+---
+
+Fix airnode-client httpGatewayPath by removing extra `/`

--- a/packages/airnode-node/src/workers/local-gateways/server.ts
+++ b/packages/airnode-node/src/workers/local-gateways/server.ts
@@ -119,7 +119,7 @@ export function startGatewayServer(config: Config, enabledGateways: GatewayName[
   }
 
   if (enabledGateways.includes('httpGateway')) {
-    const httpGatewayPath = `/${HTTP_BASE_PATH}/:endpointId`;
+    const httpGatewayPath = `${HTTP_BASE_PATH}/:endpointId`;
     const httpRequestHandler = async function (req: Request, res: Response) {
       logger.log(`Received request for http data`);
 


### PR DESCRIPTION
Removes extra `/` that is present as shown below:

```sh
[2022-08-31 06:22:17.788] INFO HTTP signed data gateway listening for request on "http://localhost:3000/http-signed-data/:endpointId" 
[2022-08-31 06:22:17.793] INFO HTTP (testing) gateway listening for request on "http://localhost:3000//http-data/:endpointId"
```

Compare to: https://github.com/api3dao/airnode/blob/e592573a2434cc16e97812524955c50ae4ba0ead/packages/airnode-node/src/workers/local-gateways/server.ts#L54