### PR TITLE
chore: add min release age for renovate branches/PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,5 +25,7 @@
     "enabled": true
   },
   "reviewers": ["team:airnode"],
+  "minimumReleaseAge": "5 days",
+  "internalChecksFilter": "strict",
   "dependencyDashboard": false
 }


### PR DESCRIPTION
Renovate currently opens PRs nearly immediately when packages are released, whereas we'd prefer the increased stability of packages that have been out for several days. The PR adds a minimum release age of 5 days. Renovate documentation for the change [here](https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days).