### PR TITLE
refactor: use api3/chains for chain names in airnode-examples

### DIFF
--- a/.changeset/many-wombats-join.md
+++ b/.changeset/many-wombats-join.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-examples': patch
+---
+
+Use api3/chains instead of airnode-protocol for chain names

--- a/packages/airnode-examples/src/utils.ts
+++ b/packages/airnode-examples/src/utils.ts
@@ -3,7 +3,8 @@ import { join } from 'path';
 import { parse as parseEnvFile } from 'dotenv';
 import prompts, { PromptObject } from 'prompts';
 import isWsl from 'is-wsl';
-import references from '@api3/airnode-protocol/deployments/references.json';
+import { AirnodeRrpV0 } from '@api3/airnode-protocol/deployments/references.json';
+import { hardhatConfig } from '@api3/chains';
 
 export const supportedNetworks = ['ethereum-sepolia-testnet', 'polygon-testnet', 'ethereum-goerli-testnet'] as const;
 
@@ -104,12 +105,9 @@ export const setMaxPromiseTimeout = <T>(promise: Promise<T>, timeoutMs: number):
  * @returns The AirnodeRrpV0 contract address for the named network
  */
 export const getExistingAirnodeRrpV0 = (networkName: string) => {
-  const { chainNames, AirnodeRrpV0 } = references;
+  const networks = hardhatConfig.networks();
 
-  // get network ID (key) for a given network name (value)
-  const networkId = (Object.keys(chainNames) as (keyof typeof chainNames)[]).find((name) => {
-    return chainNames[name] === networkName;
-  });
+  const networkId = networks[networkName].chainId.toString() as keyof typeof AirnodeRrpV0;
 
   if (networkId) {
     return AirnodeRrpV0[networkId];


### PR DESCRIPTION
Closes #1741. Surprisingly, this was all that was needed, and the changes are covered by the tests below (and I confirmed in api3/chains that the network names are the same): 

https://github.com/api3dao/airnode/blob/b87e0b336cbdf027bffac90c408e01cb68d98e84/packages/airnode-examples/src/utils.test.ts#L23-L34

I checked throughout the repo for other instances where `references.json` of `airnode-protocol` is used for anything besides contract addresses (e.g. where we use `chainNames`) and this was it. Airnode logs report "Chain-ID" ([example](https://github.com/api3dao/airnode/issues/1708#issuecomment-1493444876)) rather than chain name, and other references to `references.json` are specific to addresses e.g. here in validator:

https://github.com/api3dao/airnode/blob/b87e0b336cbdf027bffac90c408e01cb68d98e84/packages/airnode-validator/src/config/config.ts#L18-L21