### PR TITLE
Update Airnode to use Node 18

### DIFF
--- a/.changeset/short-donuts-pay.md
+++ b/.changeset/short-donuts-pay.md
@@ -1,0 +1,14 @@
+---
+'@api3/airnode-adapter': minor
+'@api3/airnode-admin': minor
+'@api3/airnode-deployer': minor
+'@api3/airnode-examples': minor
+'@api3/airnode-node': minor
+'@api3/airnode-operation': minor
+'@api3/airnode-protocol': minor
+'@api3/airnode-utilities': minor
+'@api3/airnode-abi': minor
+'@api3/airnode-validator': minor
+---
+
+Bump Node.js from 14 to 18

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  TARGET_NODE_VERSION: '14.19.3'
+  TARGET_NODE_VERSION: '18.14.0'
 
 jobs:
   documentation:

--- a/.github/workflows/protocol-verify.yml
+++ b/.github/workflows/protocol-verify.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  TARGET_NODE_VERSION: '14.19.3'
+  TARGET_NODE_VERSION: '18.14.0'
 
 jobs:
   pre-build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.3-alpine3.15 AS environment
+FROM node:18.14.0-alpine3.17 AS environment
 
 ENV appDir="/app" \
     buildDir="/build" \

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "^14.19.3"
+    "node": "^18.14.0"
   },
   "repository": {
     "type": "git",

--- a/packages/airnode-adapter/package.json
+++ b/packages/airnode-adapter/package.json
@@ -33,7 +33,7 @@
     "@types/mocha": "^10.0.0",
     "chai": "^4.3.6",
     "ethereum-waffle": "^3.4.4",
-    "hardhat": "2.9.9",
+    "hardhat": "2.10.2",
     "jest": "^29.2.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.3",

--- a/packages/airnode-admin/docker/Dockerfile
+++ b/packages/airnode-admin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.3-alpine3.15
+FROM node:18.14.0-alpine3.17
 
 ARG npmRegistryUrl=https://registry.npmjs.org/
 ARG npmTag=latest
@@ -8,9 +8,9 @@ ENV name="airnode-admin" \
 ENV packageName="@api3/${name}"
 
 LABEL application=${name} \
-      description="Airnode Admin CLI"
+    description="Airnode Admin CLI"
 
-    # Install airnode-admin
+# Install airnode-admin
 RUN npm set registry ${npmRegistryUrl} && \
     yarn global add ${packageName}@${npmTag} && \
     ln -s /usr/local/share/.config/yarn/global/node_modules/${packageName}/dist ${appDir} && \

--- a/packages/airnode-deployer/docker/Dockerfile
+++ b/packages/airnode-deployer/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.3-alpine3.15
+FROM node:18.14.0-alpine3.17
 
 ARG npmRegistryUrl=https://registry.npmjs.org/
 ARG npmTag=latest
@@ -9,7 +9,7 @@ ENV name="airnode-deployer" \
 ENV packageName="@api3/${name}"
 
 LABEL application=${name} \
-      description="Airnode Deployer CLI"
+    description="Airnode Deployer CLI"
 
 COPY ./entrypoint.sh /entrypoint.sh
 

--- a/packages/airnode-deployer/terraform/aws/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/aws/modules/function/main.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_function" "lambda" {
   function_name                  = var.name
   handler                        = var.handler
   memory_size                    = var.memory_size
-  runtime                        = "nodejs14.x"
+  runtime                        = "nodejs18.x"
   role                           = aws_iam_role.lambda_role.arn
   timeout                        = var.timeout
   reserved_concurrent_executions = var.reserved_concurrent_executions

--- a/packages/airnode-deployer/terraform/gcp/modules/function/main.tf
+++ b/packages/airnode-deployer/terraform/gcp/modules/function/main.tf
@@ -56,7 +56,7 @@ resource "google_storage_bucket_object" "function_zip" {
 
 resource "google_cloudfunctions_function" "function" {
   name    = var.name
-  runtime = "nodejs14"
+  runtime = "nodejs18"
 
   available_memory_mb   = var.memory_size
   source_archive_bucket = google_storage_bucket_object.function_zip.bucket

--- a/packages/airnode-examples/package.json
+++ b/packages/airnode-examples/package.json
@@ -50,7 +50,7 @@
     "chalk": "^4.1.2",
     "dotenv": "^16.0.3",
     "ethereum-waffle": "^3.4.4",
-    "hardhat": "2.9.9",
+    "hardhat": "2.10.2",
     "jest": "^29.2.2",
     "prompts": "^2.4.2",
     "ts-jest": "^29.0.3",

--- a/packages/airnode-node/docker/Dockerfile
+++ b/packages/airnode-node/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.3-alpine3.15
+FROM node:18.14.0-alpine3.17
 
 ARG npmRegistryUrl=https://registry.npmjs.org/
 ARG npmTag=latest
@@ -9,12 +9,12 @@ ENV name="airnode-client" \
 ENV cronjob="/etc/cron.d/${name}"
 
 LABEL application=${name} \
-      description="Airnode Client"
+    description="Airnode Client"
 
 COPY airnode-crontab ${cronjob}
 COPY entrypoint.sh /entrypoint.sh
 
-    # Install Tini to correctly pass signals
+# Install Tini to correctly pass signals
 RUN apk add --update --no-cache tini dos2unix && \
     # Install airnode-node
     npm set registry ${npmRegistryUrl} && \

--- a/packages/airnode-node/src/handlers/initialize-provider.test.ts
+++ b/packages/airnode-node/src/handlers/initialize-provider.test.ts
@@ -1,14 +1,20 @@
+import { ethers } from 'ethers';
 import { initializeProvider } from './initialize-provider';
 import * as evmHandler from '../evm/handlers/initialize-provider';
 import * as fixtures from '../../test/fixtures';
 
 describe('initializeProvider', () => {
+  jest.setTimeout(30_000);
   fixtures.setEnvVariables({ AIRNODE_WALLET_PRIVATE_KEY: fixtures.getAirnodeWalletPrivateKey() });
 
-  it('initializes EVM providers', () => {
+  it('initializes EVM providers', async () => {
+    const getBlockNumberSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlockNumber');
+    const currentBlockNumber = 18;
+    getBlockNumberSpy.mockResolvedValueOnce(currentBlockNumber);
+
     const initializeSpy = jest.spyOn(evmHandler, 'initializeProvider');
     const state = fixtures.buildEVMProviderState();
-    initializeProvider(state);
+    await initializeProvider(state);
     expect(initializeSpy).toHaveBeenCalledTimes(1);
     expect(initializeSpy).toHaveBeenCalledWith(state);
   });

--- a/packages/airnode-node/src/handlers/process-http-request.test.ts
+++ b/packages/airnode-node/src/handlers/process-http-request.test.ts
@@ -12,6 +12,7 @@ function buildConfigWithEndpoint(endpoint?: Endpoint) {
 }
 
 describe('processHttpRequest', () => {
+  jest.setTimeout(10_000);
   it('returns an error if endpoint testability is turned off', async () => {
     const endpoint = fixtures.buildOIS().endpoints[0];
     const config = buildConfigWithEndpoint(endpoint);

--- a/packages/airnode-operation/hardhat.config.ts
+++ b/packages/airnode-operation/hardhat.config.ts
@@ -13,7 +13,7 @@ const config: HardhatUserConfig = {
         // related accounts. Make sure they have more than enough ETH to
         // do this (1m ETH each).
         accountsBalance: '1000000000000000000000000',
-        count: 1000,
+        count: 100,
       },
     },
     localhost: {

--- a/packages/airnode-operation/package.json
+++ b/packages/airnode-operation/package.json
@@ -33,7 +33,7 @@
     "@api3/airnode-utilities": "^0.10.0",
     "ethers": "^5.7.2",
     "express": "^4.18.2",
-    "hardhat": "2.9.9",
+    "hardhat": "2.10.2",
     "morgan": "^1.10.0",
     "pm2": "^5.2.2"
   },

--- a/packages/airnode-protocol/package.json
+++ b/packages/airnode-protocol/package.json
@@ -35,7 +35,7 @@
     "chai": "^4.3.6",
     "copyfiles": "^2.4.1",
     "ethereum-waffle": "^3.4.4",
-    "hardhat": "2.9.9",
+    "hardhat": "2.10.2",
     "hardhat-deploy": "^0.11.19",
     "hardhat-gas-reporter": "^1.0.9",
     "replace-in-file": "^6.3.5",

--- a/packages/airnode-utilities/package.json
+++ b/packages/airnode-utilities/package.json
@@ -27,7 +27,7 @@
     "@nomiclabs/hardhat-ethers": "^2.2.1",
     "@types/jest": "^29.2.0",
     "@types/node": "^17.0.18",
-    "hardhat": "2.9.9",
+    "hardhat": "2.10.2",
     "jest": "^29.2.2",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,7 +2729,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1", "@solidity-parser/parser@^0.14.3":
+"@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1", "@solidity-parser/parser@^0.14.2", "@solidity-parser/parser@^0.14.3":
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.5.tgz#87bc3cc7b068e08195c219c91cd8ddff5ef1a804"
   integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
@@ -2796,9 +2796,9 @@
     ethers "^5.0.2"
 
 "@types/abstract-leveldown@*":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz#f055979a99f7654e84d6b8e6267419e9c4cfff87"
-  integrity sha512-q5veSX6zjUy/DlDhR4Y4cU0k2Ar+DT2LUraP00T19WLmTO6Se1djepCCaqU6nQrwcJ5Hyo/CWqxTzrrFg8eqbQ==
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-7.2.1.tgz#bb16403c17754b0c4d5772d71d03b924a03d4c80"
+  integrity sha512-YK8irIC+eMrrmtGx0H4ISn9GgzLd9dojZWJaMbjp1YHLl2VqqNFBNrL5Q3KjGf4VE3sf/4hmq6EhQZ7kZp1NoQ==
 
 "@types/adm-zip@^0.5.0":
   version "0.5.0"
@@ -3339,11 +3339,6 @@
   dependencies:
     "@typescript-eslint/types" "5.41.0"
     eslint-visitor-keys "^3.3.0"
-
-"@ungap/promise-all-settled@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
-  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
 "@vercel/ncc@^0.34.0":
   version "0.34.0"
@@ -6273,17 +6268,10 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1:
+debug@4, debug@4.3.4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
@@ -7527,7 +7515,7 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha512-EoltVQTRNg2Uy4o84qpa2aXymXDJhxm7eos/ACOg0DG4baAbMjhbdAEsx9GeE8sC3XCxnYvrrzZDH8D8MtA2iQ==
 
-ethereum-cryptography@^0.1.2, ethereum-cryptography@^0.1.3:
+ethereum-cryptography@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz#8d6143cfc3d74bf79bbd8edecdf29e4ae20dd191"
   integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
@@ -9099,10 +9087,10 @@ hardhat-gas-reporter@^1.0.9:
     eth-gas-reporter "^0.2.25"
     sha1 "^1.1.1"
 
-hardhat@2.9.9:
-  version "2.9.9"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.9.9.tgz#05c1015eb73e0230309534b00deeb080724aace0"
-  integrity sha512-Qv7SXnRc0zq1kGXruNnSKpP3eFccXMR5Qv6GVX9hBIJ5efN0PflKPq92aQ5Cv3jrjJeRevLznWZVz7bttXhVfw==
+hardhat@2.10.2:
+  version "2.10.2"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.10.2.tgz#ff94ee4cb144a9c114641581ff5e4d7bea5f93a9"
+  integrity sha512-L/KvDDT/MA6332uAtYTqdcHoSABljw4pPjHQe5SHdIJ+xKfaSc6vDKw03CmrQ5Xup0gHs8XnVSBpZo1AbbIW7g==
   dependencies:
     "@ethereumjs/block" "^3.6.2"
     "@ethereumjs/blockchain" "^5.5.2"
@@ -9112,7 +9100,7 @@ hardhat@2.9.9:
     "@ethersproject/abi" "^5.1.2"
     "@metamask/eth-sig-util" "^4.0.0"
     "@sentry/node" "^5.18.1"
-    "@solidity-parser/parser" "^0.14.1"
+    "@solidity-parser/parser" "^0.14.2"
     "@types/bn.js" "^5.1.0"
     "@types/lru-cache" "^5.1.0"
     abort-controller "^3.0.0"
@@ -9125,7 +9113,7 @@ hardhat@2.9.9:
     debug "^4.1.1"
     enquirer "^2.3.0"
     env-paths "^2.2.0"
-    ethereum-cryptography "^0.1.2"
+    ethereum-cryptography "^1.0.3"
     ethereumjs-abi "^0.6.8"
     ethereumjs-util "^7.1.4"
     find-up "^2.1.0"
@@ -9137,7 +9125,7 @@ hardhat@2.9.9:
     lodash "^4.17.11"
     merkle-patricia-tree "^4.2.4"
     mnemonist "^0.38.0"
-    mocha "^9.2.0"
+    mocha "^10.0.0"
     p-map "^4.0.0"
     qs "^6.7.0"
     raw-body "^2.4.1"
@@ -11742,12 +11730,12 @@ minimatch@3.0.5:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-4.2.1.tgz#40d9d511a46bdc4e563c22c3080cde9c0d8299b4"
-  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
   dependencies:
-    brace-expansion "^1.1.7"
+    brace-expansion "^2.0.1"
 
 minimatch@^5.0.1:
   version "5.1.0"
@@ -11932,6 +11920,33 @@ mocha@7.1.2:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
+mocha@^10.0.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+  dependencies:
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "5.0.1"
+    ms "2.1.3"
+    nanoid "3.3.3"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    workerpool "6.2.1"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
+
 mocha@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.2.0.tgz#01cc227b00d875ab1eed03a75106689cfed5a604"
@@ -11961,36 +11976,6 @@ mocha@^7.1.1:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
-
-mocha@^9.2.0:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.2.tgz#d70db46bdb93ca57402c809333e5a84977a88fb9"
-  integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
-  dependencies:
-    "@ungap/promise-all-settled" "1.1.2"
-    ansi-colors "4.1.1"
-    browser-stdout "1.3.1"
-    chokidar "3.5.3"
-    debug "4.3.3"
-    diff "5.0.0"
-    escape-string-regexp "4.0.0"
-    find-up "5.0.0"
-    glob "7.2.0"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "4.1.0"
-    log-symbols "4.1.0"
-    minimatch "4.2.1"
-    ms "2.1.3"
-    nanoid "3.3.1"
-    serialize-javascript "6.0.0"
-    strip-json-comments "3.1.1"
-    supports-color "8.1.1"
-    which "2.0.2"
-    workerpool "6.2.0"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
-    yargs-unparser "2.0.0"
 
 mock-fs@^4.1.0:
   version "4.14.0"
@@ -12113,10 +12098,10 @@ nano-json-stream-parser@^0.1.2:
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
   integrity sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==
 
-nanoid@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -16657,7 +16642,7 @@ which@1.3.1, which@^1.1.1, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@2.0.2, which@^2.0.1, which@^2.0.2:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -16706,10 +16691,10 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-workerpool@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
-  integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
+workerpool@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Closes #1631 and closes #1346. While this doesn't address https://github.com/api3dao/airnode/issues/1544, that can be done after (given it requires another OIS release) as the engine specification doesn't actually appear to enforce version 14 of `Node 14`.

~~Edit: The `airnode-node` unit tests all pass, yet the step fails...  Trying to isolate / reproduce.~~ Found the failing test and fixed it.