### PR TITLE
Fix Terraform boolean interpretation

### DIFF
--- a/.changeset/tricky-starfishes-march.md
+++ b/.changeset/tricky-starfishes-march.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': patch
+---
+
+Fix Terraform boolean interpretation

--- a/packages/airnode-deployer/terraform/aws/main.tf
+++ b/packages/airnode-deployer/terraform/aws/main.tf
@@ -27,7 +27,7 @@ module "run" {
 
 module "startCoordinatorNoGws" {
   source = "./modules/function"
-  count  = var.http_gateway_enabled == false && var.http_signed_data_gateway_enabled == false ? 1 : 0
+  count  = !var.http_gateway_enabled && !var.http_signed_data_gateway_enabled ? 1 : 0
 
   name               = "${local.name_prefix}-startCoordinator"
   handler            = "index.startCoordinator"
@@ -50,7 +50,7 @@ module "startCoordinatorNoGws" {
 
 module "startCoordinatorHttpGw" {
   source = "./modules/function"
-  count  = var.http_gateway_enabled == true && var.http_signed_data_gateway_enabled == false ? 1 : 0
+  count  = var.http_gateway_enabled && !var.http_signed_data_gateway_enabled ? 1 : 0
 
   name               = "${local.name_prefix}-startCoordinator"
   handler            = "index.startCoordinator"
@@ -74,7 +74,7 @@ module "startCoordinatorHttpGw" {
 
 module "startCoordinatorHttpSignedGw" {
   source = "./modules/function"
-  count  = var.http_gateway_enabled == false && var.http_signed_data_gateway_enabled == true ? 1 : 0
+  count  = !var.http_gateway_enabled && var.http_signed_data_gateway_enabled ? 1 : 0
 
   name               = "${local.name_prefix}-startCoordinator"
   handler            = "index.startCoordinator"
@@ -98,7 +98,7 @@ module "startCoordinatorHttpSignedGw" {
 
 module "startCoordinatorBothGws" {
   source = "./modules/function"
-  count  = var.http_gateway_enabled == true && var.http_signed_data_gateway_enabled == true ? 1 : 0
+  count  = var.http_gateway_enabled && var.http_signed_data_gateway_enabled ? 1 : 0
 
   name               = "${local.name_prefix}-startCoordinator"
   handler            = "index.startCoordinator"

--- a/packages/airnode-deployer/terraform/aws/variables.tf
+++ b/packages/airnode-deployer/terraform/aws/variables.tf
@@ -42,32 +42,38 @@ variable "handler_dir" {
 
 variable "max_concurrency" {
   description = "Maximum amount of concurrent executions for Airnode Run Lambda"
+  type        = number
   default     = -1
 }
 
 variable "disable_concurrency_reservation" {
   description = "Flag to disable any concurrency reservations"
+  type        = bool
   default     = false
 }
 
 variable "http_gateway_enabled" {
   description = "Flag to enable HTTP Gateway"
+  type        = bool
   default     = false
 }
 
 variable "http_max_concurrency" {
   description = "Maximum amount of concurrent executions for Airnode HTTP Gateway Lambda"
+  type        = number
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#reserved_concurrent_executions
   default = -1
 }
 
 variable "http_signed_data_gateway_enabled" {
   description = "Flag to enable Signed Data Gateway"
+  type        = bool
   default     = false
 }
 
 variable "http_signed_data_max_concurrency" {
   description = "Maximum amount of concurrent executions for Airnode Signed Data Gateway Lambda"
+  type        = number
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#reserved_concurrent_executions
   default = -1
 }

--- a/packages/airnode-deployer/terraform/gcp/main.tf
+++ b/packages/airnode-deployer/terraform/gcp/main.tf
@@ -71,8 +71,8 @@ module "startCoordinator" {
   airnode_bucket        = var.airnode_bucket
   deployment_bucket_dir = var.deployment_bucket_dir
   environment_variables = {
-    HTTP_GATEWAY_URL             = var.http_gateway_enabled == false ? null : "https://${module.httpGw[0].api_url}/${random_uuid.http_path_key.result}"
-    HTTP_SIGNED_DATA_GATEWAY_URL = var.http_signed_data_gateway_enabled == false ? null : "https://${module.httpSignedGw[0].api_url}${random_uuid.http_signed_data_path_key.result}"
+    HTTP_GATEWAY_URL             = var.http_gateway_enabled ? "https://${module.httpGw[0].api_url}/${random_uuid.http_path_key.result}" : null
+    HTTP_SIGNED_DATA_GATEWAY_URL = var.http_signed_data_gateway_enabled ? "https://${module.httpSignedGw[0].api_url}${random_uuid.http_signed_data_path_key.result}" : null
     AIRNODE_WALLET_PRIVATE_KEY   = var.airnode_wallet_private_key
   }
 
@@ -83,7 +83,7 @@ module "startCoordinator" {
 }
 
 resource "google_project_service" "apigateway_api" {
-  count = var.http_gateway_enabled == false && var.http_signed_data_gateway_enabled == false ? 0 : 1
+  count = var.http_gateway_enabled || var.http_signed_data_gateway_enabled ? 1 : 0
 
   service = "apigateway.googleapis.com"
 
@@ -96,7 +96,7 @@ resource "google_project_service" "apigateway_api" {
 }
 
 resource "google_project_service" "servicecontrol_api" {
-  count = var.http_gateway_enabled == false && var.http_signed_data_gateway_enabled == false ? 0 : 1
+  count = var.http_gateway_enabled || var.http_signed_data_gateway_enabled ? 1 : 0
 
   service = "servicecontrol.googleapis.com"
 
@@ -110,7 +110,7 @@ resource "google_project_service" "servicecontrol_api" {
 
 module "httpReq" {
   source = "./modules/function"
-  count  = var.http_gateway_enabled == false ? 0 : 1
+  count  = var.http_gateway_enabled ? 1 : 0
 
   name                  = "${local.name_prefix}-httpReq"
   entry_point           = "httpReq"
@@ -132,7 +132,7 @@ module "httpReq" {
 
 module "httpGw" {
   source = "./modules/apigateway"
-  count  = var.http_gateway_enabled == false ? 0 : 1
+  count  = var.http_gateway_enabled ? 1 : 0
 
   name          = "${local.name_prefix}-httpGw"
   template_file = "./templates/httpGw.yaml.tpl"
@@ -157,7 +157,7 @@ module "httpGw" {
 
 module "httpSignedReq" {
   source = "./modules/function"
-  count  = var.http_signed_data_gateway_enabled == false ? 0 : 1
+  count  = var.http_signed_data_gateway_enabled ? 1 : 0
 
   name                  = "${local.name_prefix}-httpSignedReq"
   entry_point           = "httpSignedReq"
@@ -182,7 +182,7 @@ module "httpSignedReq" {
 
 module "httpSignedGw" {
   source = "./modules/apigateway"
-  count  = var.http_signed_data_gateway_enabled == false ? 0 : 1
+  count  = var.http_signed_data_gateway_enabled ? 1 : 0
 
   name          = "${local.name_prefix}-httpSignedGw"
   template_file = "./templates/httpSignedGw.yaml.tpl"

--- a/packages/airnode-deployer/terraform/gcp/variables.tf
+++ b/packages/airnode-deployer/terraform/gcp/variables.tf
@@ -46,31 +46,37 @@ variable "handler_dir" {
 
 variable "max_concurrency" {
   description = "Maximum amount of concurrent executions for Airnode Run Cloud function"
+  type        = number
   default     = 0
 }
 
 variable "disable_concurrency_reservation" {
   description = "Flag to disable any concurrency reservations"
+  type        = bool
   default     = false
 }
 
 variable "http_gateway_enabled" {
   description = "Flag to enable HTTP Gateway"
+  type        = bool
   default     = false
 }
 
 variable "http_max_concurrency" {
   description = "Maximum amount of concurrent executions for Airnode HTTP Gateway Cloud Function"
+  type        = number
   default     = 0
 }
 
 variable "http_signed_data_gateway_enabled" {
   description = "Flag to enable Signed Data Gateway"
+  type        = bool
   default     = false
 }
 
 variable "http_signed_data_max_concurrency" {
   description = "Maximum amount of concurrent executions for Airnode Signed Data Gateway Cloud Function"
+  type        = number
   default     = 0
 }
 


### PR DESCRIPTION
Fix #1530

It looks like Terraform doesn't like boolean comparisons (`bool_var == false` vs `!bool_var`) and may also interpret variables from the command line as strings without type being specified. I did change both and it looks like it works correctly now.

Tested only AWS, leaving GCP to @martinkolenic.