### PR TITLE
Skip api call

### DIFF
--- a/.changeset/wicked-socks-peel.md
+++ b/.changeset/wicked-socks-peel.md
@@ -1,0 +1,9 @@
+---
+'@api3/airnode-adapter': minor
+'@api3/airnode-deployer': minor
+'@api3/airnode-examples': minor
+'@api3/airnode-node': minor
+'@api3/airnode-validator': minor
+---
+
+Added API call skip feature.

--- a/packages/airnode-adapter/package.json
+++ b/packages/airnode-adapter/package.json
@@ -19,7 +19,7 @@
     "test:watch": "yarn test:ts --watch"
   },
   "dependencies": {
-    "@api3/ois": "1.2.0",
+    "@api3/ois": "1.3.0",
     "@api3/promise-utils": "^0.3.0",
     "axios": "1.1.3",
     "bignumber.js": "^9.1.0",

--- a/packages/airnode-adapter/src/request-building/build-request.ts
+++ b/packages/airnode-adapter/src/request-building/build-request.ts
@@ -10,7 +10,7 @@ function cacheRequestOptions(options: BuildRequestOptions): CachedBuildRequestOp
     throw new Error(`Endpoint: '${options.endpointName}' not found in the OIS.`);
   }
 
-  const { method, path } = endpoint.operation;
+  const { method, path } = endpoint.operation!;
   const operation = ois.apiSpecifications.paths[path][method]!;
   return { ...options, endpoint, operation };
 }
