### PR TITLE
Remove unnecessary async/await

### DIFF
--- a/.changeset/stupid-knives-lick.md
+++ b/.changeset/stupid-knives-lick.md
@@ -1,0 +1,11 @@
+---
+'@api3/airnode-admin': patch
+'@api3/airnode-deployer': patch
+'@api3/airnode-examples': patch
+'@api3/airnode-node': patch
+'@api3/airnode-operation': patch
+'@api3/airnode-protocol': patch
+'@api3/airnode-utilities': patch
+---
+
+Remove unnecessary async/await, enforce it via eslint

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,5 +60,9 @@ module.exports = {
     'no-useless-escape': 'off',
     semi: 'error',
     eqeqeq: ['error', 'smart'],
+
+    // Other
+    'require-await': 'error',
+    'no-return-await': 'error',
   },
 };

--- a/packages/airnode-admin/src/cli.ts
+++ b/packages/airnode-admin/src/cli.ts
@@ -156,7 +156,7 @@ yargs
     {
       'airnode-mnemonic': airnodeMnemonic,
     },
-    async (args) => {
+    (args) => {
       const xpub = admin.deriveAirnodeXpub(args['airnode-mnemonic']);
       logger.log(`Airnode xpub: ${xpub}`);
     }
@@ -168,7 +168,7 @@ yargs
       'airnode-xpub': airnodeXpub,
       'airnode-address': airnodeAddress,
     },
