### PR TITLE
Adds an extra to the tx estimate to account for EIP-150 reserved gas

### DIFF
--- a/.changeset/blue-starfishes-help.md
+++ b/.changeset/blue-starfishes-help.md
@@ -1,0 +1,5 @@
+---
+"@api3/airnode-node": patch
+---
+
+Adds extra gas to estimate to account for EIP-150

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.test.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.test.ts
@@ -656,8 +656,8 @@ describe('submitApiCall', () => {
             {
               level: 'INFO',
               message: `Gas limit is set to ${
-                73804 + 290001 + 5684
-              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001} + EIP150: ${5684}) for Request:${apiCall.id}.`,
+                73804 + 290001 + 5774
+              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001} + EIP150: ${5774}) for Request:${apiCall.id}.`,
             },
             { level: 'INFO', message: `Submitting API call fulfillment for Request:${apiCall.id}...` },
           ]);
@@ -686,7 +686,7 @@ describe('submitApiCall', () => {
             apiCall.fulfillFunctionId,
             '0x448b8ad3a330cf8f269f487881b59efff721b3dfa8e61f7c8fd2480389459ed3',
             '0xda6d5aa27f48aa951ba401c8a779645f7d1fa4a46a5e99eb7da04b4e059449a834ca1058c85dfe8117305265228f8cf7ae64c3ef3c4d1cc191f77807227dac461b',
-            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001 + 5684) }
+            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001 + 5774) }
           );
           expect(failMock).not.toHaveBeenCalled();
         }
@@ -735,8 +735,8 @@ describe('submitApiCall', () => {
             {
               level: 'INFO',
               message: `Gas limit is set to ${
-                73804 + 290001 + 5684
-              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001} + EIP150: ${5684}) for Request:${apiCall.id}.`,
+                73804 + 290001 + 5774
+              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001} + EIP150: ${5774}) for Request:${apiCall.id}.`,
             },
             { level: 'INFO', message: `Submitting API call fulfillment for Request:${apiCall.id}...` },
             {
@@ -768,7 +768,7 @@ describe('submitApiCall', () => {
             apiCall.fulfillFunctionId,
             '0x448b8ad3a330cf8f269f487881b59efff721b3dfa8e61f7c8fd2480389459ed3',
             '0xda6d5aa27f48aa951ba401c8a779645f7d1fa4a46a5e99eb7da04b4e059449a834ca1058c85dfe8117305265228f8cf7ae64c3ef3c4d1cc191f77807227dac461b',
-            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001 + 5684) }
+            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001 + 5774) }
           );
           expect(failMock).not.toHaveBeenCalled();
         }

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.test.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.test.ts
@@ -656,8 +656,8 @@ describe('submitApiCall', () => {
             {
               level: 'INFO',
               message: `Gas limit is set to ${
-                73804 + 290001
-              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001}) for Request:${apiCall.id}.`,
+                73804 + 290001 + 5684
+              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001} + EIP150: ${5684}) for Request:${apiCall.id}.`,
             },
             { level: 'INFO', message: `Submitting API call fulfillment for Request:${apiCall.id}...` },
           ]);
@@ -686,7 +686,7 @@ describe('submitApiCall', () => {
             apiCall.fulfillFunctionId,
             '0x448b8ad3a330cf8f269f487881b59efff721b3dfa8e61f7c8fd2480389459ed3',
             '0xda6d5aa27f48aa951ba401c8a779645f7d1fa4a46a5e99eb7da04b4e059449a834ca1058c85dfe8117305265228f8cf7ae64c3ef3c4d1cc191f77807227dac461b',
-            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001) }
+            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001 + 5684) }
           );
           expect(failMock).not.toHaveBeenCalled();
         }
@@ -735,8 +735,8 @@ describe('submitApiCall', () => {
             {
               level: 'INFO',
               message: `Gas limit is set to ${
-                73804 + 290001
-              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001}) for Request:${apiCall.id}.`,
+                73804 + 290001 + 5684
+              } (AirnodeRrp: ${73804} + Fulfillment Call: ${290001} + EIP150: ${5684}) for Request:${apiCall.id}.`,
             },
             { level: 'INFO', message: `Submitting API call fulfillment for Request:${apiCall.id}...` },
             {
@@ -768,7 +768,7 @@ describe('submitApiCall', () => {
             apiCall.fulfillFunctionId,
             '0x448b8ad3a330cf8f269f487881b59efff721b3dfa8e61f7c8fd2480389459ed3',
             '0xda6d5aa27f48aa951ba401c8a779645f7d1fa4a46a5e99eb7da04b4e059449a834ca1058c85dfe8117305265228f8cf7ae64c3ef3c4d1cc191f77807227dac461b',
-            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001) }
+            { ...txOpts, gasLimit: ethers.BigNumber.from(73804 + 290001 + 5684) }
           );
           expect(failMock).not.toHaveBeenCalled();
         }

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.ts
@@ -316,15 +316,20 @@ export async function estimateGasAndSubmitFulfill(
   }
 
   const [airnodeRrpGasCost, fulfillmentCallGasCost] = estimateGasData;
