### PR TITLE
Add rollback command to deployer

### DIFF
--- a/.changeset/sweet-papayas-bake.md
+++ b/.changeset/sweet-papayas-bake.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': minor
+---
+
+Add rollback command to deployer

--- a/packages/airnode-deployer/src/cli/commands.ts
+++ b/packages/airnode-deployer/src/cli/commands.ts
@@ -1,8 +1,11 @@
-import { loadConfig } from '@api3/airnode-node';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadConfig, deriveDeploymentVersionId } from '@api3/airnode-node';
 import { go } from '@api3/promise-utils';
 import { bold } from 'chalk';
-import { deployAirnode, removeAirnode } from '../infrastructure';
-import { writeReceiptFile, parseReceiptFile, parseSecretsFile } from '../utils';
+import { deployAirnode, removeAirnode, saveDeploymentFiles } from '../infrastructure';
+import { writeReceiptFile, parseReceiptFile, parseSecretsFile, deriveAirnodeAddress } from '../utils';
 import * as logger from '../utils/logger';
 import { logAndReturnError, MultiMessageError } from '../utils/infrastructure';
 
@@ -70,6 +73,8 @@ export async function deploy(configPath: string, secretsPath: string, receiptFil
   const output = goDeployAirnode.data;
   if (output.httpGatewayUrl) logger.info(`HTTP gateway URL: ${output.httpGatewayUrl}`);
   if (output.httpSignedDataGatewayUrl) logger.info(`HTTP signed data gateway URL: ${output.httpSignedDataGatewayUrl}`);
+
+  return { creationTime: time };
 }
 
 export async function removeWithReceipt(receiptFilename: string) {
@@ -78,4 +83,38 @@ export async function removeWithReceipt(receiptFilename: string) {
 
   // If the function throws, the CLI will fail with a non zero status code
   await removeAirnode(deploymentId);
+}
+
+export async function rollback(deploymentId: string, versionId: string, receiptFile: string, autoRemove: boolean) {
+  const spinner = logger.getSpinner().start(`Rollback of deployment '${deploymentId}' to version '${versionId}'`);
+  if (logger.inDebugMode()) {
+    spinner.info();
+  }
+
+  const configDirTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'airnode'));
+  const configPathTmp = path.join(configDirTmp, 'config.json');
+  const secretsPathTmp = path.join(configDirTmp, 'secrets.env');
+
+  try {
+    await saveDeploymentFiles(deploymentId, versionId, configPathTmp, secretsPathTmp);
+    const { creationTime } = await deploy(configPathTmp, secretsPathTmp, receiptFile, autoRemove);
+
+    const secrets = parseSecretsFile(secretsPathTmp);
+    const config = loadConfig(configPathTmp, secrets);
+    const { airnodeWalletMnemonic, cloudProvider, stage, nodeVersion } = config.nodeSettings;
+    const airnodeAddress = deriveAirnodeAddress(airnodeWalletMnemonic);
+    const newVersionId = deriveDeploymentVersionId(
+      cloudProvider,
+      airnodeAddress,
+      stage,
+      nodeVersion,
+      `${creationTime.getTime()}`
+    );
+
+    spinner.succeed(
+      `Rollback of deployment '${deploymentId}' successful, new version '${newVersionId}' with configuration from version '${versionId}' created`
+    );
+  } finally {
+    fs.rmSync(configDirTmp, { recursive: true });
+  }
 }

--- a/packages/airnode-deployer/src/cli/index.ts
+++ b/packages/airnode-deployer/src/cli/index.ts
@@ -5,7 +5,7 @@ import sortBy from 'lodash/sortBy';
 import { availableCloudProviders, CloudProvider, version as getNodeVersion } from '@api3/airnode-node';
 import { logger as loggerUtils } from '@api3/airnode-utilities';
 import { go } from '@api3/promise-utils';
-import { deploy, removeWithReceipt } from './commands';
+import { deploy, removeWithReceipt, rollback } from './commands';
 import * as logger from '../utils/logger';
 import { longArguments } from '../utils/cli';
 import { MultiMessageError } from '../utils/infrastructure';
@@ -27,7 +27,7 @@ function drawHeader() {
   );
 }
 
-async function runCommand(command: () => Promise<void>) {
+async function runCommand(command: () => Promise<any>) {
   const goCommand = await go(command);
   if (!goCommand.success) {
     loggerUtils.log('\n\n\nError details:');
@@ -50,6 +50,7 @@ const cliExamples = [
   'list --cloud-providers gcp',
   'info aws808e2a22',
   'fetch-files aws808e2a22',
+  'rollback aws808e2a22 5bbcd317',
   'remove-with-receipt -r config/receipt.json',
   'remove aws808e2a22',
 ];
@@ -211,6 +212,51 @@ yargs(hideBin(process.argv))
       );
       if (!goFetchFiles.success) {
         logger.fail(goFetchFiles.error.message);
+        // eslint-disable-next-line functional/immutable-data
+        process.exitCode = 1;
+      }
+    }
+  )
+  .command(
+    'rollback <deployment-id> <version-id>',
+    'Deploy one of the previous Airnode deployment versions',
+    (yargs) => {
+      yargs.positional('deployment-id', {
+        description: `ID of the deployment (from 'list' command)`,
+        type: 'string',
+      });
+      yargs.positional('version-id', {
+        description: `ID of the deployment version (from 'info' command)`,
+        type: 'string',
+      });
+      yargs.option('receipt', {
+        alias: 'r',
+        description: 'Output path for receipt file',
+        default: 'config/receipt.json',
+        type: 'string',
+      });
+      // Flag arguments without value are not supported. See: https://github.com/yargs/yargs/issues/1532
+      yargs.option('auto-remove', {
+        description: 'Enable automatic removal of deployed resources for failed deployments',
+        default: true,
+        type: 'boolean',
+      });
+    },
+    async (args) => {
+      logger.debugMode(args.debug as boolean);
+      logger.debug(`Running command ${args._[0]} with arguments ${longArguments(args)}`);
+
+      // Looks like due to the bug in yargs (https://github.com/yargs/yargs/issues/1649) we need to specify the types explicitely
+      const goRollback = await go(() =>
+        rollback(
+          args.deploymentId as string,
+          args.versionId as string,
+          args.receipt as string,
+          args.autoRemove as boolean
+        )
+      );
+      if (!goRollback.success) {
+        logger.fail(goRollback.error.message);
         // eslint-disable-next-line functional/immutable-data
         process.exitCode = 1;
       }


### PR DESCRIPTION
Close #1406

At this point `src/infrastructure/index.ts` should be refactored a bit, some common code can be extracted into functions and the whole thing should be divided into separate files. I'm leaving that for a separate issue.