### PR TITLE
Fix wrong name in airnode-examples Requester contracts

### DIFF
--- a/.changeset/cold-camels-clean.md
+++ b/.changeset/cold-camels-clean.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-examples': patch
+---
+
+Fix wrong parameter name in Requester contracts

--- a/packages/airnode-examples/contracts/authenticated-coinmarketcap/Requester.sol
+++ b/packages/airnode-examples/contracts/authenticated-coinmarketcap/Requester.sol
@@ -8,7 +8,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/coingecko-post-processing/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko-post-processing/Requester.sol
@@ -14,7 +14,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => FulfillmentData) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/coingecko-pre-processing/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko-pre-processing/Requester.sol
@@ -8,7 +8,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/coingecko-signed-data/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko-signed-data/Requester.sol
@@ -8,7 +8,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/coingecko-template/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko-template/Requester.sol
@@ -8,7 +8,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         bytes32 templateId,

--- a/packages/airnode-examples/contracts/coingecko-testable/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko-testable/Requester.sol
@@ -8,7 +8,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/coingecko/Requester.sol
+++ b/packages/airnode-examples/contracts/coingecko/Requester.sol
@@ -8,7 +8,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/failing-example/Requester.sol
+++ b/packages/airnode-examples/contracts/failing-example/Requester.sol
@@ -8,7 +8,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bool) public incomingFulfillments;
     mapping(bytes32 => int256) public fulfilledData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/relay-security-schemes/Requester.sol
+++ b/packages/airnode-examples/contracts/relay-security-schemes/Requester.sol
@@ -13,7 +13,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => bytes32) public relayedChainType;
     mapping(bytes32 => bytes32) public relayedRequestId;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,

--- a/packages/airnode-examples/contracts/weather-multi-value/Requester.sol
+++ b/packages/airnode-examples/contracts/weather-multi-value/Requester.sol
@@ -11,7 +11,7 @@ contract Requester is RrpRequesterV0 {
     mapping(bytes32 => string) public weatherData;
     mapping(bytes32 => uint256) public timestampData;
 
-    constructor(address airnodeAddress) RrpRequesterV0(airnodeAddress) {}
+    constructor(address airnodeRrp) RrpRequesterV0(airnodeRrp) {}
 
     function makeRequest(
         address airnode,


### PR DESCRIPTION
See the base RRP Requester constructor: https://github.com/api3dao/airnode/blob/master/packages/airnode-protocol/contracts/rrp/requesters/RrpRequesterV0.sol#L23