### PR TITLE
fix _gasPrice e2e test and simplify getReservedParameterValue

### DIFF
--- a/.changeset/fresh-penguins-kneel.md
+++ b/.changeset/fresh-penguins-kneel.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': patch
+---
+
+Fix \_gasPrice reserved parameter e2e test

--- a/packages/airnode-node/src/adapters/http/parameters.ts
+++ b/packages/airnode-node/src/adapters/http/parameters.ts
@@ -12,16 +12,7 @@ export function getReservedParameterValue(
     return undefined;
   }
 
-  if (reservedParameter.fixed) {
-    return reservedParameter.fixed;
-  }
-
-  const requestParameter = requestParameters[name];
-  if (!requestParameter) {
-    return reservedParameter.default;
-  }
-
-  return requestParameter;
+  return reservedParameter.fixed || requestParameters[name] || reservedParameter.default;
 }
 
 export function getReservedParameters(endpoint: Endpoint, requestParameters: ApiCallParameters) {


### PR DESCRIPTION
`find` wasn't working as expected with the async callback. This PR corrects that deficiency and improves the robustness of the test by returning the transcation that used the expected `gasPrice`, confirming there was only one such transaction, and re-confirming the `gasPrice`.

The second commit simplifies the return logic of `getReservedParameterValue`