### PR TITLE
Replace deprecated hardhat-etherscan with hardhat-verify

### DIFF
--- a/.changeset/lazy-cars-juggle.md
+++ b/.changeset/lazy-cars-juggle.md
@@ -1,0 +1,5 @@
+---
+"@api3/airnode-protocol": minor
+---
+
+Replace deprecated hardhat-etherscan with hardhat-verify

--- a/packages/airnode-protocol/README.md
+++ b/packages/airnode-protocol/README.md
@@ -64,7 +64,7 @@ AirnodeRrpV0DryRun: 0x2e768206bf5112e7D7efAf1d9df614C26475193f
 - `arbitrum`, `avalanche`, `metis` and their testnets do not support deterministic deployment and are deployed
   undeterministically, resulting different contract addresses.
 
-- `fantom`, `metis`, `milkomeda` and their testnets are not verified due to not being supported by hardhat-etherscan or
+- `fantom`, `fantom` testnet, and `milkomeda` testnet are not verified due to not being supported by hardhat-verify or
   the support being broken. The addresses act as the verification for deterministic deployments, and you can use
   `deploy:verify-local` to verify undeterministic deployments.
 

--- a/packages/airnode-protocol/hardhat.config.js
+++ b/packages/airnode-protocol/hardhat.config.js
@@ -1,5 +1,5 @@
+require('@nomicfoundation/hardhat-verify');
 require('@nomiclabs/hardhat-waffle');
-require('@nomiclabs/hardhat-etherscan');
 require('solidity-coverage');
 require('hardhat-deploy');
 require('hardhat-gas-reporter');

--- a/packages/airnode-protocol/package.json
+++ b/packages/airnode-protocol/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "@api3/chains": "^4.5.1",
+    "@nomicfoundation/hardhat-verify": "^2.0.4",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
-    "@nomiclabs/hardhat-etherscan": "^3.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.6",
     "@typechain/ethers-v5": "^11.1.2",
     "chai": "^4.4.1",

--- a/packages/airnode-protocol/scripts/verify-local.ts
+++ b/packages/airnode-protocol/scripts/verify-local.ts
@@ -1,4 +1,4 @@
-// Even though hardhat-etherscan claims to also verify the deployment locally,
+// Even though hardhat-verify claims to also verify the deployment locally,
 // it doesn't expose that as a command. As a result, you can't verify deployments
 // on chains at which there is no supported block explorer. This is an alternative
 // that fetches the deployed bytecode from a chain and compares that with the output

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,6 +2714,21 @@
     mcl-wasm "^0.7.1"
     rustbn.js "~0.2.0"
 
+"@nomicfoundation/hardhat-verify@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.4.tgz#65b86787fc7b47d38fd941862266065c7eb9bca4"
+  integrity sha512-B8ZjhOrmbbRWqJi65jvQblzjsfYktjqj2vmOm+oc2Vu8drZbT2cjeSCRHZKbS7lOtfW78aJZSFvw+zRLCiABJA==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^8.1.0"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    lodash.clonedeep "^4.5.0"
+    semver "^6.3.0"
+    table "^6.8.0"
+    undici "^5.14.0"
+
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz#4c858096b1c17fe58a474fe81b46815f93645c15"
@@ -2784,22 +2799,6 @@
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz#b41053e360c31a32c2640c9a45ee981a7e603fe0"
   integrity sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==
-
-"@nomiclabs/hardhat-etherscan@^3.1.8":
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.8.tgz#3c12ee90b3733e0775e05111146ef9418d4f5a38"
-  integrity sha512-v5F6IzQhrsjHh6kQz4uNrym49brK9K5bYCq2zQZ729RYRaifI9hHbtmK+KkIVevfhut7huQFEQ77JLRMAzWYjQ==
-  dependencies:
-    "@ethersproject/abi" "^5.1.2"
-    "@ethersproject/address" "^5.0.2"
-    cbor "^8.1.0"
-    chalk "^2.4.2"
-    debug "^4.1.1"
-    fs-extra "^7.0.1"
-    lodash "^4.17.11"
-    semver "^6.3.0"
-    table "^6.8.0"
-    undici "^5.14.0"
 
 "@nomiclabs/hardhat-waffle@^2.0.6":
   version "2.0.6"
