### PR TITLE
Fix wrong changeset target

### DIFF
--- a/.changeset/young-cougars-nail.md
+++ b/.changeset/young-cougars-nail.md
@@ -1,5 +1,5 @@
 ---
-'@api3/airnode-node': minor
+'@api3/airnode-node': patch
 ---
 
 Ignore requests with an invalid sponsor wallet


### PR DESCRIPTION
The fix https://github.com/api3dao/airnode/pull/1758 should have been marked as for a `patch` release, not a `minor` one.