-    async (args) => {
+    (args) => {
       const goVerifyAirnodeXpub = goSync(() => admin.verifyAirnodeXpub(args['airnode-xpub'], args['airnode-address']));
       if (!goVerifyAirnodeXpub.success) {
         logger.error(`Airnode xpub is: INVALID`);

--- a/packages/airnode-admin/src/implementation.ts
+++ b/packages/airnode-admin/src/implementation.ts
@@ -146,7 +146,7 @@ export const verifyAirnodeXpub = (airnodeXpub: string, airnodeAddress: string): 
   return hdNode;
 };
 
-export async function deriveSponsorWalletAddress(airnodeXpub: string, airnodeAddress: string, sponsorAddress: string) {
+export function deriveSponsorWalletAddress(airnodeXpub: string, airnodeAddress: string, sponsorAddress: string) {
   const hdNode = verifyAirnodeXpub(airnodeXpub, airnodeAddress);
   const derivationPath = deriveWalletPathFromSponsorAddress(sponsorAddress);
   return hdNode.derivePath(derivationPath).address;
@@ -254,7 +254,7 @@ export async function checkWithdrawalRequest(airnodeRrp: AirnodeRrpV0, requestId
   return { ...logParams, amount: amount.toString() };
 }
 
-export async function deriveEndpointId(oisTitle: string, endpointName: string) {
+export function deriveEndpointId(oisTitle: string, endpointName: string) {
   return ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['string', 'string'], [oisTitle, endpointName]));
 }
 
@@ -422,7 +422,7 @@ export async function getWhitelistStatus(
   };
 }
 
-export async function isRequesterWhitelisted(
+export function isRequesterWhitelisted(
   requesterAuthorizerWithAirnode: RequesterAuthorizerWithAirnode,
   airnodeAddress: string,
   endpointId: string,
@@ -431,11 +431,11 @@ export async function isRequesterWhitelisted(
   return requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, requesterAddress);
 }
 
-export async function generateMnemonic() {
+export function generateMnemonic() {
   const wallet = ethers.Wallet.createRandom();
   return wallet.mnemonic.phrase;
 }
 
-export async function deriveAirnodeAddress(airnodeMnemonic: string) {
+export function deriveAirnodeAddress(airnodeMnemonic: string) {
   return ethers.Wallet.fromMnemonic(airnodeMnemonic).address;
 }

--- a/packages/airnode-admin/test/e2e/cli.feature.ts
+++ b/packages/airnode-admin/test/e2e/cli.feature.ts
@@ -60,7 +60,7 @@ describe('CLI', () => {
     return goExecSync.data;
   };
 
-  const deriveSponsorWallet = async (airnodeMnemonic: string, sponsorAddress: string): Promise<ethers.Wallet> => {
+  const deriveSponsorWallet = (airnodeMnemonic: string, sponsorAddress: string): ethers.Wallet => {
     return ethers.Wallet.fromMnemonic(
       airnodeMnemonic,
       `m/44'/60'/0'/${admin.deriveWalletPathFromSponsorAddress(sponsorAddress)}`
@@ -178,7 +178,7 @@ describe('CLI', () => {
       // Check that they generate the same wallet address
       expect(out).toBe(`Sponsor wallet address: ${sponsorWallet.address}`);
     });
-    it('errors out with wrong xpub message', async () => {
+    it('errors out with wrong xpub message', () => {
       const sponsorAddress = alice.address;
 
       const randomWallet = ethers.Wallet.createRandom();
@@ -215,7 +215,7 @@ describe('CLI', () => {
       expect(sponsored).toBe(true);
     });
 
-    it('uses transaction overrides', async () => {
+    it('uses transaction overrides', () => {
       const requesterAddress = bob.address;
       expect(() =>
         execCommand(
@@ -285,7 +285,7 @@ describe('CLI', () => {
         ['--template-file-path', `${__dirname}/../fixtures/${fileName}`]
       );
 
-    it('can create template', async () => {
+    it('can create template', () => {
       const out = createTemplate('template.json');
       expect(out).toMatch(new RegExp('Template ID: 0x\\w+'));
     });
@@ -334,7 +334,7 @@ Template data:
   describe('withdrawal', () => {
     let sponsor: ethers.Wallet;
     let sponsorWallet: ethers.Wallet;
-    const sponsorBalance = async () => sponsor.getBalance();
+    const sponsorBalance = () => sponsor.getBalance();
 
     beforeEach(async () => {
       // Prepare for derivation of designated wallet - see test for designated wallet derivation for details
@@ -414,7 +414,7 @@ Template data:
       ).toThrow('Unknown arguments: mnemonic, provider-url, providerUrl, not-existent-command');
     });
 
-    it('mixes legacy and EIP-1559 arguments', async () => {
+    it('mixes legacy and EIP-1559 arguments', () => {
       const requesterAddress = bob.address;
 
       expect(() =>

--- a/packages/airnode-admin/test/e2e/cli.feature.ts
+++ b/packages/airnode-admin/test/e2e/cli.feature.ts
@@ -334,7 +334,7 @@ Template data:
   describe('withdrawal', () => {
     let sponsor: ethers.Wallet;
     let sponsorWallet: ethers.Wallet;
-    const sponsorBalance = async () => await sponsor.getBalance();
+    const sponsorBalance = async () => sponsor.getBalance();
 
     beforeEach(async () => {
       // Prepare for derivation of designated wallet - see test for designated wallet derivation for details

--- a/packages/airnode-admin/test/e2e/sdk.feature.ts
+++ b/packages/airnode-admin/test/e2e/sdk.feature.ts
@@ -39,7 +39,7 @@ describe('SDK', () => {
     sdk = new AdminSdk(airnodeRrp, requesterAuthorizerWithAirnode);
   });
 
-  it('provides same API', async () => {
+  it('provides same API', () => {
     expect(airnodeRrp.address).toBeDefined();
     expect(accessControlRegistry.address).toBeDefined();
     expect(requesterAuthorizerWithAirnode.address).toBeDefined();

--- a/packages/airnode-deployer/src/entrypoint.ts
+++ b/packages/airnode-deployer/src/entrypoint.ts
@@ -5,7 +5,7 @@ if (!cloudProvider) {
 }
 
 async function cloudHandler() {
-  return await import(/* webpackIgnore: true */ `./handlers/${cloudProvider}`);
+  return import(/* webpackIgnore: true */ `./handlers/${cloudProvider}`);
 }
 
 export async function startCoordinator(...args: unknown[]) {

--- a/packages/airnode-deployer/src/entrypoint.ts
+++ b/packages/airnode-deployer/src/entrypoint.ts
@@ -4,7 +4,7 @@ if (!cloudProvider) {
   throw new Error('Missing cloud specification');
 }
 
-async function cloudHandler() {
+function cloudHandler() {
   return import(/* webpackIgnore: true */ `./handlers/${cloudProvider}`);
 }
 

--- a/packages/airnode-deployer/src/handlers/aws/index.ts
+++ b/packages/airnode-deployer/src/handlers/aws/index.ts
@@ -40,7 +40,7 @@ export async function startCoordinator() {
   return { statusCode: 200, body: JSON.stringify(response) };
 }
 
-export async function run(payload: WorkerPayload): Promise<AWSLambda.APIGatewayProxyResult> {
+export function run(payload: WorkerPayload): Promise<AWSLambda.APIGatewayProxyResult> {
   setLogOptions(payload.logOptions);
 
   switch (payload.functionName) {

--- a/packages/airnode-deployer/src/handlers/gcp/index.ts
+++ b/packages/airnode-deployer/src/handlers/gcp/index.ts
@@ -43,7 +43,7 @@ export async function startCoordinator(_req: Request, res: Response) {
   res.status(200).send(response);
 }
 
-export async function run(req: Request, res: Response) {
+export function run(req: Request, res: Response) {
   const payload: WorkerPayload = req.body;
   setLogOptions(payload.logOptions);
 

--- a/packages/airnode-deployer/src/infrastructure/aws.ts
+++ b/packages/airnode-deployer/src/infrastructure/aws.ts
@@ -70,5 +70,5 @@ export async function stateExists(bucket: string, cloudProvider: AwsCloudProvide
   AWS.config.update({ region });
   const s3 = new AWS.S3();
 
-  return await bucketExists(s3, bucket);
+  return bucketExists(s3, bucket);
 }

--- a/packages/airnode-deployer/src/infrastructure/aws.ts
+++ b/packages/airnode-deployer/src/infrastructure/aws.ts
@@ -64,7 +64,7 @@ async function bucketExists(s3: AWS.S3, bucket: string) {
   return true;
 }
 
-export async function stateExists(bucket: string, cloudProvider: AwsCloudProvider) {
+export function stateExists(bucket: string, cloudProvider: AwsCloudProvider) {
   logger.debug('Checking Terraform state existence in AWS');
   const { region } = cloudProvider;
   AWS.config.update({ region });

--- a/packages/airnode-deployer/src/infrastructure/index.ts
+++ b/packages/airnode-deployer/src/infrastructure/index.ts
@@ -69,7 +69,7 @@ async function runCommand(command: string, options: CommandOptions) {
 
 type CommandArg = string | [string, string] | [string, string, string];
 
-async function execTerraform(execOptions: CommandOptions, command: string, args: CommandArg[], options?: string[]) {
+function execTerraform(execOptions: CommandOptions, command: string, args: CommandArg[], options?: string[]) {
   const formattedArgs = formatTerraformArguments(args);
   const fullCommand = compact(['terraform', command, formattedArgs.join(' '), options?.join(' ')]).join(' ');
   return runCommand(fullCommand, execOptions);

--- a/packages/airnode-deployer/src/infrastructure/index.ts
+++ b/packages/airnode-deployer/src/infrastructure/index.ts
@@ -72,7 +72,7 @@ type CommandArg = string | [string, string] | [string, string, string];
 async function execTerraform(execOptions: CommandOptions, command: string, args: CommandArg[], options?: string[]) {
   const formattedArgs = formatTerraformArguments(args);
   const fullCommand = compact(['terraform', command, formattedArgs.join(' '), options?.join(' ')]).join(' ');
-  return await runCommand(fullCommand, execOptions);
+  return runCommand(fullCommand, execOptions);
 }
 
 function awsApplyArguments(cloudProvider: AwsCloudProvider): CommandArg[] {

--- a/packages/airnode-deployer/src/utils/validation.test.ts
+++ b/packages/airnode-deployer/src/utils/validation.test.ts
@@ -14,7 +14,7 @@ describe('config validation', () => {
     expect(notThrowingFunction).not.toThrow();
   });
 
-  it('loads the config with validation and fails because the config is invalid', async () => {
+  it('loads the config with validation and fails because the config is invalid', () => {
     const invalidConfig = JSON.parse(readFileSync(exampleConfigPath, 'utf-8'));
     invalidConfig.nodeSettings.nodeVersion = '0.4.0';
     mockReadFileSync('config.example.json', JSON.stringify(invalidConfig));

--- a/packages/airnode-examples/integrations/coingecko-template/create-secrets.ts
+++ b/packages/airnode-examples/integrations/coingecko-template/create-secrets.ts
@@ -1,7 +1,7 @@
 import { readIntegrationInfo } from '../../src';
 import { writeSecrets } from '../secrets-utils';
 
-const createSecrets = async (generateExampleFile = false) => {
+const createSecrets = (generateExampleFile = false) => {
   const secrets = [
     // NOTE: We use a hardcoded mnemonic for convenience.
     // For production use, make sure to generate the mnemonic from a reliable source.

--- a/packages/airnode-examples/integrations/secrets-utils.ts
+++ b/packages/airnode-examples/integrations/secrets-utils.ts
@@ -10,7 +10,7 @@ const createAirnodeWalletMnemonic = (generateExampleFile: boolean) => {
   return wallet.mnemonic.phrase;
 };
 
-export const getCommonSecrets = async (generateExampleFile: boolean) => {
+export const getCommonSecrets = (generateExampleFile: boolean) => {
   // NOTE: Avoid reading integrationInfo.json when generating example file
   return [
     `AIRNODE_WALLET_MNEMONIC=${createAirnodeWalletMnemonic(generateExampleFile)}`,

--- a/packages/airnode-examples/src/scripts/deploy-airnode.ts
+++ b/packages/airnode-examples/src/scripts/deploy-airnode.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { cliPrint, isWindows, readIntegrationInfo, readPackageVersion, runAndHandleErrors, runShellCommand } from '../';
 
+// eslint-disable-next-line require-await
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
   if (integrationInfo.airnodeType === 'local') {

--- a/packages/airnode-examples/src/scripts/remove-airnode.ts
+++ b/packages/airnode-examples/src/scripts/remove-airnode.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { cliPrint, isWindows, readIntegrationInfo, readPackageVersion, runAndHandleErrors, runShellCommand } from '../';
 
+// eslint-disable-next-line require-await
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
   if (integrationInfo.airnodeType === 'local') {

--- a/packages/airnode-examples/src/scripts/run-airnode-locally.ts
+++ b/packages/airnode-examples/src/scripts/run-airnode-locally.ts
@@ -8,6 +8,7 @@ import {
   isMacOrWindows,
 } from '../';
 
+// eslint-disable-next-line require-await
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
   if (integrationInfo.airnodeType !== 'local') {

--- a/packages/airnode-examples/src/scripts/stop-local-airnode.ts
+++ b/packages/airnode-examples/src/scripts/stop-local-airnode.ts
@@ -1,5 +1,6 @@
 import { cliPrint, readIntegrationInfo, runAndHandleErrors, runShellCommand } from '../';
 
+// eslint-disable-next-line require-await
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
   if (integrationInfo.airnodeType !== 'local') {

--- a/packages/airnode-node/src/api/index.ts
+++ b/packages/airnode-node/src/api/index.ts
@@ -79,7 +79,7 @@ export function buildOptions(payload: ApiCallPayload): adapter.BuildRequestOptio
 export async function signWithRequestId(requestId: string, data: string) {
   const airnodeWallet = getAirnodeWalletFromPrivateKey();
 
-  return await airnodeWallet.signMessage(
+  return airnodeWallet.signMessage(
     ethers.utils.arrayify(
       ethers.utils.keccak256(ethers.utils.solidityPack(['bytes32', 'bytes'], [requestId, data || '0x']))
     )
@@ -89,7 +89,7 @@ export async function signWithRequestId(requestId: string, data: string) {
 export async function signWithTemplateId(templateId: string, timestamp: string, data: string) {
   const airnodeWallet = getAirnodeWalletFromPrivateKey();
 
-  return await airnodeWallet.signMessage(
+  return airnodeWallet.signMessage(
     ethers.utils.arrayify(
       ethers.utils.keccak256(
         ethers.utils.solidityPack(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, data || '0x'])

--- a/packages/airnode-node/src/api/index.ts
+++ b/packages/airnode-node/src/api/index.ts
@@ -76,7 +76,7 @@ export function buildOptions(payload: ApiCallPayload): adapter.BuildRequestOptio
   }
 }
 
-export async function signWithRequestId(requestId: string, data: string) {
+export function signWithRequestId(requestId: string, data: string) {
   const airnodeWallet = getAirnodeWalletFromPrivateKey();
 
   return airnodeWallet.signMessage(
@@ -86,7 +86,7 @@ export async function signWithRequestId(requestId: string, data: string) {
   );
 }
 
-export async function signWithTemplateId(templateId: string, timestamp: string, data: string) {
+export function signWithTemplateId(templateId: string, timestamp: string, data: string) {
   const airnodeWallet = getAirnodeWalletFromPrivateKey();
 
   return airnodeWallet.signMessage(

--- a/packages/airnode-node/src/api/processing.test.ts
+++ b/packages/airnode-node/src/api/processing.test.ts
@@ -52,7 +52,7 @@ describe('processing', () => {
       const parameters = { _type: 'int256', _path: 'price', from: 'TBD' };
       const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
 
-      const throwingFunc = async () => preProcessApiSpecifications({ type: 'regular', config, aggregatedApiCall });
+      const throwingFunc = () => preProcessApiSpecifications({ type: 'regular', config, aggregatedApiCall });
 
       await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
     });
@@ -71,7 +71,7 @@ describe('processing', () => {
       const parameters = { _type: 'int256', _path: 'price', from: '*ETH' };
       const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
 
-      const throwingFunc = async () => preProcessApiSpecifications({ type: 'regular', config, aggregatedApiCall });
+      const throwingFunc = () => preProcessApiSpecifications({ type: 'regular', config, aggregatedApiCall });
 
       await expect(throwingFunc).rejects.toEqual(
         new ZodError([
@@ -126,7 +126,7 @@ describe('post-processing', () => {
     ];
     const endpoint = { ...config.ois[0].endpoints[0], postProcessingSpecifications };
 
-    const throwingFunc = async () => postProcessApiSpecifications({ price: 1000 }, endpoint);
+    const throwingFunc = () => postProcessApiSpecifications({ price: 1000 }, endpoint);
 
     await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
   });

--- a/packages/airnode-node/src/api/processing.ts
+++ b/packages/airnode-node/src/api/processing.ts
@@ -17,19 +17,16 @@ export const preProcessApiSpecifications = async (payload: ApiCallPayload): Prom
 
   const goProcessedParameters = await go(
     async () =>
-      await preProcessingSpecifications.reduce(
-        async (input: Promise<unknown>, currentValue: ProcessingSpecification) => {
-          switch (currentValue.environment) {
-            case 'Node 14':
-              return await unsafeEvaluate(await input, currentValue.value, currentValue.timeoutMs);
-            case 'Node 14 async':
-              return await unsafeEvaluateAsync(await input, currentValue.value, currentValue.timeoutMs);
-            default:
-              throw new Error(`Environment ${currentValue.environment} is not supported`);
-          }
-        },
-        Promise.resolve(aggregatedApiCall.parameters)
-      ),
+      preProcessingSpecifications.reduce(async (input: Promise<unknown>, currentValue: ProcessingSpecification) => {
+        switch (currentValue.environment) {
+          case 'Node 14':
+            return unsafeEvaluate(await input, currentValue.value, currentValue.timeoutMs);
+          case 'Node 14 async':
+            return unsafeEvaluateAsync(await input, currentValue.value, currentValue.timeoutMs);
+          default:
+            throw new Error(`Environment ${currentValue.environment} is not supported`);
+        }
+      }, Promise.resolve(aggregatedApiCall.parameters)),
     { retries: 0, totalTimeoutMs: PROCESSING_TIMEOUT }
   );
 
@@ -58,12 +55,12 @@ export const postProcessApiSpecifications = async (input: unknown, endpoint: End
 
   const goResult = await go(
     async () =>
-      await postProcessingSpecifications.reduce(async (input: any, currentValue: ProcessingSpecification) => {
+      postProcessingSpecifications.reduce(async (input: any, currentValue: ProcessingSpecification) => {
         switch (currentValue.environment) {
           case 'Node 14':
-            return await unsafeEvaluate(await input, currentValue.value, currentValue.timeoutMs);
+            return unsafeEvaluate(await input, currentValue.value, currentValue.timeoutMs);
           case 'Node 14 async':
-            return await unsafeEvaluateAsync(await input, currentValue.value, currentValue.timeoutMs);
+            return unsafeEvaluateAsync(await input, currentValue.value, currentValue.timeoutMs);
           default:
             throw new Error(`Environment ${currentValue.environment} is not supported`);
         }

--- a/packages/airnode-node/src/api/processing.ts
+++ b/packages/airnode-node/src/api/processing.ts
@@ -16,7 +16,7 @@ export const preProcessApiSpecifications = async (payload: ApiCallPayload): Prom
   }
 
   const goProcessedParameters = await go(
-    async () =>
+    () =>
       preProcessingSpecifications.reduce(async (input: Promise<unknown>, currentValue: ProcessingSpecification) => {
         switch (currentValue.environment) {
           case 'Node 14':
@@ -54,7 +54,7 @@ export const postProcessApiSpecifications = async (input: unknown, endpoint: End
   }
 
   const goResult = await go(
-    async () =>
+    () =>
       postProcessingSpecifications.reduce(async (input: any, currentValue: ProcessingSpecification) => {
         switch (currentValue.environment) {
           case 'Node 14':
@@ -64,7 +64,7 @@ export const postProcessApiSpecifications = async (input: unknown, endpoint: End
           default:
             throw new Error(`Environment ${currentValue.environment} is not supported`);
         }
-      }, input),
+      }, Promise.resolve(input)),
 
     { retries: 0, totalTimeoutMs: PROCESSING_TIMEOUT }
   );

--- a/packages/airnode-node/src/api/unsafe-evaluate.ts
+++ b/packages/airnode-node/src/api/unsafe-evaluate.ts
@@ -105,7 +105,7 @@ export const unsafeEvaluate = (input: any, code: string, timeout: number) => {
  *
  * The value given to `resolve` is expected to be the equivalent of `output` above.
  */
-export const unsafeEvaluateAsync = async (input: any, code: string, timeout: number) => {
+export const unsafeEvaluateAsync = (input: any, code: string, timeout: number) => {
   let vmReject: (reason: unknown) => void;
 
   // Make sure the timeout is applied. When the processing snippet uses setTimeout or setInterval, the timeout option

--- a/packages/airnode-node/src/coordinator/calls/coordinated-execution.ts
+++ b/packages/airnode-node/src/coordinator/calls/coordinated-execution.ts
@@ -95,7 +95,7 @@ export async function callApis(
 
   // Execute all pending API calls concurrently
   const calls = pendingAggregatedCalls.map(async (aggregatedApiCall) => {
-    return await execute(aggregatedApiCall, workerOpts);
+    return execute(aggregatedApiCall, workerOpts);
   });
 
   const logsWithresponses = await Promise.all(calls);

--- a/packages/airnode-node/src/coordinator/calls/coordinated-execution.ts
+++ b/packages/airnode-node/src/coordinator/calls/coordinated-execution.ts
@@ -94,9 +94,7 @@ export async function callApis(
   const processLog = logger.pend('INFO', `Processing ${pendingAggregatedCalls.length} pending API call(s)...`);
 
   // Execute all pending API calls concurrently
-  const calls = pendingAggregatedCalls.map(async (aggregatedApiCall) => {
-    return execute(aggregatedApiCall, workerOpts);
-  });
+  const calls = pendingAggregatedCalls.map((aggregatedApiCall) => execute(aggregatedApiCall, workerOpts));
 
   const logsWithresponses = await Promise.all(calls);
   const responseLogs = flatMap(logsWithresponses, (r) => r[0]);

--- a/packages/airnode-node/src/evm/evm-provider.test.ts
+++ b/packages/airnode-node/src/evm/evm-provider.test.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import { buildEVMProvider } from './evm-provider';
 
 describe('buildEVMProvider', () => {
-  it('returns a new JsonRpcProvider instance', async () => {
+  it('returns a new JsonRpcProvider instance', () => {
     const provider = buildEVMProvider('https://some.provider', '3');
     expect(provider).toBeInstanceOf(ethers.providers.JsonRpcProvider);
   });

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.ts
@@ -115,7 +115,7 @@ async function testAndSubmitFulfill(
 ): Promise<LogsErrorData<Request<ApiCallWithResponse>>> {
   const errorMessage = requests.getErrorMessage(request);
   if (errorMessage) {
-    return await submitFail(airnodeRrp, request, errorMessage, options);
+    return submitFail(airnodeRrp, request, errorMessage, options);
   }
 
   // Should not throw

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.ts
@@ -194,13 +194,13 @@ async function submitFail(
 // =================================================================
 // Main functions
 // =================================================================
-export const submitApiCall: SubmitRequest<ApiCallWithResponse> = async (airnodeRrp, request, options) => {
+export const submitApiCall: SubmitRequest<ApiCallWithResponse> = (airnodeRrp, request, options) => {
   if (isNil(request.nonce)) {
     const log = logger.pend(
       'ERROR',
       `API call for Request:${request.id} cannot be submitted as it does not have a nonce`
     );
-    return [[log], null, null];
+    return Promise.resolve([[log], null, null]);
   }
 
   // Should not throw

--- a/packages/airnode-node/src/evm/workers.ts
+++ b/packages/airnode-node/src/evm/workers.ts
@@ -51,14 +51,14 @@ async function spawn<T extends EVMProviderState>(
   return [[], refreshedState];
 }
 
-export async function spawnNewProvider(
+export function spawnNewProvider(
   state: ProviderState<EVMProviderState>,
   workerOpts: WorkerOptions
 ): Promise<LogsData<ProviderState<EVMProviderState> | null>> {
   return spawn(state, workerOpts, 'initializeProvider', 'Unable to initialize provider');
 }
 
-export async function spawnProviderRequestProcessor(
+export function spawnProviderRequestProcessor(
   state: ProviderState<EVMProviderSponsorState>,
   workerOpts: WorkerOptions
 ): Promise<LogsData<ProviderState<EVMProviderSponsorState> | null>> {

--- a/packages/airnode-node/src/handlers/call-api.ts
+++ b/packages/airnode-node/src/handlers/call-api.ts
@@ -1,7 +1,7 @@
 import { ApiCallResponse, LogsData, RegularAggregatedApiCall, RegularApiCallConfig } from '../types';
 import * as api from '../api';
 
-export async function callApi(
+export function callApi(
   config: RegularApiCallConfig,
   aggregatedApiCall: RegularAggregatedApiCall
 ): Promise<LogsData<ApiCallResponse>> {

--- a/packages/airnode-node/src/providers/actions.ts
+++ b/packages/airnode-node/src/providers/actions.ts
@@ -48,7 +48,7 @@ export async function initialize(
   // to configure duplicated providers safely (if they want the added redundancy)
   const evmInitializations = flatMap(
     evmChains.map((chain) => {
-      return map(chain.providers, async (_, providerName) => {
+      return map(chain.providers, (_, providerName) => {
         const state = buildEVMState(coordinatorId, airnodeAddress, chain, providerName, config);
         return initializeEVMProvider(state, workerOpts);
       });

--- a/packages/airnode-node/src/providers/worker.ts
+++ b/packages/airnode-node/src/providers/worker.ts
@@ -1,7 +1,7 @@
 import * as evmWorkers from '../evm/workers';
 import { EVMProviderState, EVMProviderSponsorState, ProviderState, WorkerOptions } from '../types';
 
-export async function spawnNewProvider(state: ProviderState<any>, workerOpts: WorkerOptions) {
+export function spawnNewProvider(state: ProviderState<any>, workerOpts: WorkerOptions) {
   if (state.settings.chainType === 'evm') {
     return evmWorkers.spawnNewProvider(state as ProviderState<EVMProviderState>, workerOpts);
   }
@@ -9,7 +9,7 @@ export async function spawnNewProvider(state: ProviderState<any>, workerOpts: Wo
   throw new Error(`Unknown chain type: ${state.settings.chainType}`);
 }
 
-export async function spawnProviderRequestProcessor(state: ProviderState<any>, workerOpts: WorkerOptions) {
+export function spawnProviderRequestProcessor(state: ProviderState<any>, workerOpts: WorkerOptions) {
   if (state.settings.chainType === 'evm') {
     return evmWorkers.spawnProviderRequestProcessor(state as ProviderState<EVMProviderSponsorState>, workerOpts);
   }

--- a/packages/airnode-operation/src/evm/deploy/account-assignment.ts
+++ b/packages/airnode-operation/src/evm/deploy/account-assignment.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import { Airnode, DeployState as State, SponsorWallet, SponsorAccount } from '../../types';
 import { deriveWalletFromMnemonic, getSponsorWallet } from '../utils';
 
-export async function assignAirnodeAccounts(state: State): Promise<State> {
+export function assignAirnodeAccounts(state: State): State {
   const airnodesByName: { [name: string]: Airnode } = {};
   for (const airnodeName of Object.keys(state.config.airnodes)) {
     const airnode = state.config.airnodes[airnodeName];
@@ -17,7 +17,7 @@ export async function assignAirnodeAccounts(state: State): Promise<State> {
   return { ...state, airnodesByName };
 }
 
-export async function assignRequesterAccounts(state: State): Promise<State> {
+export function assignRequesterAccounts(state: State): State {
   const sponsorsById: { [id: string]: SponsorAccount } = {};
   for (const configSponsor of state.config.sponsors) {
     const sponsorWallet = ethers.Wallet.createRandom().connect(state.provider);
@@ -33,7 +33,7 @@ export async function assignRequesterAccounts(state: State): Promise<State> {
   return { ...state, sponsorsById };
 }
 
-export async function assignSponsorWallets(state: State): Promise<State> {
+export function assignSponsorWallets(state: State): State {
   const sponsorsById: { [id: string]: SponsorAccount } = {};
   for (const configSponsor of state.config.sponsors) {
     const sponsor = state.sponsorsById[configSponsor.id];

--- a/packages/airnode-protocol/scripts/generate-references.ts
+++ b/packages/airnode-protocol/scripts/generate-references.ts
@@ -4,7 +4,7 @@ import { logger } from '@api3/airnode-utilities';
 import { contractNames } from './contract-names';
 const hre = require('hardhat');
 
-async function main() {
+function main() {
   const networkNames = fs
     .readdirSync(path.join('deployments'), { withFileTypes: true })
     .filter((item) => item.isDirectory())

--- a/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.test.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.test.ts
@@ -161,7 +161,9 @@ describe('Gas oracle', () => {
           transactions: Array(20).fill({ gasPrice: ethers.BigNumber.from(20) }),
         },
       ];
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
 
@@ -189,7 +191,9 @@ describe('Gas oracle', () => {
           transactions: Array(20).fill({ maxPriorityFeePerGas: ethers.BigNumber.from(2) }),
         },
       ];
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
 
@@ -202,7 +206,7 @@ describe('Gas oracle', () => {
 
     it('returns providerRecommendedEip1559GasPrice', async () => {
       jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getBlock').mockImplementation(
-        async () =>
+        () =>
           ({
             baseFeePerGas: ethers.BigNumber.from(18),
           } as any)
@@ -234,10 +238,12 @@ describe('Gas oracle', () => {
           transactions: Array(20).fill({ gasPrice: ethers.BigNumber.from(20) }),
         },
       ];
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
       const getGasPriceMock = ethers.BigNumber.from(11);
-      getGasPriceSpy.mockImplementation(async () => getGasPriceMock);
+      getGasPriceSpy.mockImplementation(() => Promise.resolve(getGasPriceMock));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       // Check that the function returned the same value as the strategy-specific function
@@ -267,10 +273,12 @@ describe('Gas oracle', () => {
           transactions: Array(20).fill({ gasPrice: ethers.BigNumber.from(20) }),
         },
       ];
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
       const getGasPriceMock = ethers.BigNumber.from(11);
-      getGasPriceSpy.mockImplementation(async () => getGasPriceMock);
+      getGasPriceSpy.mockImplementation(() => Promise.resolve(getGasPriceMock));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       // Check that the function returned the same value as the strategy-specific function
@@ -303,10 +311,12 @@ describe('Gas oracle', () => {
         },
       ];
 
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
       const getGasPriceMock = ethers.BigNumber.from(11);
-      getGasPriceSpy.mockImplementation(async () => getGasPriceMock);
+      getGasPriceSpy.mockImplementation(() => Promise.resolve(getGasPriceMock));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       // Check that the function returned the same value as the strategy-specific function
@@ -335,10 +345,12 @@ describe('Gas oracle', () => {
         null,
       ];
 
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
       const getGasPriceMock = ethers.BigNumber.from(11);
-      getGasPriceSpy.mockImplementation(async () => getGasPriceMock);
+      getGasPriceSpy.mockImplementation(() => Promise.resolve(getGasPriceMock));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       // Check that the function returned the same value as the strategy-specific function
@@ -369,10 +381,12 @@ describe('Gas oracle', () => {
           transactions: null,
         },
       ];
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
       const getGasPriceMock = ethers.BigNumber.from(11);
-      getGasPriceSpy.mockImplementation(async () => getGasPriceMock);
+      getGasPriceSpy.mockImplementation(() => Promise.resolve(getGasPriceMock));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       // Check that the function returned the same value as the strategy-specific function
@@ -402,9 +416,11 @@ describe('Gas oracle', () => {
           transactions: [{ gasPrice: ethers.BigNumber.from(20) }, { gasPrice: ethers.BigNumber.from(20) }],
         },
       ];
-      blockDataMock.forEach((block) => getBlockWithTransactionsSpy.mockImplementationOnce(async () => block as any));
+      blockDataMock.forEach((block) =>
+        getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
+      );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-      getGasPriceSpy.mockImplementation(async () => {
+      getGasPriceSpy.mockImplementation(() => {
         throw new Error('some error');
       });
 
@@ -421,11 +437,11 @@ describe('Gas oracle', () => {
         ethers.providers.StaticJsonRpcProvider.prototype,
         'getBlockWithTransactions'
       );
-      getBlockWithTransactionsSpy.mockImplementation(async () => {
+      getBlockWithTransactionsSpy.mockImplementation(() => {
         throw new Error('some error');
       });
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-      getGasPriceSpy.mockImplementation(async () => {
+      getGasPriceSpy.mockImplementation(() => {
         throw new Error('some error');
       });
 
@@ -439,7 +455,7 @@ describe('Gas oracle', () => {
 
     it('returns constantGasPrice if processGasPriceOracleStrategies returns null', async () => {
       const processGasPriceOracleStrategiesSpy = jest.spyOn(gasOracle, 'processGasPriceOracleStrategies');
-      processGasPriceOracleStrategiesSpy.mockImplementation(async () => [[], null]);
+      processGasPriceOracleStrategiesSpy.mockImplementation(() => Promise.resolve([[], null]));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       const constantGasPrice = gasOracle.fetchConstantGasPrice(constantGasPriceStrategy);
@@ -452,7 +468,7 @@ describe('Gas oracle', () => {
         ethers.providers.StaticJsonRpcProvider.prototype,
         'getBlockWithTransactions'
       );
-      getBlockWithTransactionsSpy.mockImplementation(async () => {
+      getBlockWithTransactionsSpy.mockImplementation(() => {
         throw new Error('some error');
       });
       // Mock random backoff time
@@ -469,7 +485,7 @@ describe('Gas oracle', () => {
 
     it('retries provider getGasPrice', async () => {
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-      getGasPriceSpy.mockImplementation(async () => {
+      getGasPriceSpy.mockImplementation(() => {
         throw new Error('some error');
       });
       // Mock random backoff time
@@ -498,7 +514,7 @@ describe('Gas oracle', () => {
 
     it('due to processGasPriceOracleStrategies timeout', async () => {
       const processGasPriceOracleStrategiesSpy = jest.spyOn(gasOracle, 'processGasPriceOracleStrategies');
-      processGasPriceOracleStrategiesSpy.mockImplementation(async () => new Promise(() => {})); // never resolve
+      processGasPriceOracleStrategiesSpy.mockImplementation(() => new Promise(() => {})); // never resolve
 
       const gasPricePromise = gasOracle.getGasPrice(provider, defaultChainOptions);
       await advanceTimersByTime(GAS_ORACLE_STRATEGY_MAX_TIMEOUT_MS);
@@ -511,7 +527,7 @@ describe('Gas oracle', () => {
     it('due to attemptGasOracleStrategy timeout', async () => {
       const attemptGasOracleStrategySpy = jest.spyOn(gasOracle, 'attemptGasOracleStrategy');
       attemptGasOracleStrategySpy.mockImplementation(
-        async () => new Promise(() => {}) // never resolve
+        () => new Promise(() => {}) // never resolve
       );
       // Mock random backoff time
       jest.spyOn(global.Math, 'random').mockImplementation(() => 0.4);
@@ -535,11 +551,11 @@ describe('Gas oracle', () => {
         'getBlockWithTransactions'
       );
       getBlockWithTransactionsSpy.mockImplementation(
-        async () => new Promise(() => {}) // never resolve
+        () => new Promise(() => {}) // never resolve
       );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
       getGasPriceSpy.mockImplementation(
-        async () => new Promise(() => {}) // never resolve
+        () => new Promise(() => {}) // never resolve
       );
       const getBlock = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getBlock');
       // Mock random backoff time

--- a/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.test.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.test.ts
@@ -420,9 +420,7 @@ describe('Gas oracle', () => {
         getBlockWithTransactionsSpy.mockImplementationOnce(() => Promise.resolve(block as any))
       );
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-      getGasPriceSpy.mockImplementation(() => {
-        throw new Error('some error');
-      });
+      getGasPriceSpy.mockRejectedValue(new Error('some error'));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       const constantGasPrice = gasOracle.fetchConstantGasPrice(constantGasPriceStrategy);
@@ -437,13 +435,9 @@ describe('Gas oracle', () => {
         ethers.providers.StaticJsonRpcProvider.prototype,
         'getBlockWithTransactions'
       );
-      getBlockWithTransactionsSpy.mockImplementation(() => {
-        throw new Error('some error');
-      });
+      getBlockWithTransactionsSpy.mockRejectedValue(new Error('some error'));
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-      getGasPriceSpy.mockImplementation(() => {
-        throw new Error('some error');
-      });
+      getGasPriceSpy.mockRejectedValue(new Error('some error'));
 
       const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
       const constantGasPrice = gasOracle.fetchConstantGasPrice(constantGasPriceStrategy);
@@ -468,9 +462,7 @@ describe('Gas oracle', () => {
         ethers.providers.StaticJsonRpcProvider.prototype,
         'getBlockWithTransactions'
       );
-      getBlockWithTransactionsSpy.mockImplementation(() => {
-        throw new Error('some error');
-      });
+      getBlockWithTransactionsSpy.mockRejectedValue(new Error('some error'));
       // Mock random backoff time
       jest.spyOn(global.Math, 'random').mockImplementation(() => 0.5);
 
@@ -485,9 +477,7 @@ describe('Gas oracle', () => {
 
     it('retries provider getGasPrice', async () => {
       const getGasPriceSpy = jest.spyOn(ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-      getGasPriceSpy.mockImplementation(() => {
-        throw new Error('some error');
-      });
+      getGasPriceSpy.mockRejectedValue(new Error('some error'));
       // Mock random backoff time
       jest.spyOn(global.Math, 'random').mockImplementation(() => 0.5);
 
@@ -609,12 +599,8 @@ describe('Gas oracle', () => {
     });
 
     it('returns constantGasPrice if all strategy-specific functions throw', async () => {
-      jest.spyOn(gasOracle, 'fetchLatestBlockPercentileGasPrice').mockImplementation(() => {
-        throw new Error('Unexpected error');
-      });
-      jest.spyOn(gasOracle, 'fetchProviderRecommendedGasPrice').mockImplementation(() => {
-        throw new Error('Unexpected error');
-      });
+      jest.spyOn(gasOracle, 'fetchLatestBlockPercentileGasPrice').mockRejectedValue(new Error('Unexpected error'));
+      jest.spyOn(gasOracle, 'fetchProviderRecommendedGasPrice').mockRejectedValue(new Error('Unexpected error'));
 
       const goGasPrice = await go(() => gasOracle.getGasPrice(provider, defaultChainOptions));
       // Ensure that getGasPrice did not throw

--- a/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.ts
@@ -133,15 +133,14 @@ export const fetchLatestBlockPercentileGasPrice = async (
   const blockTagsToFetch = ['latest', -pastToCompareInBlocks];
 
   // Fetch blocks in parallel
-  const blockPromises = blockTagsToFetch.map(
-    async (blockTag) =>
-      await go(() => provider.getBlockWithTransactions(blockTag), {
-        attemptTimeoutMs: GAS_ORACLE_STRATEGY_ATTEMPT_TIMEOUT_MS,
-        totalTimeoutMs: calculateTimeout(startTime, GAS_ORACLE_STRATEGY_MAX_TIMEOUT_MS),
-        retries: 1,
-        delay: { type: 'random', minDelayMs: RANDOM_BACKOFF_MIN_MS, maxDelayMs: RANDOM_BACKOFF_MAX_MS },
-        onAttemptError: (goError) => logger.warn(`Failed attempt to get block. Error: ${goError.error}.`),
-      })
+  const blockPromises = blockTagsToFetch.map(async (blockTag) =>
+    go(() => provider.getBlockWithTransactions(blockTag), {
+      attemptTimeoutMs: GAS_ORACLE_STRATEGY_ATTEMPT_TIMEOUT_MS,
+      totalTimeoutMs: calculateTimeout(startTime, GAS_ORACLE_STRATEGY_MAX_TIMEOUT_MS),
+      retries: 1,
+      delay: { type: 'random', minDelayMs: RANDOM_BACKOFF_MIN_MS, maxDelayMs: RANDOM_BACKOFF_MAX_MS },
+      onAttemptError: (goError) => logger.warn(`Failed attempt to get block. Error: ${goError.error}.`),
+    })
   );
 
   // Reject as soon as possible if fetching a block fails for speed
@@ -212,11 +211,11 @@ export const attemptGasOracleStrategy = async (
 ): Promise<GasTarget> => {
   switch (gasOracleConfig.gasPriceStrategy) {
     case 'latestBlockPercentileGasPrice':
-      return await fetchLatestBlockPercentileGasPrice(provider, gasOracleConfig, startTime);
+      return fetchLatestBlockPercentileGasPrice(provider, gasOracleConfig, startTime);
     case 'providerRecommendedGasPrice':
-      return await fetchProviderRecommendedGasPrice(provider, gasOracleConfig, startTime);
+      return fetchProviderRecommendedGasPrice(provider, gasOracleConfig, startTime);
     case 'providerRecommendedEip1559GasPrice':
-      return await fetchProviderRecommendedEip1559GasPrice(provider, gasOracleConfig, startTime);
+      return fetchProviderRecommendedEip1559GasPrice(provider, gasOracleConfig, startTime);
     default:
       throw new Error('Unsupported gas price oracle strategy.');
   }

--- a/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.ts
@@ -133,7 +133,7 @@ export const fetchLatestBlockPercentileGasPrice = async (
   const blockTagsToFetch = ['latest', -pastToCompareInBlocks];
 
   // Fetch blocks in parallel
-  const blockPromises = blockTagsToFetch.map(async (blockTag) =>
+  const blockPromises = blockTagsToFetch.map((blockTag) =>
     go(() => provider.getBlockWithTransactions(blockTag), {
       attemptTimeoutMs: GAS_ORACLE_STRATEGY_ATTEMPT_TIMEOUT_MS,
       totalTimeoutMs: calculateTimeout(startTime, GAS_ORACLE_STRATEGY_MAX_TIMEOUT_MS),
@@ -204,7 +204,7 @@ export const fetchLatestBlockPercentileGasPrice = async (
   }
 };
 
-export const attemptGasOracleStrategy = async (
+export const attemptGasOracleStrategy = (
   provider: Provider,
   gasOracleConfig: config.GasPriceOracleStrategy,
   startTime: number

--- a/packages/airnode-utilities/test/e2e/gas-oracle.feature.ts
+++ b/packages/airnode-utilities/test/e2e/gas-oracle.feature.ts
@@ -181,9 +181,7 @@ describe('Gas oracle', () => {
           hre.ethers.providers.StaticJsonRpcProvider.prototype,
           'getBlockWithTransactions'
         );
-        getBlockWithTransactionsSpy.mockImplementation(() => {
-          throw new Error('some error');
-        });
+        getBlockWithTransactionsSpy.mockRejectedValue(new Error('some error'));
 
         const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
         const providerRecommendedGasPrice = await gasOracle.fetchProviderRecommendedGasPrice(
@@ -201,12 +199,8 @@ describe('Gas oracle', () => {
           'getBlockWithTransactions'
         );
         const getGasPriceSpy = jest.spyOn(hre.ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-        getBlockWithTransactionsSpy.mockImplementation(() => {
-          throw new Error('some error');
-        });
-        getGasPriceSpy.mockImplementation(() => {
-          throw new Error('some error');
-        });
+        getBlockWithTransactionsSpy.mockRejectedValue(new Error('some error'));
+        getGasPriceSpy.mockRejectedValue(new Error('some error'));
 
         const [_logs, gasTarget] = await gasOracle.getGasPrice(provider, defaultChainOptions);
         const constantGasPrice = gasOracle.fetchConstantGasPrice(constantGasPriceStrategy);
@@ -226,12 +220,8 @@ describe('Gas oracle', () => {
         });
 
         it('returns constantGasPrice if all strategy-specific functions throw', async () => {
-          jest.spyOn(gasOracle, 'fetchLatestBlockPercentileGasPrice').mockImplementation(() => {
-            throw new Error('Unexpected error');
-          });
-          jest.spyOn(gasOracle, 'fetchProviderRecommendedGasPrice').mockImplementation(() => {
-            throw new Error('Unexpected error');
-          });
+          jest.spyOn(gasOracle, 'fetchLatestBlockPercentileGasPrice').mockRejectedValue(new Error('Unexpected error'));
+          jest.spyOn(gasOracle, 'fetchProviderRecommendedGasPrice').mockRejectedValue(new Error('Unexpected error'));
 
           const goGasPrice = await go(() => gasOracle.getGasPrice(provider, defaultChainOptions));
           // Ensure that getGasPrice did not throw

--- a/packages/airnode-utilities/test/e2e/gas-oracle.feature.ts
+++ b/packages/airnode-utilities/test/e2e/gas-oracle.feature.ts
@@ -181,7 +181,7 @@ describe('Gas oracle', () => {
           hre.ethers.providers.StaticJsonRpcProvider.prototype,
           'getBlockWithTransactions'
         );
-        getBlockWithTransactionsSpy.mockImplementation(async () => {
+        getBlockWithTransactionsSpy.mockImplementation(() => {
           throw new Error('some error');
         });
 
@@ -201,10 +201,10 @@ describe('Gas oracle', () => {
           'getBlockWithTransactions'
         );
         const getGasPriceSpy = jest.spyOn(hre.ethers.providers.StaticJsonRpcProvider.prototype, 'getGasPrice');
-        getBlockWithTransactionsSpy.mockImplementation(async () => {
+        getBlockWithTransactionsSpy.mockImplementation(() => {
           throw new Error('some error');
         });
-        getGasPriceSpy.mockImplementation(async () => {
+        getGasPriceSpy.mockImplementation(() => {
           throw new Error('some error');
         });
 


### PR DESCRIPTION
## Problem description

While working in an unrelated feature I installed @api3/airnode-admin and wanted to use `deriveSponsorWalletAddress` function which should be synchronous, but I had to use `await`... 

## Fix

I realized that it's because the function is has the `async` modifier in the implementation, but it doesn't await anything. I added two eslint rules (`require-await` to make sure async is used only when necessary and `no-return-await` to remove unnecessary await).

The implementation mostly removes the unnecessary async/await, but there are a few exception. Some functions need to be asynchronous even though in nature they could be synchronous. There are two workarounds:
- Use `Promise.resolve(value)` 
- Disable the rule for a particular line