### PR TITLE
fix: bump ois to v2.2.1

### DIFF
--- a/.changeset/serious-insects-talk.md
+++ b/.changeset/serious-insects-talk.md
@@ -1,0 +1,8 @@
+---
+'@api3/airnode-validator': patch
+'@api3/airnode-deployer': patch
+'@api3/airnode-adapter': patch
+'@api3/airnode-node': patch
+---
+
+Bump ois to v2.2.1

--- a/packages/airnode-adapter/package.json
+++ b/packages/airnode-adapter/package.json
@@ -19,7 +19,7 @@
     "test:watch": "yarn test:ts --watch"
   },
   "dependencies": {
-    "@api3/ois": "2.2.0",
+    "@api3/ois": "2.2.1",
     "@api3/promise-utils": "^0.4.0",
     "axios": "^1.5.0",
     "bignumber.js": "^9.1.2",

--- a/packages/airnode-adapter/test/fixtures/ois.ts
+++ b/packages/airnode-adapter/test/fixtures/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(overrides?: Partial<OIS>): OIS {
   return {
-    oisFormat: '2.2.0',
+    oisFormat: '2.2.1',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-deployer/config/config.example.json
+++ b/packages/airnode-deployer/config/config.example.json
@@ -94,7 +94,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-deployer/package.json
+++ b/packages/airnode-deployer/package.json
@@ -43,7 +43,7 @@
     "lodash": "^4.17.21",
     "ora": "^5.4.1",
     "yargs": "^17.7.2",
-    "zod": "^3.22.2"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@aws-sdk/util-stream-node": "^3.370.0",

--- a/packages/airnode-deployer/test/fixtures/config.aws.valid.json
+++ b/packages/airnode-deployer/test/fixtures/config.aws.valid.json
@@ -95,7 +95,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-deployer/test/fixtures/config.gcp.valid.json
+++ b/packages/airnode-deployer/test/fixtures/config.gcp.valid.json
@@ -93,7 +93,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinMarketCap Basic Authenticated Request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'CoinMarketCap Basic Authenticated Request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/config.example.json
@@ -111,7 +111,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/create-config.ts
@@ -119,7 +119,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-http-gateways/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-http-gateways/config.example.json
@@ -99,7 +99,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-http-gateways/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-http-gateways/create-config.ts
@@ -106,7 +106,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko coins markets request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'CoinGecko coins markets request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko history data request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'CoinGecko history data request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-template/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-template/config.example.json
@@ -89,7 +89,7 @@
   ],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-template/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-template/create-config.ts
@@ -98,7 +98,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   ],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/failing-example/config.example.json
+++ b/packages/airnode-examples/integrations/failing-example/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "Failure Example",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/failing-example/create-config.ts
+++ b/packages/airnode-examples/integrations/failing-example/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'Failure Example',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "Relay Security Schemes via httpbin",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'Relay Security Schemes via httpbin',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/weather-multi-value/config.example.json
+++ b/packages/airnode-examples/integrations/weather-multi-value/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "OpenWeather Multiple Encoded Values",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
+++ b/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.2.0',
+      oisFormat: '2.2.1',
       title: 'OpenWeather Multiple Encoded Values',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-node/config/config.example.json
+++ b/packages/airnode-node/config/config.example.json
@@ -113,7 +113,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "version": "1.2.3",
       "title": "Currency Converter API",
       "apiSpecifications": {

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -29,7 +29,7 @@
     "@api3/airnode-protocol": "^0.12.0",
     "@api3/airnode-utilities": "^0.12.0",
     "@api3/airnode-validator": "^0.12.0",
-    "@api3/ois": "2.2.0",
+    "@api3/ois": "2.2.1",
     "@api3/promise-utils": "^0.4.0",
     "@aws-sdk/client-lambda": "^3.418.0",
     "date-fns": "^2.30.0",
@@ -39,7 +39,7 @@
     "google-auth-library": "^9.0.0",
     "lodash": "^4.17.21",
     "yargs": "^17.7.2",
-    "zod": "^3.22.2"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@api3/airnode-operation": "^0.12.0",

--- a/packages/airnode-node/test/fixtures/config/config.valid.json
+++ b/packages/airnode-node/test/fixtures/config/config.valid.json
@@ -84,7 +84,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-node/test/fixtures/config/ois.ts
+++ b/packages/airnode-node/test/fixtures/config/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(ois?: Partial<OIS>): OIS {
   return {
-    oisFormat: '2.2.0',
+    oisFormat: '2.2.1',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-validator/package.json
+++ b/packages/airnode-validator/package.json
@@ -22,14 +22,14 @@
   },
   "dependencies": {
     "@api3/airnode-protocol": "^0.12.0",
-    "@api3/ois": "2.2.0",
+    "@api3/ois": "2.2.1",
     "@api3/promise-utils": "^0.4.0",
     "dotenv": "^16.3.1",
     "ethers": "^5.7.2",
     "lodash": "^4.17.21",
     "ora": "^5.4.1",
     "yargs": "^17.7.2",
-    "zod": "^3.22.2"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@types/yargs": "^17.0.25",

--- a/packages/airnode-validator/test/fixtures/config.valid.json
+++ b/packages/airnode-validator/test/fixtures/config.valid.json
@@ -102,7 +102,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
+++ b/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
@@ -106,7 +106,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
+++ b/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
@@ -72,7 +72,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.2.0",
+      "oisFormat": "2.2.1",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/ois.json
+++ b/packages/airnode-validator/test/fixtures/ois.json
@@ -1,5 +1,5 @@
 {
-  "oisFormat": "2.2.0",
+  "oisFormat": "2.2.1",
   "version": "1.2.3",
   "title": "coinlayer",
   "apiSpecifications": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,13 +29,13 @@
   dependencies:
     zod "^3.22.2"
 
-"@api3/ois@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-2.2.0.tgz#15924f09797926355c58534e26579015bfccee76"
-  integrity sha512-cgOvwu1WlMllW2SJeGO78HXaecjEd58hd4UTabXviAX8p6eGJ0WsTB7uwF6G/ahy0hTVA16uKcSpdZVd7ZsDoQ==
+"@api3/ois@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-2.2.1.tgz#caa5c672c51b5572cf9bb30226a0647b3a51a57d"
+  integrity sha512-C4tSMBccDlD8NkZMVATQXOKctI46fSOlzpbZmZoFknsIdYfQvGNU49StGRJZ6fJJkwXEX1TlkRC7rY2yHEJjqw==
   dependencies:
     lodash "^4.17.21"
-    zod "^3.22.2"
+    zod "^3.22.3"
 
 "@api3/promise-utils@^0.4.0":
   version "0.4.0"
@@ -15080,12 +15080,12 @@ zksync-web3@^0.14.3:
   resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.3.tgz#64ac2a16d597464c3fc4ae07447a8007631c57c9"
   integrity sha512-hT72th4AnqyLW1d5Jlv8N2B/qhEnl2NePK2A3org7tAa24niem/UAaHMkEvmWI3SF9waYUPtqAtjpf+yvQ9zvQ==
 
-zod@^3.21.4:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.0.tgz#2478211a9bf477eb2d7d2ce031b5f8ff0d596407"
-  integrity sha512-y5KZY/ssf5n7hCGDGGtcJO/EBJEm5Pa+QQvFBeyMOtnFYOSflalxIFFvdaYevPhePcmcKC4aTbFkCcXN7D0O8Q==
-
 zod@^3.22.2:
   version "3.22.2"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.2.tgz#3add8c682b7077c05ac6f979fea6998b573e157b"
   integrity sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==
+
+zod@^3.22.3:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
the only substantive change being a fix for the error message path being wrong for certain validation errors, see https://github.com/api3dao/ois/issues/105