### PR TITLE
[v0.8] Update to latest OIS version

### DIFF
--- a/.changeset/stale-gifts-sort.md
+++ b/.changeset/stale-gifts-sort.md
@@ -1,0 +1,9 @@
+---
+'@api3/airnode-adapter': patch
+'@api3/airnode-deployer': patch
+'@api3/airnode-examples': patch
+'@api3/airnode-node': patch
+'@api3/airnode-validator': patch
+---
+
+Update ois version to latest patch

--- a/packages/airnode-adapter/package.json
+++ b/packages/airnode-adapter/package.json
@@ -19,7 +19,7 @@
     "test:watch": "yarn test:ts --watch"
   },
   "dependencies": {
-    "@api3/ois": "1.1.1",
+    "@api3/ois": "1.1.2",
     "@api3/promise-utils": "^0.3.0",
     "axios": "^0.27.2",
     "bignumber.js": "^9.1.0",

--- a/packages/airnode-adapter/test/fixtures/ois.ts
+++ b/packages/airnode-adapter/test/fixtures/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(overrides?: Partial<OIS>): OIS {
   return {
-    oisFormat: '1.1.1',
+    oisFormat: '1.1.2',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-deployer/config/config.example.json
+++ b/packages/airnode-deployer/config/config.example.json
@@ -89,7 +89,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-deployer/package.json
+++ b/packages/airnode-deployer/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.21",
     "ora": "^5.4.1",
     "yargs": "^17.5.1",
-    "zod": "^3.17.3"
+    "zod": "^3.18.0"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "^3.1.2",

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
@@ -77,7 +77,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinMarketCap Basic Authenticated Request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
@@ -84,7 +84,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'CoinMarketCap Basic Authenticated Request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
@@ -77,7 +77,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko coins markets request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
@@ -84,7 +84,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'CoinGecko coins markets request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
@@ -77,7 +77,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko history data request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
@@ -84,7 +84,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'CoinGecko history data request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
@@ -86,7 +86,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
@@ -93,7 +93,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-template/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-template/config.example.json
@@ -83,7 +83,7 @@
   ],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-template/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-template/create-config.ts
@@ -92,7 +92,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   ],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-testable/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-testable/config.example.json
@@ -86,7 +86,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
@@ -93,7 +93,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko/config.example.json
@@ -77,7 +77,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko/create-config.ts
@@ -84,7 +84,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/failing-example/config.example.json
+++ b/packages/airnode-examples/integrations/failing-example/config.example.json
@@ -77,7 +77,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "Failure Example",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/failing-example/create-config.ts
+++ b/packages/airnode-examples/integrations/failing-example/create-config.ts
@@ -84,7 +84,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'Failure Example',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -77,7 +77,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "Relay Security Schemes via httpbin",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -84,7 +84,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'Relay Security Schemes via httpbin',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/weather-multi-value/config.example.json
+++ b/packages/airnode-examples/integrations/weather-multi-value/config.example.json
@@ -77,7 +77,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "OpenWeather Multiple Encoded Values",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
+++ b/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
@@ -84,7 +84,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.1.1',
+      oisFormat: '1.1.2',
       title: 'OpenWeather Multiple Encoded Values',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-node/config/config.example.json
+++ b/packages/airnode-node/config/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "version": "1.2.3",
       "title": "Currency Converter API",
       "apiSpecifications": {

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -29,7 +29,7 @@
     "@api3/airnode-protocol": "^0.8.0",
     "@api3/airnode-utilities": "^0.8.0",
     "@api3/airnode-validator": "^0.8.0",
-    "@api3/ois": "1.1.1",
+    "@api3/ois": "1.1.2",
     "@api3/promise-utils": "^0.3.0",
     "aws-sdk": "^2.1209.0",
     "body-parser": "^1.20.0",
@@ -39,7 +39,7 @@
     "google-auth-library": "^8.5.1",
     "lodash": "^4.17.21",
     "yargs": "^17.5.1",
-    "zod": "^3.17.3"
+    "zod": "^3.18.0"
   },
   "devDependencies": {
     "@api3/airnode-operation": "^0.8.0",

--- a/packages/airnode-node/test/fixtures/config/config.valid.json
+++ b/packages/airnode-node/test/fixtures/config/config.valid.json
@@ -73,7 +73,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.0.0",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-node/test/fixtures/config/ois.ts
+++ b/packages/airnode-node/test/fixtures/config/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(ois?: Partial<OIS>): OIS {
   return {
-    oisFormat: '1.1.1',
+    oisFormat: '1.1.2',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-validator/package.json
+++ b/packages/airnode-validator/package.json
@@ -23,14 +23,14 @@
     "test:e2e:update-snapshot": "yarn test:e2e --updateSnapshot"
   },
   "dependencies": {
-    "@api3/ois": "1.1.1",
+    "@api3/ois": "1.1.2",
     "@api3/promise-utils": "^0.3.0",
     "dotenv": "^16.0.2",
     "ethers": "^5.7.0",
     "lodash": "^4.17.21",
     "ora": "^5.4.1",
     "yargs": "^17.5.1",
-    "zod": "^3.17.3"
+    "zod": "^3.18.0"
   },
   "devDependencies": {
     "@types/yargs": "^17.0.12",

--- a/packages/airnode-validator/test/fixtures/config.valid.json
+++ b/packages/airnode-validator/test/fixtures/config.valid.json
@@ -66,7 +66,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
+++ b/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
@@ -70,7 +70,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
+++ b/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
@@ -66,7 +66,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.1.1",
+      "oisFormat": "1.1.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/ois.json
+++ b/packages/airnode-validator/test/fixtures/ois.json
@@ -1,5 +1,5 @@
 {
-  "oisFormat": "1.1.1",
+  "oisFormat": "1.1.2",
   "version": "1.2.3",
   "title": "coinlayer",
   "apiSpecifications": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,13 +10,13 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@api3/ois@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-1.1.1.tgz#8760c3d4d35435d68a4726ac9d4d17e91e0ac02e"
-  integrity sha512-u7LPVmcstVdgNXnZ0JgWV23NA4SPnT8Uk5PkguFnmMr1Or1J7TO4Iq2lpTJnzJcwUTy52MndCfEMVvGvHJ5Pww==
+"@api3/ois@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-1.1.2.tgz#104dbbe38c864868fa99a7c979230ba992651ee3"
+  integrity sha512-kKF/GtmVewrdhKd/mnAX/UCGs508dcqP/Np/FG7B8I3fX6LAH1Gg3SGXiIQZFQ0V9u8CStsf7CpZj9BVLLri+Q==
   dependencies:
     lodash "^4.17.21"
-    zod "^3.17.3"
+    zod "^3.18.0"
 
 "@api3/promise-utils@^0.3.0":
   version "0.3.0"
@@ -17255,7 +17255,7 @@ zksync-web3@^0.8.1:
   resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.8.1.tgz#db289d8f6caf61f4d5ddc471fa3448d93208dc14"
   integrity sha512-1A4aHPQ3MyuGjpv5X/8pVEN+MdZqMjfVmiweQSRjOlklXYu65wT9BGEOtCmMs5d3gIvLp4ssfTeuR5OCKOD2kw==
 
-zod@^3.17.3:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.18.0.tgz#2eed58b3cafb8d9a67aa2fee69279702f584f3bc"
-  integrity sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==
+zod@^3.18.0:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
+  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==


### PR DESCRIPTION
Basically clone of https://github.com/api3dao/airnode/pull/1423

This new patch version was discussed in https://api3workspace.slack.com/archives/C02AYRX8D89/p1663747786616859?thread_ts=1662763603.054039&cid=C02AYRX8D89

The main point is for Airnode to use the latest patch version of OIS 1.1. 