### PR TITLE
ci: exclude package.json from deployment verification trigger

### DIFF
--- a/.github/workflows/protocol-verify.yml
+++ b/.github/workflows/protocol-verify.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'packages/airnode-protocol/**'
+      - '!packages/airnode-protocol/package.json'
     types: [opened, synchronize, reopened]
 
 env:


### PR DESCRIPTION
Closes #1874. The solution comes from [these Actions docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths). CC @andreogle and @bbenligiray as the [issue](https://github.com/api3dao/airnode/issues/1874) could be relevant for the discussion in https://github.com/api3dao/chains/issues/70.