### PR TITLE
Use shared Renovate preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # IDE specific files
 .vscode
+.idea
 *.swp
 *.swo
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,31 +1,14 @@
 {
-  "extends": ["config:base", "docker:disable"],
-  "automerge": true,
-  "automergeType": "pr",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>api3dao/renovate-config", "docker:disable"],
   "packageRules": [
     {
-      "matchPackageNames": ["chalk", "hardhat", "ora", "node", "@openzeppelin/contracts", "zod"],
+      "matchPackageNames": ["ora", "node", "@openzeppelin/contracts"],
       "enabled": false
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "schedule": ["before 2am on monday"],
-      "groupName": "devDependencies (non-major)"
-    },
-    {
-      "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "schedule": ["before 2am on monday"],
-      "groupName": "dependencies (non-major)"
     }
   ],
-  "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": false
   },
-  "reviewers": ["team:airnode"],
-  "minimumReleaseAge": "5 days",
-  "internalChecksFilter": "strict",
-  "dependencyDashboard": false
+  "reviewers": ["team:airnode"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["local>api3dao/renovate-config", "docker:disable"],
   "packageRules": [
     {
-      "matchPackageNames": ["ora", "node", "@openzeppelin/contracts"],
+      "matchPackageNames": ["ora", "node", "@openzeppelin/contracts", "zod"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Relates to https://github.com/api3dao/tasks/issues/1777

I'm leaving `lockFileMaintenance` disabled, because enabling it with yarn v1 would increase the risk of supply chain attacks.