### PR TITLE
Fix Terraform dependency cycle error when removing HTTP gateways

### DIFF
--- a/.changeset/fifty-planes-sell.md
+++ b/.changeset/fifty-planes-sell.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': patch
+---
+
+Fix dependency cycle issue when removing HTTP gateways

--- a/packages/airnode-deployer/terraform/aws/modules/function/data.tf
+++ b/packages/airnode-deployer/terraform/aws/modules/function/data.tf
@@ -33,8 +33,8 @@ data "aws_iam_policy_document" "lambda_invoke_policy" {
 
 data "archive_file" "lambda_zip" {
   type        = "zip"
-  output_path = "${local.tmp_output_dir}/${var.name}.zip"
-  source_dir  = local.tmp_input_dir
+  output_path = local.tmp_archive
+  source_dir  = local.tmp_dir
 
-  depends_on = [null_resource.fetch_lambda_files]
+  depends_on = [local_file.index_js, local_file.aws_index_js, local_file.config_json]
 }

--- a/packages/airnode-deployer/terraform/aws/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/aws/modules/function/main.tf
@@ -52,7 +52,11 @@ resource "aws_lambda_function" "lambda" {
   ]
 
   environment {
-    variables = merge(merge(var.environment_variables, fileexists(var.secrets_file) ? { for tuple in regexall("(.*?)=(.*)", file(var.secrets_file)) : tuple[0] => tuple[1] } : {}), { AIRNODE_CLOUD_PROVIDER = "aws" })
+    variables = merge(
+      var.environment_variables,
+      fileexists(var.secrets_file) ? { for tuple in regexall("(.*?)=(.*)", file(var.secrets_file)) : tuple[0] => tuple[1] } : {},
+      { AIRNODE_CLOUD_PROVIDER = "aws" }
+    )
   }
 }
 

