### PR TITLE
Increase OEV gateway memory

### DIFF
--- a/.changeset/healthy-jeans-cheer.md
+++ b/.changeset/healthy-jeans-cheer.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-deployer': minor
+---
+
+Increase OEV gateway memory limit

--- a/packages/airnode-deployer/terraform/aws/main.tf
+++ b/packages/airnode-deployer/terraform/aws/main.tf
@@ -300,7 +300,7 @@ module "signOevReq" {
   name                           = "${local.name_prefix}-signOevReq"
   handler                        = "index.signOevReq"
   source_dir                     = var.handler_dir
-  memory_size                    = 256
+  memory_size                    = 2048
   timeout                        = 30
   configuration_file             = var.configuration_file
   secrets_file                   = var.secrets_file


### PR DESCRIPTION
We've been discussing plans to increase the OEV gateway memory to reuse the OEV gateway implementation in https://github.com/api3dao/oev-auctioneer/issues/6. I've done some [experiments](https://api3workspace.slack.com/archives/C06A83ZN30D/p1703591954683099) and the cold start varies depending on the gateway memory. This is because the lambda gets CPU proportionally to the memory (and higher memory means higher CPU which decreases the work at cold start).

I am opening a PR which changes the GW memory to 2048 (not configurable).