### PR TITLE
fix: harmonize HTTP gateway response object when encoding fails

### DIFF
--- a/.changeset/eighty-items-fail.md
+++ b/.changeset/eighty-items-fail.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-node': patch
+---
+
+Harmonize HTTP gateway response object when encoding fails compared to when it succeeds

--- a/packages/airnode-node/src/api/index.ts
+++ b/packages/airnode-node/src/api/index.ts
@@ -238,7 +238,10 @@ export async function processSuccessfulApiCall(
     const log = logger.pend('ERROR', goExtractAndEncodeResponse.error.message);
     // The HTTP gateway is a special case for ChainAPI where we return data from a successful API call that failed processing
     if (payload.type === 'http-gateway') {
-      return [[log], { success: true, errorMessage: goExtractAndEncodeResponse.error.message, data: rawResponse.data }];
+      return [
+        [log],
+        { success: true, errorMessage: goExtractAndEncodeResponse.error.message, data: { rawValue: rawResponse.data } },
+      ];
     }
     return [[log], { success: false, errorMessage: goExtractAndEncodeResponse.error.message }];
   }

--- a/packages/airnode-node/test/e2e/http.feature.ts
+++ b/packages/airnode-node/test/e2e/http.feature.ts
@@ -46,7 +46,7 @@ describe('processHttpRequest', () => {
     const [_err, result] = await processHttpRequest(modifiedConfig, endpointId, minimalParameters);
 
     const expected: HttpGatewayApiCallResponse = {
-      data: { result: '723.39202' },
+      data: { rawValue: { result: '723.39202' } },
       success: true,
       errorMessage: `Invalid type: ${invalidType}`,
     };


### PR DESCRIPTION
Closes #1845.

@bbenligiray you say in #1845:
> As a note, unlike Solution 1, this keeps the `rawValue` name, which is misleading. This is not the raw response of the API, but rather the response that is post-processed by the Airnode.

And I agree

> So if Solution 2 will be implemented, this field should be renamed to something more accurate, such as `postProcessedResponse`/`postProcessedBody`/`postProcessedValue`.

For consistency, wouldn't we want the field renamed in the case both of encoding success and failure? I assume yes, in which case this would be a breaking change for anyone using / expecting the HTTP gateway `rawValue` field. Now, we could argue that the HTTP gateway is experimental and its fields shouldn't be relied upon, but having this change in v0.12.0 --> v0.12.1 (as currently slated) feels a bit much. We could also say this is v0.13 instead of v0.12.1, but there is more process (e.g. docs release) for that.

What I've done for the moment is harmonize it so that `rawValue` is returned upon encoding failure like success, which is consistent if slightly inaccurate in name, but happy to make the changes throughout the codebase and docs (e.g. [here](https://docs.api3.org/reference/airnode/latest/understand/http-gateways.html), [here](https://docs.api3.org/guides/airnode/deploy-airnode/deploy-aws/), [here](https://docs.api3.org/guides/airnode/post-processing/), etc.) if you want it renamed.

I've tested `rawValue` is present and contains the expected API response from coingecko by using the CI-built client docker image and a wrong `_path` e.g. `market_data.current_price.usd234` instead of `market_data.current_price.usd`.