### PR TITLE
Change oracle gas strategy fallback log level to WARN

### DIFF
--- a/.changeset/five-seas-drop.md
+++ b/.changeset/five-seas-drop.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-utilities': patch
+---
+
+Change oracle gas strategy fallback log level to WARN

--- a/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.ts
+++ b/packages/airnode-utilities/src/evm/gas-prices/gas-oracle.ts
@@ -287,7 +287,7 @@ export const processGasPriceOracleStrategies = async (
     if (!goAttemptGasOraclePriceStrategy.success) {
       logs.push(
         logger.pend(
-          'ERROR',
+          'WARN',
           `Strategy (${strategy.gasPriceStrategy}) failed to return a gas price. Error: ${goAttemptGasOraclePriceStrategy.error.message}.`
         )
       );


### PR DESCRIPTION
This PR changes `ERROR` to a more appropriate `WARN` for when one of a series of oracle gas strategies fails. Based on [this Discord discussion](https://discord.com/channels/758003776174030948/765618225144266793/1044948715208704040).

Current behavior of a strategy that fails followed by a successful one (log level `INFO`): 
```txt
[2022-11-24 06:11:02.820] ERROR Strategy (latestBlockPercentileGasPrice) failed to return a gas price. Error: Unable to get enough blocks or transactions to calculate percentileGasPrice.. Coordinator-ID:fc7f96081b
ffd482, Chain-ID:31337, Provider:exampleProvider, Endpoint-ID:0xfb87102cdabadf905321521ba0b3cbf74ad09c5d400ac2eccdbef8d6143e78c4, Sponsor-Address:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
[2022-11-24 06:11:02.820] INFO Strategy (providerRecommendedGasPrice) gas price set to 1.394093102 gwei.        Coordinator-ID:fc7f96081bffd482, Chain-ID:31337, Provider:exampleProvider, Endpoint-ID:0xfb87102cdaba
df905321521ba0b3cbf74ad09c5d400ac2eccdbef8d6143e78c4, Sponsor-Address:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
```

~~Creating PR as a draft to further investigate E2E test failures...~~