### PR TITLE
Allow publishing snapshot packages to the official NPM registry

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:14.19.3-alpine3.15 AS environment
 
-ENV appDir="/app"
+ENV appDir="/app" \
+    # Settings to true to convince changesets that this is run in the CI and it shouldn't check for or require 2FA auth
+    # https://github.com/changesets/changesets/blob/8c0846977597ddaf51aaeb35f1f0f9428bf8ba14/packages/cli/src/commands/publish/publishPackages.ts#L57
+    CI="true"
 
 RUN apk add --update --no-cache git rsync docker $([ $(arch) == "aarch64" ] && echo "python3 make g++") && \
     yarn global add npm && \

--- a/docker/scripts/cli.ts
+++ b/docker/scripts/cli.ts
@@ -79,9 +79,6 @@ yargs(process.argv.slice(2))
       logger.log(`Running command '${args._[0]}' with arguments ${longArguments(args)}`);
 
       // Temporary check for not yet supported functionality
-      if (args.npmRegistry === 'https://registry.npmjs.org/') {
-        throw new Error('Publishing packages to the official NPM registry is not supported yet');
-      }
       if (!args.snapshot) {
         throw new Error('Only snapshot packages are supported at the moment');
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "docker:scripts:npm-registry:stop": "yarn docker:scripts:npm-registry stop",
     "docker:scripts:publish-packages": "docker run --rm -v $(pwd):/airnode -v /var/run/docker.sock:/var/run/docker.sock api3/airnode-packaging:latest publish-packages",
     "docker:scripts:publish-packages:local": "yarn docker:scripts:publish-packages --npm-registry local --npm-tag local --snapshot",
+    "docker:scripts:publish-packages:snapshot": "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e NPM_TOKEN api3/airnode-packaging:latest publish-packages --snapshot --npm-tag",
     "format:check": "yarn prettier:check && yarn terraform:fmt:check",
     "format:write": "yarn prettier:write && yarn terraform:fmt:write",
     "lint": "yarn run lint:eslint && yarn run lint:solhint && yarn format:check && yarn ts-node scripts/validate-ts-references.ts",


### PR DESCRIPTION
In order to do a snapshot release one must:
1. Retrieve the NPM registry access token and export it: `export NPM_TOKEN=npm_***`
2. Call the yarn `docker:scripts:publish-packages:snapshot` target with the version for which the snapshot should be published: `yarn docker:scripts:publish-packages:snapshot v0.10.0`

Close #1332