### PR TITLE
Fix Terraform secrets parsing for older TF version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 .github/
 **/node_modules/**
 **/dist/**
-!docker/scripts/dist
+!docker/scripts/dist/**
 **/build/**
 **/coverage/**
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts-fermium

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "docker:build:latest": "yarn docker:build:packaging && yarn docker:build:images:latest",
     "docker:build:local": "yarn docker:build:packaging && yarn docker:build:images:local",
     "docker:build:packaging": "yarn docker:scripts:build && docker build --tag api3/airnode-packaging:latest --file docker/Dockerfile .",
-    "docker:scripts:build": "ncc build docker/scripts/cli.ts -o docker/scripts/dist --no-cache --minify --source-map --transpile-only",
+    "docker:scripts:build": "ncc build docker/scripts/cli.ts -o docker/scripts/dist --no-cache --source-map --transpile-only",
     "docker:scripts:docker:build": "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock api3/airnode-packaging:latest docker build",
     "docker:scripts:docker:build:latest": "yarn docker:scripts:docker:build",
     "docker:scripts:docker:build:local": "yarn docker:scripts:docker:build --npm-registry local --npm-tag snapshot-local --docker-tags local",

--- a/packages/airnode-deployer/terraform/aws/modules/function/variables.tf
+++ b/packages/airnode-deployer/terraform/aws/modules/function/variables.tf
@@ -10,7 +10,7 @@ locals {
   # Trim whitespaces from the line
   secrets_lines_trimmed = [for line in local.secrets_lines : trimspace(line)]
   # Discard commented lines (starting with '#')
-  secrets_lines_uncommented = [for line in local.secrets_lines_trimmed : line if !startswith(line, "#")]
+  secrets_lines_uncommented = [for line in local.secrets_lines_trimmed : line if can(regex("^[^#].*$", line))]
   # Discard lines not matching the pattern and split them. We're looking for line that has non-whitespace characters before '=' and anything after
   secrets_lines_matched = [for line in local.secrets_lines_uncommented : regex("^([^[:space:]]+?)=(.*)$", line) if can(regex("^([^[:space:]]+?)=(.*)$", line))]
   # Convert the list to a map, remove quotation marks around the values. When duplicate keys are encountered the last found value is used.

--- a/packages/airnode-deployer/terraform/gcp/modules/function/variables.tf
+++ b/packages/airnode-deployer/terraform/gcp/modules/function/variables.tf
@@ -14,7 +14,7 @@ locals {
   # Trim whitespaces from the line
   secrets_lines_trimmed = [for line in local.secrets_lines : trimspace(line)]
   # Discard commented lines (starting with '#')
-  secrets_lines_uncommented = [for line in local.secrets_lines_trimmed : line if !startswith(line, "#")]
+  secrets_lines_uncommented = [for line in local.secrets_lines_trimmed : line if can(regex("^[^#].*$", line))]
   # Discard lines not matching the pattern and split them. We're looking for line that has non-whitespace characters before '=' and anything after
   secrets_lines_matched = [for line in local.secrets_lines_uncommented : regex("^([^[:space:]]+?)=(.*)$", line) if can(regex("^([^[:space:]]+?)=(.*)$", line))]
   # Convert the list to a map, remove quotation marks around the values. When duplicate keys are encountered the last found value is used.


### PR DESCRIPTION
I needed to use `regex` function instead of `startswith` because the older Terraform 0.12 used for Airnode v0.10 doesn't support it.

Also includes fixes for Docker image builds.

The new regex explenation:
![Screenshot_20230329_175437](https://user-images.githubusercontent.com/1655405/228596701-bbbe70f0-669b-40a6-82c4-b74c27fb5796.png)