-  const totalCost = airnodeRrpGasCost.add(fulfillmentCallGasCost);
+  const subTotalCost = airnodeRrpGasCost.add(fulfillmentCallGasCost);
+  // https://github.com/ethereum/EIPs/issues/114
+  // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md
+  const eip150GasReserve = subTotalCost.div(64);
+  const totalGasCost = subTotalCost.add(eip150GasReserve);
+
   // If gas estimation is success, submit fulfillment without making static test call
   const gasLimitNoticeLog = logger.pend(
     'INFO',
-    `Gas limit is set to ${totalCost} (AirnodeRrp: ${airnodeRrpGasCost} + Fulfillment Call: ${fulfillmentCallGasCost}) for Request:${request.id}.`
+    `Gas limit is set to ${totalGasCost} (AirnodeRrp: ${airnodeRrpGasCost} + Fulfillment Call: ${fulfillmentCallGasCost} + EIP150: ${eip150GasReserve}) for Request:${request.id}.`
   );
   const [submitLogs, submitErr, submitData] = await submitFulfill(airnodeRrp, request, {
     ...options,
-    gasTarget: { ...options.gasTarget, gasLimit: totalCost },
+    gasTarget: { ...options.gasTarget, gasLimit: totalGasCost },
   });
   return [[...estimateGasLogs, gasLimitNoticeLog, ...submitLogs], submitErr, submitData];
 }

--- a/packages/airnode-node/src/evm/fulfillments/api-calls.ts
+++ b/packages/airnode-node/src/evm/fulfillments/api-calls.ts
@@ -319,7 +319,7 @@ export async function estimateGasAndSubmitFulfill(
   const subTotalCost = airnodeRrpGasCost.add(fulfillmentCallGasCost);
   // https://github.com/ethereum/EIPs/issues/114
   // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md
-  const eip150GasReserve = subTotalCost.div(64);
+  const eip150GasReserve = subTotalCost.div(63);
   const totalGasCost = subTotalCost.add(eip150GasReserve);
 
   // If gas estimation is success, submit fulfillment without making static test call


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode/issues/1997

### What does this change

The way Airnode currently estimates gas for fulfill txs (`AirnodeRrpV0DryRun.fulfill()` + `target.fulfill()`) produces a gas estimate that might be inaccurate on txs where the `fulfill()` function requires a lot of gas to be executed. This is mainly because even thought we estimate a low level `.call(...)` on `AirnodeRrpV0DryRun.fulfill()`, the 1/64 gas reserve on the caller introduced in EIP-150 is not being considered on the estimate. This is fine for a `fulfill()` tx that doesn't need much gas to execute (because we are overestimating anyways) but for fulfillments that require large amounts of gas this reserved gas must be accounted for or we could end up with estimates that are less than actually needed.