### PR TITLE
Revert back to using beacon array for OEV gateway request/response

### DIFF
--- a/.changeset/sour-dodos-look.md
+++ b/.changeset/sour-dodos-look.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-deployer': patch
+'@api3/airnode-node': patch
+---
+
+Revert back to using beacon array for OEV gateway request/response

--- a/packages/airnode-deployer/terraform/aws/templates/oevGw.yaml.tpl
+++ b/packages/airnode-deployer/terraform/aws/templates/oevGw.yaml.tpl
@@ -74,7 +74,7 @@ components:
       type: array
       minItems: 1
       items:
-        type: integer
+        type: string
 
   examples:
     EndpointRequestExample:

--- a/packages/airnode-deployer/terraform/aws/templates/oevGw.yaml.tpl
+++ b/packages/airnode-deployer/terraform/aws/templates/oevGw.yaml.tpl
@@ -40,8 +40,10 @@ components:
         bidAmount:
           type: string
         beacons:
-          type: object
-          additionalProperties:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
             type: object
             required:
               - airnodeAddress
@@ -69,9 +71,10 @@ components:
                     type: string
 
     EndpointResponse:
-      type: object
-      additionalProperties:
-        type: string
+      type: array
+      minItems: 1
+      items:
+        type: integer
 
   examples:
     EndpointRequestExample:
@@ -84,29 +87,31 @@ components:
           "updateId": "0x...",
           "bidderAddress": "0x...",
           "bidAmount": "123...",
-          "beacons": {
-            "beaconId1": {
+          "beacons": [
+            {
               "airnodeAddress": "0x...",
               "endpointId": "0x...",
               "encodedParameters": "0x...",
-              "timestamp": "16...",
-              "encodedValue": "0x...",
-              "signature": "0x..."
+              "signedData": {
+                "timestamp": "16...",
+                "encodedValue": "0x...",
+                "signature": "0x..."
+              }
             },
-            "beaconId2": {
+            {
               "airnodeAddress": "0x...",
               "endpointId": "0x...",
               "encodedParameters": "0x..."
             }
-          }
+          ]
         }
     EndpointResponseExample:
       summary: Endpoint response example
       value: |
-        {
-          "beaconId1": "0x...",
-          "beaconId2": "0x...",
-        }
+        [
+          "0x...",
+          "0x...",
+        ]
 
 paths:
   /${path_key}:

--- a/packages/airnode-node/src/handlers/sign-oev-data.test.ts
+++ b/packages/airnode-node/src/handlers/sign-oev-data.test.ts
@@ -56,10 +56,9 @@ describe('signOevData', () => {
 
     expect(err).toBeNull();
     expect(res!.success).toBeTruthy();
-    expect(res!.data).toEqual({
-      '0x1032c3cbea7692429f3f1bdb72c47b5c61bdd3ca995a763027f8aa511b42b11b':
-        '0xe88e4110be68b36b8416b87135c894951724b3cc140fd0a2fe7d0d51cc73dcff2bc6cd8bcf69adb39b3b01304e266ad1b81291e8214466af0c418e1b702168ba1b',
-    });
+    expect(res!.data).toEqual([
+      '0xe88e4110be68b36b8416b87135c894951724b3cc140fd0a2fe7d0d51cc73dcff2bc6cd8bcf69adb39b3b01304e266ad1b81291e8214466af0c418e1b702168ba1b',
+    ]);
   });
 
   it('signs the OEV data for beacon set', async () => {
@@ -71,11 +70,9 @@ describe('signOevData', () => {
 
     expect(err).toBeNull();
     expect(res!.success).toBeTruthy();
-    expect(res!.data).toEqual({
-      '0x1032c3cbea7692429f3f1bdb72c47b5c61bdd3ca995a763027f8aa511b42b11b':
-        '0xf990802abc67a45b901bc30084c472b43937e0d2d67e76b352d8841ac80fe0c54d2e95252a4921a61daf3783f24b3d7e7e7479a2cae7e22ae4aea314fda5d8f91b',
-      '0xd6965b1162b263e4dac3084ff0589614a464ac3e4ca012cb90ebb73094f7204e':
-        '0xd6264e508ec92085a96c15b27d11e1e228b8afd06b57c039efe836df92f247a9660862c030eb38c9549a69dacb7ed2daf5c1140a2af92f0cffbd1419a04286061c',
-    });
+    expect(res!.data).toEqual([
+      '0xf990802abc67a45b901bc30084c472b43937e0d2d67e76b352d8841ac80fe0c54d2e95252a4921a61daf3783f24b3d7e7e7479a2cae7e22ae4aea314fda5d8f91b',
+      '0xd6264e508ec92085a96c15b27d11e1e228b8afd06b57c039efe836df92f247a9660862c030eb38c9549a69dacb7ed2daf5c1140a2af92f0cffbd1419a04286061c',
+    ]);
   });
 });

--- a/packages/airnode-node/src/handlers/sign-oev-data.ts
+++ b/packages/airnode-node/src/handlers/sign-oev-data.ts
@@ -13,32 +13,26 @@ export async function signOevData(
   const airnodeAddress = airnodeWallet.address;
 
   const beaconsToSign = beacons.filter((beacon) => beacon.airnodeAddress === airnodeAddress);
-  const goSignedBeacons = await go(() =>
+  const goSignatures = await go(() =>
     Promise.all(
-      beaconsToSign.map(async (beacon) => {
-        return {
-          beaconId: beacon.beaconId,
-          signature: await airnodeWallet.signMessage(
-            ethers.utils.arrayify(
-              ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [oevUpdateHash, beacon.templateId])
-            )
-          ),
-        };
+      beaconsToSign.map((beacon) => {
+        return airnodeWallet.signMessage(
+          ethers.utils.arrayify(
+            ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [oevUpdateHash, beacon.templateId])
+          )
+        );
       })
     )
   );
-  if (!goSignedBeacons.success) {
-    return [new Error(`Can't sign the data: ${goSignedBeacons.error}`), null];
+  if (!goSignatures.success) {
+    return [new Error(`Can't sign the data: ${goSignatures.error}`), null];
   }
-  const signedBeacons = goSignedBeacons.data;
 
   return [
     null,
     {
       success: true,
-      data: signedBeacons.reduce((acc, { beaconId, signature }) => {
-        return { ...acc, [beaconId]: signature };
-      }, {} as SignOevDataResponse['data']),
+      data: goSignatures.data,
     },
   ];
 }

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -247,7 +247,7 @@ export interface HttpSignedDataApiCallSuccessResponse {
 
 export interface SignOevDataResponse {
   success: true;
-  data: { [beaconId: string]: string }; // The value is the signature for the respective beacon.
+  data: string[]; // Signatures for the beacons of this Airnode in order they were provided
 }
 
 export interface ApiCallErrorResponse {


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode/issues/1690

Beacons order is important when deriving beacon set ID. This was discussed https://api3workspace.slack.com/archives/C043YH02PGQ/p1679575311162519 and also a bit with @amarthadan privately. 

The decision was to NOT enforce this and be aligned with the (loose) contract implementation. We agreed to revert back to using arrays for request/response body. It is the responsibility of the OEV gateway caller to pass the beacons in correct order.