### PR TITLE
fix: undefined error property in json logging

### DIFF
--- a/.changeset/strong-llamas-laugh.md
+++ b/.changeset/strong-llamas-laugh.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-utilities': patch
+---
+
+Fix logging undefined error property bug

--- a/packages/airnode-utilities/src/logging/logging.ts
+++ b/packages/airnode-utilities/src/logging/logging.ts
@@ -117,7 +117,7 @@ export function logFull(level: LogLevel, message: string, options: LogOptions | 
   }
 
   json(level, message, options);
-  if (level === 'ERROR' && (options as ErrorLogOptions).error!.stack!) {
+  if (level === 'ERROR' && (options as ErrorLogOptions).error?.stack) {
     json('ERROR', (options as ErrorLogOptions).error!.stack!, options);
   }
 }


### PR DESCRIPTION
Closes #1547. Relatively simple fix as the bug appears to just have been a typo of copying the wrong line i.e. the code block several lines above this change has the correct conditional.