@@ -25,12 +25,12 @@ export function buildRequest(options: BuildRequestOptions): Request {
   // Different base URLs are not supported at the operation level
   const baseUrl = ois.apiSpecifications.servers[0].url;
   const parameters = buildParameters(cachedOptions);
-  const path = parsePathWithParameters(endpoint.operation.path, parameters.paths);
+  const path = parsePathWithParameters(endpoint.operation!.path, parameters.paths);
 
   return {
     baseUrl,
     path,
-    method: endpoint.operation.method,
+    method: endpoint.operation!.method,
     headers: parameters.headers,
     data: parameters.query,
   };

--- a/packages/airnode-adapter/test/fixtures/ois.ts
+++ b/packages/airnode-adapter/test/fixtures/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(overrides?: Partial<OIS>): OIS {
   return {
-    oisFormat: '1.2.0',
+    oisFormat: '1.3.0',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-adapter/test/fixtures/options.ts
+++ b/packages/airnode-adapter/test/fixtures/options.ts
@@ -25,7 +25,7 @@ export function buildRequestOptions(overrides?: Partial<BuildRequestOptions>): B
 export function buildCacheRequestOptions(overrides?: Partial<CachedBuildRequestOptions>): CachedBuildRequestOptions {
   const options = buildRequestOptions();
   const endpoint = options.ois.endpoints[0];
-  const { method, path } = endpoint.operation;
+  const { method, path } = endpoint.operation!;
   const operation = options.ois.apiSpecifications.paths[path][method]!;
   return {
     ...options,

--- a/packages/airnode-deployer/config/config.example.json
+++ b/packages/airnode-deployer/config/config.example.json
@@ -87,7 +87,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-deployer/test/fixtures/config.aws.valid.json
+++ b/packages/airnode-deployer/test/fixtures/config.aws.valid.json
@@ -90,7 +90,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-deployer/test/fixtures/config.gcp.valid.json
+++ b/packages/airnode-deployer/test/fixtures/config.gcp.valid.json
@@ -90,7 +90,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinMarketCap Basic Authenticated Request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
@@ -85,7 +85,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinMarketCap Basic Authenticated Request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/config.example.json
@@ -90,7 +90,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/create-config.ts
@@ -98,7 +98,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko coins markets request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
@@ -85,7 +85,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinGecko coins markets request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko history data request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
@@ -85,7 +85,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinGecko history data request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/config.example.json
@@ -86,7 +86,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-signed-data/create-config.ts
@@ -93,7 +93,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-template/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-template/config.example.json
@@ -84,7 +84,7 @@
   ],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-template/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-template/create-config.ts
@@ -93,7 +93,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   ],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-testable/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-testable/config.example.json
@@ -86,7 +86,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-testable/create-config.ts
@@ -93,7 +93,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko/create-config.ts
@@ -85,7 +85,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/failing-example/config.example.json
+++ b/packages/airnode-examples/integrations/failing-example/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "Failure Example",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/failing-example/create-config.ts
+++ b/packages/airnode-examples/integrations/failing-example/create-config.ts
@@ -85,7 +85,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'Failure Example',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "Relay Security Schemes via httpbin",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -85,7 +85,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'Relay Security Schemes via httpbin',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/weather-multi-value/config.example.json
+++ b/packages/airnode-examples/integrations/weather-multi-value/config.example.json
@@ -78,7 +78,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "OpenWeather Multiple Encoded Values",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
+++ b/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
@@ -85,7 +85,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '1.2.0',
+      oisFormat: '1.3.0',
       title: 'OpenWeather Multiple Encoded Values',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-node/config/config.example.json
+++ b/packages/airnode-node/config/config.example.json
@@ -79,7 +79,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "version": "1.2.3",
       "title": "Currency Converter API",
       "apiSpecifications": {

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -29,7 +29,7 @@
     "@api3/airnode-protocol": "^0.9.0",
     "@api3/airnode-utilities": "^0.9.0",
     "@api3/airnode-validator": "^0.9.0",
-    "@api3/ois": "1.2.0",
+    "@api3/ois": "1.3.0",
     "@api3/promise-utils": "^0.3.0",
     "aws-sdk": "^2.1243.0",
     "dotenv": "^16.0.3",

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -246,6 +246,11 @@ export interface ApiCallErrorResponse {
   errorMessage: string;
 }
 
+export interface SkipApiCallError {
+  success: false;
+  errorMessage: string;
+}
+
 export type AggregatedApiCall = RegularAggregatedApiCall | HttpSignedDataAggregatedApiCall;
 
 export interface BaseAggregatedApiCall {

--- a/packages/airnode-node/test/fixtures/config/ois.ts
+++ b/packages/airnode-node/test/fixtures/config/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(ois?: Partial<OIS>): OIS {
   return {
-    oisFormat: '1.2.0',
+    oisFormat: '1.3.0',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-validator/package.json
+++ b/packages/airnode-validator/package.json
@@ -21,7 +21,7 @@
     "test:e2e:update-snapshot": "yarn test:e2e --updateSnapshot"
   },
   "dependencies": {
-    "@api3/ois": "1.2.0",
+    "@api3/ois": "1.3.0",
     "@api3/promise-utils": "^0.3.0",
     "dotenv": "^16.0.3",
     "ethers": "^5.7.2",

--- a/packages/airnode-validator/test/fixtures/config.valid.json
+++ b/packages/airnode-validator/test/fixtures/config.valid.json
@@ -79,7 +79,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
+++ b/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
+++ b/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
@@ -67,7 +67,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "1.2.0",
+      "oisFormat": "1.3.0",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/ois.json
+++ b/packages/airnode-validator/test/fixtures/ois.json
@@ -1,5 +1,5 @@
 {
-  "oisFormat": "1.2.0",
+  "oisFormat": "1.3.0",
   "version": "1.2.3",
   "title": "coinlayer",
   "apiSpecifications": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@api3/ois@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-1.2.0.tgz#752894b7cd2968a53437b9abaa9aef07968359d3"
-  integrity sha512-K3d873YhmLCqL0L5op9LBtgPIgcGicC4pNq34olCjhACh3TaowNNk3mFvZrRgUj/TdapiAKvtPtPtvnj1KO2zw==
+"@api3/ois@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-1.3.0.tgz#3780a1bcd439e2fdb1316955d97f5124311ad316"
+  integrity sha512-fdUsK1WwVN6FJUPPwDWpjyJNTg2MCaWYej8rr4bIoFMPvBre9ow7vKMw99+qdAS1P5CZP0Yvba14yacy3f3P4w==
   dependencies:
     lodash "^4.17.21"
     zod "^3.19.1"
@@ -4108,14 +4108,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.0, axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
-axios@^1.0.0, axios@^1.1.3:
+axios@1.1.3, axios@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.1.3.tgz#8274250dada2edf53814ed7db644b9c2866c1e35"
   integrity sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==
@@ -4123,6 +4116,13 @@ axios@^1.0.0, axios@^1.1.3:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
+
+axios@^0.21.0, axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
Added a feature that lets skipping API calls. Instead of API call it uses `output`  of `preProcessingSpecifications`, `postProcessingSpecifications`, or both. To skip API call, `operation` must be undefined, `fixedOperationParameters` must be an empty array and one of `preProcessingSpecifications` or `postProcessingSpecifications` must be defined and not be an empty array.