--- a/packages/airnode-deployer/terraform/aws/modules/function/variables.tf
+++ b/packages/airnode-deployer/terraform/aws/modules/function/variables.tf
@@ -1,9 +1,7 @@
 locals {
-  tmp_dir               = "/tmp/${var.name}-${random_uuid.uuid.result}"
-  tmp_input_dir         = "${local.tmp_dir}/input"
-  tmp_configuration_dir = "${local.tmp_input_dir}/config-data"
-  tmp_handlers_dir      = "${local.tmp_input_dir}/handlers"
-  tmp_output_dir        = "${local.tmp_dir}/output"
+  uuid        = uuid()
+  tmp_dir     = "/tmp/${var.name}#${local.uuid}"
+  tmp_archive = "/tmp/${var.name}#${local.uuid}.zip"
 }
 
 variable "handler" {

--- a/packages/airnode-deployer/terraform/gcp/modules/function/data.tf
+++ b/packages/airnode-deployer/terraform/gcp/modules/function/data.tf
@@ -3,8 +3,8 @@ data "google_project" "project" {
 
 data "archive_file" "function_zip" {
   type        = "zip"
-  output_path = "${local.tmp_output_dir}/${var.name}.zip"
-  source_dir  = local.tmp_input_dir
+  output_path = local.tmp_archive
+  source_dir  = local.tmp_dir
 
-  depends_on = [null_resource.fetch_function_files]
+  depends_on = [local_file.index_js, local_file.gcp_index_js, local_file.config_json]
 }

--- a/packages/airnode-deployer/terraform/gcp/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/gcp/modules/function/main.tf
@@ -65,7 +65,11 @@ resource "google_cloudfunctions_function" "function" {
   entry_point           = var.entry_point
   timeout               = var.timeout
   max_instances         = var.max_instances
-  environment_variables = merge(merge(var.environment_variables, fileexists(var.secrets_file) ? { for tuple in regexall("(.*?)=(.*)", file(var.secrets_file)) : tuple[0] => tuple[1] } : {}), { AIRNODE_CLOUD_PROVIDER = "gcp" })
+  environment_variables = merge(
+    var.environment_variables,
+    fileexists(var.secrets_file) ? { for tuple in regexall("(.*?)=(.*)", file(var.secrets_file)) : tuple[0] => tuple[1] } : {},
+    { AIRNODE_CLOUD_PROVIDER = "gcp" }
+  )
   service_account_email = google_service_account.function_service_account.email
 }
 

--- a/packages/airnode-deployer/terraform/gcp/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/gcp/modules/function/main.tf
@@ -1,6 +1,3 @@
-resource "random_uuid" "uuid" {
-}
-
 resource "random_string" "function_service_account_id" {
   length  = 20
   lower   = true
@@ -9,23 +6,19 @@ resource "random_string" "function_service_account_id" {
   number  = false
 }
 
-resource "null_resource" "fetch_function_files" {
-  provisioner "local-exec" {
-    command = <<EOC
-rm -rf ${local.tmp_dir}
-mkdir -p "${local.tmp_input_dir}" "${local.tmp_configuration_dir}"
-cp -r "${var.source_dir}/." "${local.tmp_input_dir}"
-rm -rf "${local.tmp_handlers_dir}"
-mkdir -p "${local.tmp_handlers_dir}"
-cp -r "${var.source_dir}/handlers/gcp" "${local.tmp_handlers_dir}/gcp"
-cp "${var.configuration_file}" "${local.tmp_configuration_dir}"
-EOC
-  }
+resource "local_file" "index_js" {
+  source   = "${var.source_dir}/index.js"
+  filename = "${local.tmp_dir}/index.js"
+}
 
-  triggers = {
-    // Run always
-    trigger = uuid()
-  }
+resource "local_file" "gcp_index_js" {
+  source   = "${var.source_dir}/handlers/gcp/index.js"
+  filename = "${local.tmp_dir}/handlers/gcp/index.js"
+}
+
+resource "local_file" "config_json" {
+  source   = var.configuration_file
+  filename = "${local.tmp_dir}/config-data/config.json"
 }
 
 resource "google_service_account" "function_service_account" {

--- a/packages/airnode-deployer/terraform/gcp/modules/function/variables.tf
+++ b/packages/airnode-deployer/terraform/gcp/modules/function/variables.tf
@@ -1,9 +1,7 @@
 locals {
-  tmp_dir               = "/tmp/${var.name}-${random_uuid.uuid.result}"
-  tmp_input_dir         = "${local.tmp_dir}/input"
-  tmp_configuration_dir = "${local.tmp_input_dir}/config-data"
-  tmp_handlers_dir      = "${local.tmp_input_dir}/handlers"
-  tmp_output_dir        = "${local.tmp_dir}/output"
+  uuid        = uuid()
+  tmp_dir     = "/tmp/${var.name}#${local.uuid}"
+  tmp_archive = "/tmp/${var.name}#${local.uuid}.zip"
   # Two locations, which are called europe-west and us-central in App Engine commands and in the Google Cloud console,
   # are called europe-west1 and us-central1, respectively, elsewhere in Google documentation.
   # https://cloud.google.com/appengine/docs/locations


### PR DESCRIPTION
Close #1450

The first two commits are just some cleaning/minor refactor since I was going through the recipes anyway.

The last commit is the fix to #1450. The problem is in the [two lines](https://github.com/api3dao/airnode/blob/master/packages/airnode-deployer/terraform/aws/main.tf#L34-L35) that are passing the gateways' URLs to the coordinator's env variables. At this point, I'm almost certain that the dependency cycle error is a bug in Terraform and shouldn't happen. Even though the coordinator references the gateways (their output), the gateways don't reference the coordinator back, so there should not be any dependency cycle. I may create a minimal reproducible example and open it as an issue. The only solution that works is to condition the whole module instead of the individual environment variables. It's ugly, I don't like it, but, it's the only thing that works. That being said, I would still merge it. Even though the scenario where the error occurs is improbable I would keep the fix even though it complicates the code a bit.

The error doesn't occur with GCP (which is also odd as the structure of the modules and references between them are the same).