### PR TITLE
Bump Node.js version in Dockerfiles

### DIFF
--- a/.changeset/pretty-masks-decide.md
+++ b/.changeset/pretty-masks-decide.md
@@ -1,0 +1,7 @@
+---
+'@api3/airnode-deployer': patch
+'@api3/airnode-admin': patch
+'@api3/airnode-node': patch
+---
+
+Bump Node.js version in Dockerfiles

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.14.0-alpine3.17 AS environment
+FROM node:18.19.1-alpine3.19 AS environment
 
 ENV appDir="/app" \
     buildDir="/build" \
@@ -7,7 +7,7 @@ ENV appDir="/app" \
     CI="true"
 
 RUN apk add --update --no-cache git rsync docker $([ $(arch) == "aarch64" ] && echo "python3 make g++") && \
-    yarn global add npm@9.9.2 && \
+    yarn global add npm && \
     # Download both solidity compilers as per: https://github.com/nomiclabs/hardhat/issues/1280#issuecomment-949822371
     mkdir -p /root/.cache/hardhat-nodejs/compilers-v2/wasm && \
     wget -O /root/.cache/hardhat-nodejs/compilers-v2/wasm/soljson-v0.8.9+commit.e5eed63a.js https://solc-bin.ethereum.org/wasm/soljson-v0.8.9+commit.e5eed63a.js && \

--- a/packages/airnode-admin/docker/Dockerfile
+++ b/packages/airnode-admin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.14.0-alpine3.17
+FROM node:18.19.1-alpine3.19
 
 ARG npmRegistryUrl=https://registry.npmjs.org/
 ARG npmTag=latest

--- a/packages/airnode-deployer/docker/Dockerfile
+++ b/packages/airnode-deployer/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.14.0-alpine3.17
+FROM node:18.19.1-alpine3.19
 
 ARG npmRegistryUrl=https://registry.npmjs.org/
 ARG npmTag=latest

--- a/packages/airnode-node/docker/Dockerfile
+++ b/packages/airnode-node/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.14.0-alpine3.17
+FROM node:18.19.1-alpine3.19
 
 ARG npmRegistryUrl=https://registry.npmjs.org/
 ARG npmTag=latest


### PR DESCRIPTION
Closes #1978 by using a more recently released Node.js 18 version. This also unpins the npm version within the Dockerfile (thus reverting #1873 and 565c3bb) as Node.js 18.19.1 [uses npm v10.2.4](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2024-02-14-version-18191-hydrogen-lts-rafaelgss-prepared-by-marco-ippolito).