### PR TITLE
Allow patch-level changes to @api3/ois dependency

### DIFF
--- a/.changeset/happy-trees-act.md
+++ b/.changeset/happy-trees-act.md
@@ -1,0 +1,7 @@
+---
+'@api3/airnode-adapter': minor
+'@api3/airnode-node': minor
+'@api3/airnode-validator': minor
+---
+
+Allow patch-level changes to @api3/ois dependency

--- a/packages/airnode-adapter/package.json
+++ b/packages/airnode-adapter/package.json
@@ -19,7 +19,7 @@
     "test:watch": "yarn test:ts --watch"
   },
   "dependencies": {
-    "@api3/ois": "1.2.0",
+    "@api3/ois": "~1.2",
     "@api3/promise-utils": "^0.3.0",
     "axios": "^0.27.2",
     "bignumber.js": "^9.1.0",

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -29,7 +29,7 @@
     "@api3/airnode-protocol": "^0.8.0",
     "@api3/airnode-utilities": "^0.8.0",
     "@api3/airnode-validator": "^0.8.0",
-    "@api3/ois": "1.2.0",
+    "@api3/ois": "~1.2",
     "@api3/promise-utils": "^0.3.0",
     "aws-sdk": "^2.1219.0",
     "body-parser": "^1.20.0",

--- a/packages/airnode-validator/package.json
+++ b/packages/airnode-validator/package.json
@@ -23,7 +23,7 @@
     "test:e2e:update-snapshot": "yarn test:e2e --updateSnapshot"
   },
   "dependencies": {
-    "@api3/ois": "1.2.0",
+    "@api3/ois": "~1.2",
     "@api3/promise-utils": "^0.3.0",
     "dotenv": "^16.0.2",
     "ethers": "^5.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@api3/ois@1.2.0":
+"@api3/ois@~1.2":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-1.2.0.tgz#752894b7cd2968a53437b9abaa9aef07968359d3"
   integrity sha512-K3d873YhmLCqL0L5op9LBtgPIgcGicC4pNq34olCjhACh3TaowNNk3mFvZrRgUj/TdapiAKvtPtPtvnj1KO2zw==


### PR DESCRIPTION
Follow-up to #1466 based on the suggestion by @amarthadan to relax the OIS dependency in the `package.json` files. 

`~1.2` is the same as `1.2.x` per [tilde ranges](https://github.com/npm/node-semver#tilde-ranges-123-12-1).