### PR TITLE
Fix external links

### DIFF
--- a/.changeset/cold-knives-count.md
+++ b/.changeset/cold-knives-count.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-examples': patch
+---
+
+Fix airnode-examples links to cloud provider docs

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Airnode is a fully-serverless oracle node that is designed specifically for API 
 
 ## Documentation
 
-You can find all information about Airnode in the [documentation](https://docs.api3.org/airnode/latest/).
+You can find an overview of Airnode in the [documentation](https://docs.api3.org/explore/airnode/what-is-airnode.html).
 
 ## For developers
 

--- a/packages/airnode-examples/README.md
+++ b/packages/airnode-examples/README.md
@@ -136,7 +136,7 @@ yarn deploy-rrp
 If you intend to deploy Airnode on AWS, you will need to specify the credentials which will be used by the
 [deployer](https://github.com/api3dao/airnode/tree/master/packages/airnode-deployer). If you are not sure where to find
 these or how to create an AWS account, see
-[the following docs section](https://docs.api3.org/reference/airnode/latest/docker/deployer-image.html#aws).
+[the following docs section](https://docs.api3.org/reference/airnode/latest/understand/configuring.html#aws-setup-aws-deployment-only).
 
 After you know the secrets, run the following script to specify them:
 
@@ -155,7 +155,7 @@ your project by pairing it with your credit card. The amount of resources used b
 within the free tier, which means no charges will be incurred.
 
 If you are not sure how to create a GCP service account, see or download the access key for it,
-[the following docs section](https://docs.api3.org/reference/airnode/latest/docker/deployer-image.html#gcp).
+[the following docs section](https://docs.api3.org/reference/airnode/latest/understand/configuring.html#gcp-setup-gcp-deployment-only).
 
 Store the access key file as `gcp.json` in the integration directory - e.g. if you have chosen the `coingecko`
 integration, store the file as `integrations/coingecko/gcp.json`.

--- a/packages/airnode-node/README.md
+++ b/packages/airnode-node/README.md
@@ -4,7 +4,7 @@
 
 ## Documentation
 
-You can learn all the information about Airnode in the [docs](https://docs.api3.org/airnode/latest/).
+You can learn all the information about Airnode in the [docs](https://docs.api3.org/reference/airnode/latest/).
 
 ## For developers
 

--- a/packages/airnode-protocol/README.md
+++ b/packages/airnode-protocol/README.md
@@ -4,7 +4,8 @@
 
 ## Documentation
 
-You can learn about Airnode and the protocols used in the [documentation](https://docs.api3.org/airnode/latest/).
+You can learn about Airnode and the protocols used in the
+[documentation](https://docs.api3.org/reference/airnode/latest/).
 
 ## For developers
 


### PR DESCRIPTION
Backporting https://github.com/api3dao/airnode/pull/1789 to fix building on the `v0.11` branch.