### PR TITLE
Migration from 0.8 to 0.9 Airnode

### DIFF
--- a/migration-guides/v0.8->v0.9.md
+++ b/migration-guides/v0.8->v0.9.md
@@ -1,0 +1,68 @@
+## Migration Guide
+
+The following guide assumes a valid v0.8.x `config.json` file. All changes listed below will need to be implemented in
+order to migrate to Airnode v0.9.0. This document is written in a way that will preserve existing behaviour with earlier
+Airnode versions.
+
+The document also mentions changes of the user facing services related to Airnode, such as airnode-deployer,
+airnode-admin and more.
+
+### Summary
+
+ois update to 1.1.2 deployer CLI changes
+
+1. `ois[n].oisFormat` updated to "1.1.2"
+
+2. `nodeSettings.nodeVersion` updated to "0.9.0"
+
+3. `airnode-deployer remove-with-deployment-details` now accepts a full `--airnode-address` argument instead of the
+   short airnode address (`--airnode-address-short`)
+
+### Details
+
+1. `ois[n].oisFormat`
+
+Updated to "1.1.2"
+
+```diff
+{
+-  "oisFormat": "1.0.0"
++  "oisFormat": "1.1.2"
+}
+```
+
+2. `nodeSettings.nodeVersion`
+
+Updated to "0.8.9"
+
+```diff
+{
+-  "nodeVersion": "0.8.0"
++  "nodeVersion": "0.9.0"
+}
+```
+
+3. `airnode-deployer remove-with-deployment-details` accepts `--airnode-address` parameter
+
+In 0.9. the airnode-deployer undergone an internal refactor which improves cloud provider deployments. The only user
+facing change is that deployer no longer uses short Airnode address to remove airnode when using the
+`remove-with-deployment-details` command.
+
+```diff
+- docker run -it --rm \
+-   -v "$(pwd):/app/config" \
+-   api3/airnode-deployer:0.8.0 remove-with-deployment-details \
+-   --airnode-address-short abd9eaa \
+-   --stage dev \
+-   --cloud-provider gcp \
+-   --projectId myAirnode101 \ ← GCP only
+-   --region us-east1
++ docker run -it --rm \
++   -v "$(pwd):/app/config" \
++   api3/airnode-deployer:0.9.0 remove-with-deployment-details \
++   --airnode-address 0xabd9eaa588B6818Ac4C32c5e9b31962E351Cd39F \
++   --stage dev \
++   --cloud-provider gcp \
++   --projectId myAirnode101 \ ← GCP only
++   --region us-east1
+```


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode/issues/1448

Inspired by https://gist.github.com/andreogle/699cb4ddee8b151d594a74acd437b753

The 0.9 release has very few changes, most notably the deployer refactor. We will see if anything else gets added (hence the draft PR).