### PR TITLE
Bump api3/ois to v2.3.2

### DIFF
--- a/.changeset/olive-eyes-greet.md
+++ b/.changeset/olive-eyes-greet.md
@@ -1,0 +1,9 @@
+---
+'@api3/airnode-validator': patch
+'@api3/airnode-deployer': patch
+'@api3/airnode-examples': patch
+'@api3/airnode-adapter': patch
+'@api3/airnode-node': patch
+---
+
+Bump api3/ois to v2.3.2

--- a/packages/airnode-adapter/package.json
+++ b/packages/airnode-adapter/package.json
@@ -19,7 +19,7 @@
     "test:watch": "yarn test:ts --watch"
   },
   "dependencies": {
-    "@api3/ois": "2.3.1",
+    "@api3/ois": "2.3.2",
     "@api3/promise-utils": "^0.4.0",
     "axios": "^1.6.7",
     "bignumber.js": "^9.1.2",

--- a/packages/airnode-adapter/test/fixtures/ois.ts
+++ b/packages/airnode-adapter/test/fixtures/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(overrides?: Partial<OIS>): OIS {
   return {
-    oisFormat: '2.3.1',
+    oisFormat: '2.3.2',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-deployer/config/config.example.json
+++ b/packages/airnode-deployer/config/config.example.json
@@ -94,7 +94,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-deployer/test/fixtures/config.aws.valid.json
+++ b/packages/airnode-deployer/test/fixtures/config.aws.valid.json
@@ -95,7 +95,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-deployer/test/fixtures/config.gcp.valid.json
+++ b/packages/airnode-deployer/test/fixtures/config.gcp.valid.json
@@ -93,7 +93,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinMarketCap Basic Authenticated Request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
+++ b/packages/airnode-examples/integrations/authenticated-coinmarketcap/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'CoinMarketCap Basic Authenticated Request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/config.example.json
@@ -111,7 +111,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-cross-chain-authorizer/create-config.ts
@@ -119,7 +119,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-http-gateways/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-http-gateways/config.example.json
@@ -99,7 +99,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-http-gateways/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-http-gateways/create-config.ts
@@ -106,7 +106,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko coins markets request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-post-processing/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'CoinGecko coins markets request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko history data request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-pre-processing/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'CoinGecko history data request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko-template/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko-template/config.example.json
@@ -89,7 +89,7 @@
   ],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko-template/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko-template/create-config.ts
@@ -98,7 +98,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   ],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/coingecko/config.example.json
+++ b/packages/airnode-examples/integrations/coingecko/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/coingecko/create-config.ts
+++ b/packages/airnode-examples/integrations/coingecko/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'CoinGecko basic request',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/failing-example/config.example.json
+++ b/packages/airnode-examples/integrations/failing-example/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "Failure Example",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/failing-example/create-config.ts
+++ b/packages/airnode-examples/integrations/failing-example/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'Failure Example',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
+++ b/packages/airnode-examples/integrations/relay-security-schemes/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "Relay Security Schemes via httpbin",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
+++ b/packages/airnode-examples/integrations/relay-security-schemes/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'Relay Security Schemes via httpbin',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-examples/integrations/weather-multi-value/config.example.json
+++ b/packages/airnode-examples/integrations/weather-multi-value/config.example.json
@@ -83,7 +83,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "OpenWeather Multiple Encoded Values",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
+++ b/packages/airnode-examples/integrations/weather-multi-value/create-config.ts
@@ -90,7 +90,7 @@ const createConfig = async (generateExampleFile: boolean): Promise<Config> => ({
   templates: [],
   ois: [
     {
-      oisFormat: '2.3.1',
+      oisFormat: '2.3.2',
       title: 'OpenWeather Multiple Encoded Values',
       version: '1.0.0',
       apiSpecifications: {

--- a/packages/airnode-node/config/config.example.json
+++ b/packages/airnode-node/config/config.example.json
@@ -113,7 +113,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "version": "1.2.3",
       "title": "Currency Converter API",
       "apiSpecifications": {

--- a/packages/airnode-node/package.json
+++ b/packages/airnode-node/package.json
@@ -31,7 +31,7 @@
     "@api3/airnode-validator": "^0.14.0",
     "@api3/chains": "^4.5.1",
     "@api3/commons": "^0.6.2",
-    "@api3/ois": "2.3.1",
+    "@api3/ois": "2.3.2",
     "@api3/promise-utils": "^0.4.0",
     "@aws-sdk/client-lambda": "^3.418.0",
     "date-fns": "^2.30.0",

--- a/packages/airnode-node/test/fixtures/config/config.valid.json
+++ b/packages/airnode-node/test/fixtures/config/config.valid.json
@@ -84,7 +84,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-node/test/fixtures/config/ois.ts
+++ b/packages/airnode-node/test/fixtures/config/ois.ts
@@ -2,7 +2,7 @@ import { OIS } from '@api3/ois';
 
 export function buildOIS(ois?: Partial<OIS>): OIS {
   return {
-    oisFormat: '2.3.1',
+    oisFormat: '2.3.2',
     version: '1.2.3',
     title: 'Currency Converter API',
     apiSpecifications: {

--- a/packages/airnode-validator/package.json
+++ b/packages/airnode-validator/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@api3/airnode-protocol": "^0.14.0",
-    "@api3/ois": "2.3.1",
+    "@api3/ois": "2.3.2",
     "@api3/promise-utils": "^0.4.0",
     "dotenv": "^16.4.1",
     "ethers": "^5.7.2",

--- a/packages/airnode-validator/test/fixtures/config.valid.json
+++ b/packages/airnode-validator/test/fixtures/config.valid.json
@@ -102,7 +102,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
+++ b/packages/airnode-validator/test/fixtures/interpolated-config.valid.json
@@ -106,7 +106,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
+++ b/packages/airnode-validator/test/fixtures/invalid-secret-name/config.json
@@ -72,7 +72,7 @@
   "templates": [],
   "ois": [
     {
-      "oisFormat": "2.3.1",
+      "oisFormat": "2.3.2",
       "title": "CoinGecko basic request",
       "version": "1.0.0",
       "apiSpecifications": {

--- a/packages/airnode-validator/test/fixtures/ois.json
+++ b/packages/airnode-validator/test/fixtures/ois.json
@@ -1,5 +1,5 @@
 {
-  "oisFormat": "2.3.1",
+  "oisFormat": "2.3.2",
   "version": "1.2.3",
   "title": "coinlayer",
   "apiSpecifications": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,10 +72,10 @@
     winston-console-format "^1.0.8"
     zod "^3.22.4"
 
-"@api3/ois@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/@api3/ois/-/ois-2.3.1.tgz#de80dc1b404f094be9049d2a8fdc0362cdfd7dce"
-  integrity sha512-7TmgEiJn3TrqV2BZGh4fKTF4qX7Q/dyGdQh9L6gj4dHBmoKzfK0eDbwjWR+RokYrd9k4E4whGNxEnzdZr3ubSA==
+"@api3/ois@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@api3/ois/-/ois-2.3.2.tgz#1707a7311e7db55384b8b2ea7513eccb0dfd8846"
+  integrity sha512-hYQCbCAtWMGKV+pECRY5tbfCSOcheeo9s6wtrhn1dOWw151VeG0sKG3VbBEsyA6cvSaldewBWY3t/JGaupdThg==
   dependencies:
     lodash "^4.17.21"
     zod "^3.22.4"


### PR DESCRIPTION
Needed for Airnode v0.14.1 patch release, [see here](https://github.com/api3dao/ois/pull/130#issue-2116339122). My plan is into merge to master, cherry-pick this commit on the `v0.14` branch, then release. Sound like a plan?