### PR TITLE
fix: remove unnecessary eslint-disable-line

### DIFF
--- a/.changeset/fair-houses-compare.md
+++ b/.changeset/fair-houses-compare.md
@@ -1,0 +1,5 @@
+---
+'@api3/airnode-protocol': patch
+---
+
+Remove unnecessary eslint-disable-line

--- a/packages/airnode-protocol/src/index.ts
+++ b/packages/airnode-protocol/src/index.ts
@@ -93,9 +93,6 @@ export {
   FailedRequestEvent,
   RequestedWithdrawalEvent,
   FulfilledWithdrawalEvent,
-} from './contracts/rrp/AirnodeRrpV0'; // eslint-disable-line import/no-unresolved
-// NOTE: there seems to be an issue with eslint-plugin-import
-// not being able to find the above files. Hopefully a future version (> 2.26.0)
-// fixes this. https://github.com/api3dao/airnode/pull/1004#issuecomment-1096152730
+} from './contracts/rrp/AirnodeRrpV0';
 
 export { TypedEventFilter } from './contracts/common';


### PR DESCRIPTION
I'm not sure if this PR was enabled by merging #1835, #1901, or something earlier, but [this thread](https://github.com/api3dao/airnode/pull/1178/files#r895009240) is now resolved. 