### PR TITLE
Disable number conversion for release CLI

### DIFF
--- a/docker/scripts/cli.ts
+++ b/docker/scripts/cli.ts
@@ -32,6 +32,9 @@ const runCliCommand = (command: () => void) => {
 };
 
 yargs(process.argv.slice(2))
+  .parserConfiguration({
+    'parse-numbers': false,
+  })
   .command('npm-registry', 'Manages the local NPM registry', (yargs) => {
     yargs
       .command('start', 'Start the local NPM registry', {}, (args) => {


### PR DESCRIPTION
By default, yargs tries to parse everything that looks like a number as a number. This is not desired since some version tags (e.g. 0.10) can be parsed as a number but we need their string representation instead ('0.10' v 0.1).