### PR TITLE
Change the HTTP gateway for ChainAPI test calls

### DIFF
--- a/.changeset/four-dingos-reply.md
+++ b/.changeset/four-dingos-reply.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-operation': minor
+'@api3/airnode-node': minor
+---
+
+Change the HTTP gateway for ChainAPI test calls by 1) returning data from successful API calls that fail processing and 2) making reserved parameters inaccessible in pre/post processing

--- a/packages/airnode-node/src/api/index.ts
+++ b/packages/airnode-node/src/api/index.ts
@@ -234,6 +234,10 @@ export async function processSuccessfulApiCall(
   );
   if (!goExtractAndEncodeResponse.success) {
     const log = logger.pend('ERROR', goExtractAndEncodeResponse.error.message);
+    // The HTTP gateway is a special case for ChainAPI where we return data from a successful API call that failed processing
+    if (payload.type === 'http-gateway') {
+      return [[log], { success: true, errorMessage: goExtractAndEncodeResponse.error.message, data: rawResponse.data }];
+    }
     return [[log], { success: false, errorMessage: goExtractAndEncodeResponse.error.message }];
   }
 

--- a/packages/airnode-node/src/types.ts
+++ b/packages/airnode-node/src/types.ts
@@ -223,7 +223,10 @@ export interface AuthorizationByRequestId {
 }
 
 export type RegularApiCallResponse = RegularApiCallSuccessResponse | ApiCallErrorResponse;
-export type HttpGatewayApiCallResponse = HttpGatewayApiCallSuccessResponse | ApiCallErrorResponse;
+export type HttpGatewayApiCallResponse =
+  | HttpGatewayApiCallSuccessResponse
+  | HttpGatewayApiCallPartialResponse
+  | ApiCallErrorResponse;
 export type HttpSignedDataApiCallResponse = HttpSignedDataApiCallSuccessResponse | ApiCallErrorResponse;
 
 export type ApiCallResponse = RegularApiCallResponse | HttpGatewayApiCallResponse | HttpSignedDataApiCallResponse;
@@ -238,6 +241,12 @@ export interface RegularApiCallSuccessResponse {
 export interface HttpGatewayApiCallSuccessResponse {
   success: true;
   data: { values: unknown[]; rawValue: unknown; encodedValue: string };
+}
+
+export interface HttpGatewayApiCallPartialResponse {
+  success: true;
+  errorMessage: string;
+  data: unknown;
 }
 
 export interface HttpSignedDataApiCallSuccessResponse {

--- a/packages/airnode-node/test/e2e/http.feature.ts
+++ b/packages/airnode-node/test/e2e/http.feature.ts
@@ -4,27 +4,53 @@ import { deployAirnodeAndMakeRequests, increaseTestTimeout } from '../setup/e2e'
 
 increaseTestTimeout();
 
-it('makes a call to test the API', async () => {
-  const { config } = await deployAirnodeAndMakeRequests(__filename);
-
+describe('processHttpRequest', () => {
   const parameters = {
     from: 'ETH',
     _type: 'int256',
     _path: 'result',
   };
+
   // EndpointID from the trigger fixture ../fixtures/config/config.ts
   const endpointId = '0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6';
 
-  const [_err, result] = await processHttpRequest(config, endpointId, parameters);
+  let config: any;
+  beforeAll(async () => {
+    const deploymentData = await deployAirnodeAndMakeRequests(__filename);
+    config = deploymentData.config;
+  });
 
-  const expected: HttpGatewayApiCallResponse = {
-    // Value is returned by the mock server from the operation package
-    data: {
-      rawValue: { success: true, result: '723.39202' },
-      encodedValue: '0x00000000000000000000000000000000000000000000000000000000044fcf02',
-      values: ['72339202'],
-    },
-    success: true,
-  };
-  expect(result).toEqual(expected);
+  it('makes a call to test the API', async () => {
+    const [_err, result] = await processHttpRequest(config, endpointId, parameters);
+
+    const expected: HttpGatewayApiCallResponse = {
+      // Value is returned by the mock server from the operation package
+      data: {
+        rawValue: { result: '723.39202' },
+        encodedValue: '0x00000000000000000000000000000000000000000000000000000000044fcf02',
+        values: ['72339202'],
+      },
+      success: true,
+    };
+    expect(result).toEqual(expected);
+  });
+
+  it('returns data from a successful API call that failed processing', async () => {
+    const invalidType = 'invalidType';
+
+    // Use a minimal reserved parameters array with only _type (which is required by OIS) and an invalid value
+    const modifiedConfig = { ...config };
+    modifiedConfig.ois[0].endpoints[0].reservedParameters = [{ name: '_type', fixed: invalidType }];
+    const minimalParameters = { from: 'ETH' };
+
+    const [_err, result] = await processHttpRequest(modifiedConfig, endpointId, minimalParameters);
+
+    const expected: HttpGatewayApiCallResponse = {
+      data: { result: '723.39202' },
+      success: true,
+      errorMessage: `Invalid type: ${invalidType}`,
+    };
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/packages/airnode-operation/src/server.ts
+++ b/packages/airnode-operation/src/server.ts
@@ -14,11 +14,11 @@ app.get('/convert', (req, res) => {
   const { from, to } = req.query;
 
   if (from === 'ETH' && to === 'USD') {
-    res.status(200).send({ success: true, result: '723.39202' });
+    res.status(200).send({ result: '723.39202' });
     return;
   }
 
-  res.status(404).send({ success: false, error: 'Unknown price pair' });
+  res.status(404).send({ error: 'Unknown price pair' });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
Closes #1738

Changes made for HTTP gateway requests:
1. Return data from successful API calls that fail processing
2. Make reserved parameters inaccessible in pre/post processing

For 1, a new type, `HttpGatewayApiCallPartialResponse`, was added for the scenario of a HTTP gateway request that returns data from the API call but fails processing. Within this type there is an `errorMessage` field and `success` is set to `true`, which is necessary to bubble the `data` field (API response) back up through the call stack.

For 2, only `preProcessApiSpecifications` was modified. No changes were made to `postProcessApiSpecifications` because post processing only takes the raw API response data and endpoint array (for extraction of `postProcessingSpecifications`) as inputs and not reserved parameters:

https://github.com/api3dao/airnode/blob/dbde93c692fef338eb0f6386e74e8f708e4ab97b/packages/airnode-node/src/api/index.ts#L222-L223