### PR TITLE
Fix TS errors in generate-references script

### DIFF
--- a/packages/airnode-protocol/package.json
+++ b/packages/airnode-protocol/package.json
@@ -44,6 +44,7 @@
     "typescript": "^4.8.2"
   },
   "dependencies": {
+    "@api3/airnode-utilities": "^0.8.0",
     "@openzeppelin/contracts": "4.4.2",
     "ethers": "^5.7.1"
   }

--- a/packages/airnode-protocol/scripts/generate-references.ts
+++ b/packages/airnode-protocol/scripts/generate-references.ts
@@ -1,45 +1,33 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { logger } from '@api3/airnode-utilities';
 import { contractNames } from './contract-names';
 const hre = require('hardhat');
 
-function main() {
-  const networkNames = fs
-    .readdirSync(path.join('deployments'), { withFileTypes: true })
-    .filter((item) => item.isDirectory())
-    .map((item) => item.name);
+const networkNames = fs
+  .readdirSync(path.join('deployments'), { withFileTypes: true })
+  .filter((item) => item.isDirectory())
+  .map((item) => item.name);
 
-  const references: any = {};
-  references.chainNames = {};
+const references: any = {};
+references.chainNames = {};
 
-  for (const network of networkNames) {
-    references.chainNames[hre.config.networks[network].chainId] = network;
-  }
-
-  for (const contractName of contractNames) {
-    references[contractName] = {};
-
-    for (const network of networkNames) {
-      const deployment = JSON.parse(fs.readFileSync(path.join('deployments', network, `${contractName}.json`), 'utf8'));
-      references[contractName]![hre.config.networks[network].chainId] = deployment.address;
-    }
-  }
-
-  const networks = Object.entries(references.chainNames).reduce((acc, [chainId, name]) => {
-    if (name === 'mainnet') return { ...acc, [parseInt(chainId)]: { chainId: parseInt(chainId), name: 'homestead' } };
-    return { ...acc, [parseInt(chainId)]: { chainId: parseInt(chainId), name } };
-  }, {});
-  references.networks = networks;
-
-  fs.writeFileSync(path.join('deployments', 'references.json'), JSON.stringify(references, null, 2));
+for (const network of networkNames) {
+  references.chainNames[hre.config.networks[network].chainId] = network;
 }
 
-main()
-  .then(() => process.exit(0))
-  .catch((error) => {
-    logger.error(error);
-    process.exit(1);
-  });
+for (const contractName of contractNames) {
+  references[contractName] = {};
 
-export { contractNames };
+  for (const network of networkNames) {
+    const deployment = JSON.parse(fs.readFileSync(path.join('deployments', network, `${contractName}.json`), 'utf8'));
+    references[contractName]![hre.config.networks[network].chainId] = deployment.address;
+  }
+}
+
+const networks = Object.entries(references.chainNames).reduce((acc, [chainId, name]) => {
+  if (name === 'mainnet') return { ...acc, [parseInt(chainId)]: { chainId: parseInt(chainId), name: 'homestead' } };
+  return { ...acc, [parseInt(chainId)]: { chainId: parseInt(chainId), name } };
+}, {});
+references.networks = networks;
+
+fs.writeFileSync(path.join('deployments', 'references.json'), JSON.stringify(references, null, 2));

--- a/packages/airnode-protocol/scripts/tsconfig.json
+++ b/packages/airnode-protocol/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+// This TS config only exist as a TS configuration for the scripts which are invoked via ts-node
+// and don't have to be compiled. For this reason "noEmit" is set to true.
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/packages/airnode-protocol/scripts/tsconfig.json
+++ b/packages/airnode-protocol/scripts/tsconfig.json
@@ -5,5 +5,6 @@
   "compilerOptions": {
     "noEmit": true
   },
+  "references": [{ "path": "../../airnode-utilities/src" }],
   "include": ["./**/*.ts"]
 }

--- a/packages/airnode-protocol/tsconfig.json
+++ b/packages/airnode-protocol/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "files": [],
-  "references": [{ "path": "./src" }, { "path": "./test" }]
+  "references": [{ "path": "./src" }, { "path": "./test" }, { "path": "./scripts" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6165,7 +6165,7 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
-date-fns@^2.29.3:
+date-fns@^2.29.2, date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
@@ -7497,7 +7497,6 @@ ethereumjs-abi@0.6.8, ethereumjs-abi@^0.6.8:
 
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
-  uid ee3994657fa7a427238e6ba92a84d0b529bbcde0
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
   dependencies:
     bn.js "^4.11.8"
@@ -7737,7 +7736,7 @@ ethers@^5.0.1, ethers@^5.0.2, ethers@^5.5.2, ethers@^5.5.3:
     "@ethersproject/web" "5.7.0"
     "@ethersproject/wordlists" "5.7.0"
 
-ethers@^5.7.1:
+ethers@^5.7.0, ethers@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.1.tgz#48c83a44900b5f006eb2f65d3ba6277047fd4f33"
   integrity sha512-5krze4dRLITX7FpU8J4WscXqADiKmyeNlylmmDLbS95DaZpBhDe2YSwRQwKXWNyXcox7a3gBgm/MkGXV1O1S/Q==


### PR DESCRIPTION
The protocol scripts were not TypeChecked by TS and the recent PR which removed all unnecessary async/await broke the script (you can't call `.then` on synchronous function).

This PR adds type checking to the protocol scripts and removes unnecessary wrapper for `generate-references` script.