@@ -11802,6 +11801,11 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
 lodash.get@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
Closes #1950. I tested this works by running `yarn run deploy:verify` for a few chains. It turns out metis and metis testnet were verified and I was able to successfully verify milkomeda-c1, hence the README update. See below:

```md
❯ NETWORK=metis yarn run deploy:verify
yarn run v1.22.19
$ hardhat deploy --network $NETWORK --tags verify
Nothing to compile
The contract 0xb015ACeEdD478fc497A798Ab45fcED8BdEd08924 has already been verified on Etherscan.
https://andromeda-explorer.metis.io/address/0xb015ACeEdD478fc497A798Ab45fcED8BdEd08924#code
The contract 0x8262a9DAB3f8a0b1E6317551E214CeA89Bc3f56d has already been verified on Etherscan.
https://andromeda-explorer.metis.io/address/0x8262a9DAB3f8a0b1E6317551E214CeA89Bc3f56d#code
The contract 0xC02Ea0f403d5f3D45a4F1d0d817e7A2601346c9E has already been verified on Etherscan.
https://andromeda-explorer.metis.io/address/0xC02Ea0f403d5f3D45a4F1d0d817e7A2601346c9E#code
The contract 0xeefA1A591052DB4208C6BcD1E716B136E07cb692 has already been verified on Etherscan.
https://andromeda-explorer.metis.io/address/0xeefA1A591052DB4208C6BcD1E716B136E07cb692#code
Done in 5.63s.
```

```md
❯ NETWORK=metis-goerli-testnet yarn run deploy:verify
yarn run v1.22.19
$ hardhat deploy --network $NETWORK --tags verify
Nothing to compile
The contract 0x81A850254769a6C87d4F11B9F80bCc5bE1CcF50E has already been verified on Etherscan.
https://goerli.explorer.metisdevops.link/address/0x81A850254769a6C87d4F11B9F80bCc5bE1CcF50E#code
The contract 0xe40f1a1A546B70003D9ddF66B89C261cA46A0CF0 has already been verified on Etherscan.
https://goerli.explorer.metisdevops.link/address/0xe40f1a1A546B70003D9ddF66B89C261cA46A0CF0#code
The contract 0x5997C09be60196b7De9dE73C88dd7776f2875401 has already been verified on Etherscan.
https://goerli.explorer.metisdevops.link/address/0x5997C09be60196b7De9dE73C88dd7776f2875401#code
The contract 0x4923968942E8aae4656ae4913874EB7312e0F7c7 has already been verified on Etherscan.
https://goerli.explorer.metisdevops.link/address/0x4923968942E8aae4656ae4913874EB7312e0F7c7#code
Done in 4.89s.
```

```md
❯ NETWORK=milkomeda-c1 yarn run deploy:verify
yarn run v1.22.19
$ hardhat deploy --network $NETWORK --tags verify
Nothing to compile
The contract 0x92E5125adF385d86beDb950793526106143b6Df1 has already been verified on Etherscan.
https://explorer-mainnet-cardano-evm.c1.milkomeda.com/address/0x92E5125adF385d86beDb950793526106143b6Df1#code
Successfully submitted source code for contract
contracts/authorizers/RequesterAuthorizerWithAirnode.sol:RequesterAuthorizerWithAirnode at 0xf18c105D0375E80980e4EED829a4A68A539E6178
for verification on the block explorer. Waiting for verification result...

Successfully verified contract RequesterAuthorizerWithAirnode on the block explorer.
https://explorer-mainnet-cardano-evm.c1.milkomeda.com/address/0xf18c105D0375E80980e4EED829a4A68A539E6178#code

The contract 0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd has already been verified on Etherscan.
https://explorer-mainnet-cardano-evm.c1.milkomeda.com/address/0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd#code
Successfully submitted source code for contract
contracts/rrp/AirnodeRrpV0DryRun.sol:AirnodeRrpV0DryRun at 0x2e768206bf5112e7D7efAf1d9df614C26475193f
for verification on the block explorer. Waiting for verification result...

Successfully verified contract AirnodeRrpV0DryRun on the block explorer.
https://explorer-mainnet-cardano-evm.c1.milkomeda.com/address/0x2e768206bf5112e7D7efAf1d9df614C26475193f#code

Done in 83.01s.
