### PR TITLE
fix(examples): check for AirnodeRrp deployment in localhost flow

### DIFF
--- a/.changeset/curvy-timers-kick.md
+++ b/.changeset/curvy-timers-kick.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-examples': patch
+---
+
+Check for AirnodeRrp deployment in localhost flow

--- a/packages/airnode-examples/src/scripts/create-airnode-config.ts
+++ b/packages/airnode-examples/src/scripts/create-airnode-config.ts
@@ -1,7 +1,24 @@
-import { readIntegrationInfo, runAndHandleErrors } from '../';
+import { readIntegrationInfo, runAndHandleErrors, getDeployedContract, cliPrint } from '../';
 
 const main = async () => {
   const integrationInfo = readIntegrationInfo();
+
+  // If using the localhost network, check that AirnodeRrp was deployed
+  if (integrationInfo.network === 'localhost') {
+    try {
+      await getDeployedContract('@api3/airnode-protocol/contracts/rrp/AirnodeRrpV0.sol');
+    } catch (e) {
+      if (e instanceof Error && (e.message.includes('ENOENT') || e.message.includes('invalid contract address'))) {
+        cliPrint.error(
+          'AirnodeRrpV0 contract deployment not found. Please follow the RRP deployment ' +
+            'instructions in the README before running this command.'
+        );
+        process.exit(1);
+      }
+      throw e;
+    }
+  }
+
   // Import the "create-config" file from the chosen integration. See the respective "create-config.ts" file for
   // details.
   const createConfig = await import(`../../integrations/${integrationInfo.integration}/create-config.ts`);


### PR DESCRIPTION
Very minor. Contributes to #1559.

The error without this check is either `Error: ENOENT: no such file or directory...` or `Error: invalid contract address or ENS name (argument="addressOrName", value=undefined, code=INVALID_ARGUMENT, version=contracts/5.7.0)` depending on whether the `deployments/localhost.json` file is present. Both of these don't make it clear that the `deploy-rrp` wasn't run.