### PR TITLE
Catch and print docker build errors

### DIFF
--- a/.changeset/fresh-vans-relax.md
+++ b/.changeset/fresh-vans-relax.md
@@ -1,0 +1,7 @@
+---
+'@api3/airnode-admin': minor
+'@api3/airnode-deployer': minor
+'@api3/airnode-node': minor
+---
+
+Throw on docker build error

--- a/.changeset/fresh-vans-relax.md
+++ b/.changeset/fresh-vans-relax.md
@@ -4,4 +4,4 @@
 '@api3/airnode-node': minor
 ---
 
-Throw on docker build error
+Catch and print docker build errors

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,4 +18,5 @@ fi
 yarn bootstrap
 yarn build
 
+export NODE_OPTIONS="--unhandled-rejections=throw"
 yarn ts-node docker/scripts/prepare-containers.ts "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,5 +18,4 @@ fi
 yarn bootstrap
 yarn build
 
-export NODE_OPTIONS="--unhandled-rejections=throw"
 yarn ts-node docker/scripts/prepare-containers.ts "$@"

--- a/docker/scripts/utils.ts
+++ b/docker/scripts/utils.ts
@@ -4,7 +4,20 @@ import { logger } from '@api3/airnode-utilities';
 
 export const runCommand = (command: string, options?: ExecSyncOptions) => {
   logger.log(`Running command: '${command}'${options ? ` with options ${JSON.stringify(options)}` : ''}`);
-  return execSync(command, options);
+  try {
+    return execSync(command, options);
+  } catch (e) {
+    // Thrown Error object contains the entire result from child_process.spawnSync()
+    const err = e as any;
+    throw new Error(
+      [
+        ``,
+        `Command failed with non-zero status code: ${err.status}`,
+        `Stderr: ${err.stderr.toString().trim()}.`,
+        `Stdout: ${err.stdout.toString().trim()}.`,
+      ].join('\n')
+    );
+  }
 };
 
 // Taken from https://github.com/sindresorhus/is-docker


### PR DESCRIPTION
Closes #1493.

Using `throw` within `NODE_OPTIONS='--unhandled-rejections=throw'` as [this is the default for node v15.0.0 and above](https://nodejs.org/api/cli.html#--unhandled-rejectionsmode).

I tested this by inserting `exit 1` before the airnode-admin `docker build` command. Without this PR's change, the build "succeeds" despite the error, which reproduces the previous behavior:
```sh
Running command: 'exit 1; docker build --no-cache --build-arg npmRegistryUrl=http://172.17.0.3:4873 --build-arg npmTag=local --tag api3/airnode-admin-dev:local --file packages/airnode-admin/docker/Dockerfile packa
ges/airnode-admin/docker'
(node:1081) UnhandledPromiseRejectionWarning: Error: Command failed: exit 1; docker build --no-cache --build-arg npmRegistryUrl=http://172.17.0.3:4873 --build-arg npmTag=local --tag api3/airnode-admin-dev:local --
file packages/airnode-admin/docker/Dockerfile packages/airnode-admin/docker
    at checkExecSyncError (child_process.js:790:11)
    at execSync (child_process.js:863:15)
    at runCommand (/build/docker/scripts/utils.ts:7:18)
    at buildContainers (/build/docker/scripts/prepare-containers.ts:57:13)
    at /build/docker/scripts/prepare-containers.ts:71:3
    at Generator.next (<anonymous>)
    at fulfilled (/build/docker/scripts/prepare-containers.ts:11:58)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:1081) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handle
d with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 5
)
(node:1081) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Done in 61.04s.
```

With this PR's change, the process exits as desired, and there are `stdout` and `stderr` outputs, which I think suffices for our purposes (rather than needing everything streamed).
```sh
Running command: 'exit 1; docker build --no-cache --build-arg npmRegistryUrl=http://172.17.0.5:4873 --build-arg npmTag=local --tag api3/airnode-admin-dev:local --file packages/airnode-admin/docker/Dockerfile packa
ges/airnode-admin/docker'
Error: Command failed: exit 1; docker build --no-cache --build-arg npmRegistryUrl=http://172.17.0.5:4873 --build-arg npmTag=local --tag api3/airnode-admin-dev:local --file packages/airnode-admin/docker/Dockerfile
packages/airnode-admin/docker
    at checkExecSyncError (child_process.js:790:11)
    at execSync (child_process.js:863:15)
    at runCommand (/build/docker/scripts/utils.ts:7:18)
    at buildContainers (/build/docker/scripts/prepare-containers.ts:57:13)
    at /build/docker/scripts/prepare-containers.ts:71:3
    at Generator.next (<anonymous>)
    at fulfilled (/build/docker/scripts/prepare-containers.ts:11:58)
    at processTicksAndRejections (internal/process/task_queues.js:95:5) {
  status: 1,
  signal: null,
  output: [ null, Buffer(0) [Uint8Array] [], Buffer(0) [Uint8Array] [] ],
  pid: 1394,
  stdout: Buffer(0) [Uint8Array] [],
  stderr: Buffer(0) [Uint8Array] []
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```