### PR TITLE
Ignore requests with an invalid sponsor wallet

### DIFF
--- a/.changeset/young-cougars-nail.md
+++ b/.changeset/young-cougars-nail.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': minor
+---
+
+Ignore requests with an invalid sponsor wallet

--- a/packages/airnode-node/src/evm/handlers/initialize-provider.ts
+++ b/packages/airnode-node/src/evm/handlers/initialize-provider.ts
@@ -182,10 +182,16 @@ export async function initializeProvider(
   );
   logger.logPending(verifyRrpTriggersLogs);
 
+  const [verifySponsorWalletsLogs, verifiedApiCallsForSponsorWallets] = verification.verifySponsorWallets(
+    verifiedApiCallsForRrpTriggers,
+    state4.masterHDNode
+  );
+  logger.logPending(verifySponsorWalletsLogs);
+
   const state5 = state.update(state4, {
     requests: {
       ...state4.requests,
-      apiCalls: verifiedApiCallsForRrpTriggers,
+      apiCalls: verifiedApiCallsForSponsorWallets,
     },
   });
 

--- a/packages/airnode-node/src/evm/verification/request-verification.test.ts
+++ b/packages/airnode-node/src/evm/verification/request-verification.test.ts
@@ -17,7 +17,7 @@ describe('verifySponsorWallets', () => {
     };
     const invalidApiCall = fixtures.requests.buildApiCall(invalidSponsorWallet);
     const doNotMatchApiCall = fixtures.requests.buildApiCall(sponsorWalletDoesNotBelongToSponsor);
-    const [apiCalllogs, verifiesdApiCalls] = verification.verifySponsorWallets(
+    const [apiCalllogs, verifiedApiCalls] = verification.verifySponsorWallets(
       [invalidApiCall, doNotMatchApiCall],
       masterHDNode
     );
@@ -31,7 +31,7 @@ describe('verifySponsorWallets', () => {
         message: `Invalid sponsor wallet:${doNotMatchApiCall.sponsorWalletAddress} for Request:${doNotMatchApiCall.id}. Expected:0xdBFe14C250643DEFE92C9AbC52103bf4978C7113`,
       },
     ]);
-    expect(verifiesdApiCalls.length).toEqual(0);
+    expect(verifiedApiCalls.length).toEqual(0);
 
     const invalidWithdrawal = fixtures.requests.buildWithdrawal(invalidSponsorWallet);
     const doNotMatchWithdrawal = fixtures.requests.buildWithdrawal(sponsorWalletDoesNotBelongToSponsor);


### PR DESCRIPTION
Closes #1749. This was a simple fix that leverages the existing sponsor wallet verification functionality and [tests](https://github.com/api3dao/airnode/blob/022ee4f761adee0d11bd6b0231189f9b30536c1a/packages/airnode-node/src/evm/verification/request-verification.test.ts#L5) to drop requests with invalid sponsor wallets earlier within the airnode cycle prior to making an API call.