### PR TITLE
fix: populate default contract addresses when loading config

### DIFF
--- a/.changeset/lucky-parrots-beg.md
+++ b/.changeset/lucky-parrots-beg.md
@@ -1,0 +1,6 @@
+---
+'@api3/airnode-validator': patch
+'@api3/airnode-node': patch
+---
+
+fix: populate default contract addresses when loading config

--- a/packages/airnode-node/config/config.example.json
+++ b/packages/airnode-node/config/config.example.json
@@ -3,10 +3,39 @@
     {
       "maxConcurrency": 100,
       "authorizers": {
-        "requesterEndpointAuthorizers": [],
-        "crossChainRequesterAuthorizers": [],
-        "requesterAuthorizersWithErc721": [],
-        "crossChainRequesterAuthorizersWithErc721": []
+        "requesterEndpointAuthorizers": ["0x1FbDB2315678afecb367f032d93F642f64180aa4"],
+        "crossChainRequesterAuthorizers": [
+          {
+            "requesterEndpointAuthorizers": ["0x2FbDB2315678afecb367f032d93F642f64180aa5"],
+            "chainType": "evm",
+            "chainId": "5",
+            "contracts": {
+              "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+            },
+            "chainProvider": {
+              "url": "http://127.0.0.2"
+            }
+          }
+        ],
+        "requesterAuthorizersWithErc721": [
+          {
+            "erc721s": ["0x00bDB2315678afecb367f032d93F642f64180a00"],
+            "RequesterAuthorizerWithErc721": "0x999DB2315678afecb367f032d93F642f64180aa9"
+          }
+        ],
+        "crossChainRequesterAuthorizersWithErc721": [
+          {
+            "erc721s": ["0x3FbDB2315678afecb367f032d93F642f64180aa6"],
+            "chainType": "evm",
+            "chainId": "5",
+            "contracts": {
+              "RequesterAuthorizerWithErc721": "0x6bbbb2315678afecb367f032d93F642f64180aa4"
+            },
+            "chainProvider": {
+              "url": "http://127.0.0.2"
+            }
+          }
+        ]
       },
       "authorizations": {
         "requesterEndpointAuthorizations": {}

--- a/packages/airnode-node/src/config/index.test.ts
+++ b/packages/airnode-node/src/config/index.test.ts
@@ -1,0 +1,43 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { mockReadFileSync } from '../../test/mock-utils';
+import dotenv from 'dotenv';
+import { references } from '@api3/airnode-protocol';
+import { loadTrustedConfig } from '../index';
+
+const AirnodeRrpV0Addresses: { [chainId: string]: string } = references.AirnodeRrpV0;
+const RequesterAuthorizerWithErc721Addresses: { [chainId: string]: string } = references.RequesterAuthorizerWithErc721;
+
+describe('config validation', () => {
+  const exampleConfigPath = join(__dirname, '../../config/config.example.json');
+  const exampleSecrets = dotenv.parse(readFileSync(join(__dirname, '../../config/secrets.example.env')));
+
+  it('loads the config and adds default contract addresses', () => {
+    const chainId = '4';
+    const invalidConfig = JSON.parse(readFileSync(exampleConfigPath, 'utf-8'));
+    invalidConfig.chains[0].id = chainId; // Need to use an actual chain not hardhat
+    delete invalidConfig.chains[0].contracts;
+    delete invalidConfig.chains[0].authorizers.crossChainRequesterAuthorizers[0].contracts;
+    delete invalidConfig.chains[0].authorizers.crossChainRequesterAuthorizersWithErc721[0].contracts;
+    delete invalidConfig.chains[0].authorizers.requesterAuthorizersWithErc721[0].RequesterAuthorizerWithErc721;
+
+    mockReadFileSync('config.example.json', JSON.stringify(invalidConfig));
+
+    const config = loadTrustedConfig(exampleConfigPath, exampleSecrets);
+
+    expect(config.chains[0].contracts.AirnodeRrp).toEqual(AirnodeRrpV0Addresses[chainId]);
+    expect(config.chains[0].authorizers.crossChainRequesterAuthorizers[0].contracts.AirnodeRrp).toEqual(
+      AirnodeRrpV0Addresses[config.chains[0].authorizers.crossChainRequesterAuthorizers[0].chainId]
+    );
+    expect(
+      config.chains[0].authorizers.crossChainRequesterAuthorizersWithErc721[0].contracts.RequesterAuthorizerWithErc721
+    ).toEqual(
+      RequesterAuthorizerWithErc721Addresses[
+        config.chains[0].authorizers.crossChainRequesterAuthorizersWithErc721[0].chainId
+      ]
+    );
+    expect(config.chains[0].authorizers.requesterAuthorizersWithErc721[0].RequesterAuthorizerWithErc721).toEqual(
+      RequesterAuthorizerWithErc721Addresses[config.chains[0].id]
+    );
+  });
+});

--- a/packages/airnode-node/src/config/index.ts
+++ b/packages/airnode-node/src/config/index.ts
@@ -30,17 +30,15 @@ export function addDefaultContractAddresses(config: configTypes.Config): configT
   const chains = config.chains.map((chain) => {
     const contracts = configTypes.ensureValidAirnodeRrp(chain.contracts, chain.id, ctx);
 
-    const crossChainRequesterAuthorizers = chain.authorizers.crossChainRequesterAuthorizers
-      ? chain.authorizers.crossChainRequesterAuthorizers.map((craObj) => {
-          return configTypes.ensureCrossChainRequesterAuthorizerValidAirnodeRrp(craObj, ctx);
-        })
-      : [];
+    const crossChainRequesterAuthorizers = chain.authorizers.crossChainRequesterAuthorizers.map((craObj) => {
+      return configTypes.ensureCrossChainRequesterAuthorizerValidAirnodeRrp(craObj, ctx);
+    });
 
-    const crossChainRequesterAuthorizersWithErc721 = chain.authorizers.crossChainRequesterAuthorizersWithErc721
-      ? chain.authorizers.crossChainRequesterAuthorizersWithErc721.map((craObj) => {
-          return configTypes.ensureCrossChainRequesterAuthorizerWithErc721(craObj, ctx);
-        })
-      : [];
+    const crossChainRequesterAuthorizersWithErc721 = chain.authorizers.crossChainRequesterAuthorizersWithErc721.map(
+      (craObj) => {
+        return configTypes.ensureCrossChainRequesterAuthorizerWithErc721(craObj, ctx);
+      }
+    );
 
     return {
       // Add same-chain RequesterAuthorizerWithErc721 contract address, which operates
@@ -48,7 +46,7 @@ export function addDefaultContractAddresses(config: configTypes.Config): configT
       ...configTypes.ensureRequesterAuthorizerWithErc721(
         {
           ...chain,
-          contracts: contracts,
+          contracts,
           authorizers: {
             ...chain.authorizers,
             crossChainRequesterAuthorizers,

--- a/packages/airnode-validator/src/config/config.ts
+++ b/packages/airnode-validator/src/config/config.ts
@@ -159,12 +159,12 @@ export const chainOptionsSchema = z
   })
   .strict();
 
-const ensureValidAirnodeRrp = (
+export const ensureValidAirnodeRrp = (
   contracts: SchemaType<typeof airnodeRrpContractSchema>,
   chainId: string,
   ctx: RefinementCtx
 ) => {
-  if (!contracts.AirnodeRrp) {
+  if (!contracts?.AirnodeRrp) {
     if (!AirnodeRrpV0Addresses[chainId]) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -187,7 +187,7 @@ const ensureConfigValidAirnodeRrp = (value: z.infer<typeof _chainConfigSchema>, 
 
 // Similar to ensureConfigValidAirnodeRrp, but this needs to be a separate function because of the distinct
 // inferred type parameter (zod runs into cyclic inference errors with a single function that accepts either type)
-const ensureCrossChainRequesterAuthorizerValidAirnodeRrp = (
+export const ensureCrossChainRequesterAuthorizerValidAirnodeRrp = (
   value: z.infer<typeof _crossChainRequesterAuthorizerSchema>,
   ctx: RefinementCtx
 ) => {
@@ -234,7 +234,7 @@ export const requesterAuthorizerWithErc721ContractSchema = z
 
 // This transform operates on entire chain config object because this is where the chain id is defined,
 // and the chain id is necessary to look up the RequesterAuthorizerWithErc721 contract address
-const ensureRequesterAuthorizerWithErc721 = (value: z.infer<typeof _chainConfigSchema>, ctx: RefinementCtx) => {
+export const ensureRequesterAuthorizerWithErc721 = (value: z.infer<typeof _chainConfigSchema>, ctx: RefinementCtx) => {
   if (!isEmpty(value.authorizers.requesterAuthorizersWithErc721)) {
     const arr = value.authorizers.requesterAuthorizersWithErc721.map((raObj, ind) => {
       if (!raObj.RequesterAuthorizerWithErc721) {
@@ -258,11 +258,11 @@ const ensureRequesterAuthorizerWithErc721 = (value: z.infer<typeof _chainConfigS
   return value;
 };
 
-const ensureCrossChainRequesterAuthorizerWithErc721 = (
+export const ensureCrossChainRequesterAuthorizerWithErc721 = (
   value: z.infer<typeof _crossChainRequesterAuthorizersWithErc721Schema>,
   ctx: RefinementCtx
 ) => {
-  if (!value.contracts.RequesterAuthorizerWithErc721) {
+  if (!value.contracts?.RequesterAuthorizerWithErc721) {
     if (!RequesterAuthorizerWithErc721Addresses[value.chainId]) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/packages/airnode-validator/test/fixtures/config.valid.json
+++ b/packages/airnode-validator/test/fixtures/config.valid.json
@@ -8,7 +8,7 @@
           {
             "requesterEndpointAuthorizers": ["0x2FbDB2315678afecb367f032d93F642f64180aa5"],
             "chainType": "evm",
-            "chainId": "4",
+            "chainId": "5",
             "contracts": {
               "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
             },
@@ -27,7 +27,7 @@
           {
             "erc721s": ["0x3FbDB2315678afecb367f032d93F642f64180aa6"],
             "chainType": "evm",
-            "chainId": "4",
+            "chainId": "5",
             "contracts": {
               "RequesterAuthorizerWithErc721": "0x6bbbb2315678afecb367f032d93F642f64180aa4"
             },

--- a/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
+++ b/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
@@ -8,7 +8,7 @@
           {
             "requesterEndpointAuthorizers": ["0x2FbDB2315678afecb367f032d93F642f64180aa5"],
             "chainType": "evm",
-            "chainId": "4",
+            "chainId": "5",
             "contracts": {
               "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
             },
@@ -27,7 +27,7 @@
           {
             "erc721s": ["0x3FbDB2315678afecb367f032d93F642f64180aa6"],
             "chainType": "evm",
-            "chainId": "4",
+            "chainId": "5",
             "contracts": {
               "RequesterAuthorizerWithErc721": "0x6bbbb2315678afecb367f032d93F642f64180aa4"
             },


### PR DESCRIPTION
This PR closes #1809 by populating default contract address when a config file, which may omit contract addresses for which there is an existing deployment, is loaded via `loadTrustedConfig`. Rather than duplicate the code to populate default addresses, this code calls validating functions added to airnode-validator as part of #1755.