### PR TITLE
feat(node): expose endpointParameters to all pre/post-processing steps

### DIFF
--- a/.changeset/twelve-knives-relate.md
+++ b/.changeset/twelve-knives-relate.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': minor
+---
+
+Exposes endpointParameters to all pre/post-processing steps

--- a/packages/airnode-node/src/api/index.ts
+++ b/packages/airnode-node/src/api/index.ts
@@ -219,7 +219,9 @@ export async function processSuccessfulApiCall(
   // _minConfirmations is handled prior to the API call
   const { _type, _path, _times, _gasPrice } = getReservedParameters(endpoint, parameters);
 
-  const goPostProcessApiSpecifications = await go(() => postProcessApiSpecifications(rawResponse.data, endpoint));
+  const goPostProcessApiSpecifications = await go(() =>
+    postProcessApiSpecifications(rawResponse.data, endpoint, payload)
+  );
   if (!goPostProcessApiSpecifications.success) {
     const log = logger.pend('ERROR', goPostProcessApiSpecifications.error.message);
     return [[log], { success: false, errorMessage: goPostProcessApiSpecifications.error.message }];

--- a/packages/airnode-node/src/api/processing.test.ts
+++ b/packages/airnode-node/src/api/processing.test.ts
@@ -55,14 +55,15 @@ describe('pre-processing', () => {
     await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
   });
 
-  it('makes reserved parameters inaccessible for HTTP gateway requests', async () => {
+  it('demonstrates access to endPointParameters, but reserved parameters are inaccessible for HTTP gateway requests', async () => {
     const config = fixtures.buildConfig();
     const preProcessingSpecifications = [
       {
         environment: 'Node' as const,
         // pretend the user is trying to 1) override _path and 2) set a new parameter based on
         // the presence of the reserved parameter _type (which is inaccessible)
-        value: 'const output = {...input, from: "ETH", _path: "price.newpath", myVal: input._type ? "123" : "456" };',
+        value:
+          'const output = {...input, from: "ETH", _path: "price.newpath", myVal: input._type ? "123" : "456", newTo: endpointParameters.to };',
         timeoutMs: 5_000,
       },
     ];
@@ -79,12 +80,13 @@ describe('pre-processing', () => {
       from: 'ETH', // originates from the processing code
       to: 'USD', // should be unchanged from the original parameters
       myVal: '456', // is set to "456" because _type is not present in the environment
+      newTo: 'USD', // demonstrates access to endpointParameters
     });
   });
 });
 
 describe('post-processing', () => {
-  it('parameters - valid processing code', async () => {
+  it('processes valid code', async () => {
     const config = fixtures.buildConfig();
     const postProcessingSpecifications = [
       {
@@ -99,13 +101,46 @@ describe('post-processing', () => {
       },
     ];
     const endpoint = { ...config.ois[0].endpoints[0], postProcessingSpecifications };
+    const parameters = { _type: 'int256', _path: 'price' };
+    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
 
-    const result = await postProcessApiSpecifications({ price: 1000 }, endpoint);
+    const result = await postProcessApiSpecifications({ price: 1000 }, endpoint, {
+      type: 'http-gateway',
+      config,
+      aggregatedApiCall,
+    });
 
     expect(result).toEqual(4000);
   });
 
-  it('parameters - invalid processing code', async () => {
+  it('demonstrates access to endPointParameters, but reserved parameters are inaccessible for HTTP gateway requests', async () => {
+    const config = fixtures.buildConfig();
+    const postProcessingSpecifications = [
+      {
+        environment: 'Node' as const,
+        value:
+          'const reservedMultiplier = endpointParameters._times ? 1 : 2; const output = parseInt(input.price) * endpointParameters.myMultiplier * reservedMultiplier;',
+        timeoutMs: 5_000,
+      },
+    ];
+    const endpoint = { ...config.ois[0].endpoints[0], postProcessingSpecifications };
+    const myMultiplier = 10;
+    const parameters = { _type: 'int256', _path: 'price', myMultiplier };
+    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
+
+    const price = 1000;
+    const result = await postProcessApiSpecifications({ price }, endpoint, {
+      type: 'http-gateway',
+      config,
+      aggregatedApiCall,
+    });
+
+    // reserved parameters (_times) should be inaccessible to post-processing for the
+    // http-gateway, hence multiplication by 2 instead of 1
+    expect(result).toEqual(price * myMultiplier * 2);
+  });
+
+  it('throws on invalid code', async () => {
     const config = fixtures.buildConfig();
     const postProcessingSpecifications = [
       {
@@ -120,8 +155,15 @@ describe('post-processing', () => {
       },
     ];
     const endpoint = { ...config.ois[0].endpoints[0], postProcessingSpecifications };
+    const parameters = { _type: 'int256', _path: 'price' };
+    const aggregatedApiCall = fixtures.buildAggregatedRegularApiCall({ parameters });
 
-    const throwingFunc = () => postProcessApiSpecifications({ price: 1000 }, endpoint);
+    const throwingFunc = () =>
+      postProcessApiSpecifications({ price: 1000 }, endpoint, {
+        type: 'http-gateway',
+        config,
+        aggregatedApiCall,
+      });
 
     await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
   });

--- a/packages/airnode-node/src/api/unsafe-evaluate.ts
+++ b/packages/airnode-node/src/api/unsafe-evaluate.ts
@@ -78,9 +78,10 @@ const builtInNodeModules = {
 /**
  * This function is dangerous. Make sure to use it only with Trusted code.
  */
-export const unsafeEvaluate = (input: any, code: string, timeout: number) => {
+export const unsafeEvaluate = (input: any, code: string, timeout: number, endpointParameters?: any) => {
   const vmContext = {
     input,
+    endpointParameters,
     ...builtInNodeModules,
     deferredOutput: undefined,
   };
@@ -105,7 +106,7 @@ export const unsafeEvaluate = (input: any, code: string, timeout: number) => {
  *
  * The value given to `resolve` is expected to be the equivalent of `output` above.
  */
-export const unsafeEvaluateAsync = (input: any, code: string, timeout: number) => {
+export const unsafeEvaluateAsync = (input: any, code: string, timeout: number, endpointParameters?: any) => {
   let vmReject: (reason: unknown) => void;
 
   // Make sure the timeout is applied. When the processing snippet uses setTimeout or setInterval, the timeout option
@@ -131,6 +132,7 @@ export const unsafeEvaluateAsync = (input: any, code: string, timeout: number) =
 
     const vmContext = {
       input,
+      endpointParameters,
       resolve: vmResolve,
       reject: vmReject,
       setTimeout: timers.customSetTimeout,


### PR DESCRIPTION
Closes #1673. 

I implemented this by passing `endpointParameters` to the VM context in `unsafeEvaluate` and `unsafeEvaluateAsync` for both pre- and post-processing. This allows the endpointParameters to be immutable with respect to the `parameters` of the `aggregatedApiCall` (more relevant to pre-processing).

Note to achieve the above immutability and to avoid breaking existing post-processing code, I did not modify the `input` (the raw API call response data) of the `reduce` of `postProcessingSpecifications`.