### PR TITLE
update github actions CI for protocol-verification

### DIFF
--- a/.github/workflows/protocol-verify.yml
+++ b/.github/workflows/protocol-verify.yml
@@ -16,8 +16,6 @@ jobs:
   pre-build:
     name: Prepare build environment
     runs-on: ubuntu-latest
-    # Don't run twice for a push within an internal PR
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Clone airnode
         uses: actions/checkout@v3
@@ -39,8 +37,6 @@ jobs:
   build:
     name: Build Protocol
     runs-on: ubuntu-latest
-    # Don't run twice for a push within an internal PR
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     needs: pre-build
     steps:
       - uses: actions/cache@v3


### PR DESCRIPTION
Protocol verification didn't seem to be working, the following changes should trigger it on `packages/airnode-protocol` changes

The condition:
```
github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
```

probably never gets met because :
- the event is always going to be 'pull-request'
- [github.event.pull_request.head.repo.full_name](https://docs.github.com/en/webhooks/webhook-events-and-payloads#example-delivery) should be matching [github.repository](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).


There's no real way of testing github actions locally other than forking and testing it there, so if the error still persists then I will opt for that route and create another PR